### PR TITLE
[Resolves #12] Update travis config to only run PRs instead of all commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ rvm:
   - 2.5.0
   - 2.6.2
   - ruby-head
+
+branches:
+  only:
+    - development
+
 gemfile:
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
 
 branches:
   only:
+    - master
     - development
 
 gemfile:


### PR DESCRIPTION
- Updated travis.yml to run only for branches: `master` and `development`.
- Due to the nature of PRs, nothing needs to be done to ensure tests run against an open PR