### PR TITLE
[Chore] Fix rubocop usage

### DIFF
--- a/.github/workflows/.rubocop-linter.yml
+++ b/.github/workflows/.rubocop-linter.yml
@@ -1,0 +1,22 @@
+name: Rubocop Lint
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: ruby:2.6.5
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Rubocop Linter
+      uses: andrewmcodes/rubocop-linter-action@v2.0.0
+      with:
+        additional_gems: 'perx-rubocop:0.0.3'
+        fail_level: 'warning'
+        version: '0.77.0'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ jobs:
     - gemfile: gemfiles/rails_master.gemfile
     - rvm: jruby-9.1.17.0
       gemfile: gemfiles/rails_5_0.gemfile
+    # Rails 5.2.4.1 is currently broken. Code has been fixed but no release
+    # for it yet - https://github.com/rails/rails/issues/38137
+    - rvm: 2.2.9
+      gemfile: gemfiles/rails_5_2.gemfile
   exclude:
     - rvm: 2.1.9
       gemfile: gemfiles/rails_5_0.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'rails', '>= 3.1.2'
+gem 'perx-rubocop', '~> 0.0.3'
 
 group :local do
   gem 'guard-rspec', '~> 4.2'

--- a/README.md
+++ b/README.md
@@ -569,6 +569,13 @@ end
 
 * If you're looking to help, check out the TODO file for some upcoming changes I'd like to implement in Apartment.
 
+### Running bundle install
+
+mysql2 gem in some cases fails to install.
+If you face problems running bundle install in OSX, try installing the gem running:
+
+`gem install mysql2 -v '0.5.3' -- --with-ldflags=-L/usr/local/opt/openssl/lib --with-cppflags=-I/usr/local/opt/openssl/include`
+
 ## License
 
 Apartment is released under the [MIT License](http://www.opensource.org/licenses/MIT).

--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'bundler',      '>= 1.3', '< 2.0'
   s.add_development_dependency 'capybara',     '~> 2.0'
-  s.add_development_dependency 'perx-rubocop', '~> 0.0.3'
   s.add_development_dependency 'rake',         '~> 0.9'
   s.add_development_dependency 'rspec',        '~> 3.4'
   s.add_development_dependency 'rspec-rails',  '~> 3.4'


### PR DESCRIPTION
- Fixes CI runs:
  - One of the rails versions [had a bug](https://github.com/rails/rails/issues/38137) and causes the CI to fail. I've moved it to the allowed failures.
  - I think we should deprecate these versions as they are EOL. => New ticket to be created
- Fixes rubocop installation - I had not realized when I merged rubocop installation that I was breaking all CI (I'm sorry for the rushed decision). This fixes the dependencies and all CI should be passing.
- Adds rubocop to github actions. All the rubocop failures will be fixed with #8 