### PR TITLE
[Resolves #14] Add console info about tenants and fast switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,27 @@ Apartment::Tenant.drop('tenant_name')
 
 When method is called, the schema is dropped and all data from itself will be lost. Be careful with this method.
 
+### Custom Prompt
+
+#### Console methods
+
+`ros-apartment` console configures two helper methods:
+1. `tenant_list` - list available tenants while using the console
+2. `st(tenant_name:String)` - Switches the context to the tenant name passed, if
+it exists.
+
+#### Custom printed prompt
+
+`ros-apartment` also has a custom prompt that gives a bit more information about
+the context in which you're running. It shows the environment as well as the tenant
+that is currently switched to. In order for you to enable this, you need to require
+the custom console in your application.
+
+In `application.rb` add `require 'apartment/custom_console'`.
+Please note that we rely on `pry-rails` to edit the prompt, thus your project needs
+to install it as well. In order to do so, you need to add `gem 'pry-rails'` to your
+project's gemfile.
+
 ## Config
 
 The following config options should be set up in a Rails initializer such as:

--- a/lib/apartment/console.rb
+++ b/lib/apartment/console.rb
@@ -15,3 +15,26 @@ def reload!(print = true)
   Apartment::Tenant.init
   true
 end
+
+
+module Apartment
+  module CustomConsole
+    def st(schema_name = nil)
+      if schema_name.nil?
+        tenant_list.each { |t| puts t }
+      else
+        Apartment::Tenant.switch!(schema_name) if Apartment::Tenant.include? schema_name
+      end
+    end
+
+    def tenant_list
+      tenant_list = ['public']
+      Apartment::Tenant.each do |t|
+        tenant_list << t
+      end
+      tenant_list
+    end
+  end
+end
+
+include Apartment::CustomConsole

--- a/lib/apartment/console.rb
+++ b/lib/apartment/console.rb
@@ -18,9 +18,15 @@ end
 
 def st(schema_name = nil)
   if schema_name.nil?
+    # rubocop:disable Rails/Output
     tenant_list.each { |t| puts t }
+    # rubocop:enable Rails/Output
+  elsif tenant_list.include? schema_name
+    Apartment::Tenant.switch!(schema_name)
   else
-    Apartment::Tenant.switch!(schema_name) if tenant_list.include? schema_name
+    # rubocop:disable Rails/Output
+    puts "Tenant #{schema_name} is not part of the tenant list"
+    # rubocop:enable Rails/Output
   end
 end
 

--- a/lib/apartment/console.rb
+++ b/lib/apartment/console.rb
@@ -26,8 +26,6 @@ end
 
 def tenant_list
   tenant_list = [Apartment.default_tenant]
-  Apartment::Tenant.each do |t|
-    tenant_list << t
-  end
+  tenant_list += Apartment.tenant_names
   tenant_list.uniq
 end

--- a/lib/apartment/console.rb
+++ b/lib/apartment/console.rb
@@ -16,25 +16,18 @@ def reload!(print = true)
   true
 end
 
-
-module Apartment
-  module CustomConsole
-    def st(schema_name = nil)
-      if schema_name.nil?
-        tenant_list.each { |t| puts t }
-      else
-        Apartment::Tenant.switch!(schema_name) if Apartment::Tenant.include? schema_name
-      end
-    end
-
-    def tenant_list
-      tenant_list = ['public']
-      Apartment::Tenant.each do |t|
-        tenant_list << t
-      end
-      tenant_list
-    end
+def st(schema_name = nil)
+  if schema_name.nil?
+    tenant_list.each { |t| puts t }
+  else
+    Apartment::Tenant.switch!(schema_name) if tenant_list.include? schema_name
   end
 end
 
-include Apartment::CustomConsole
+def tenant_list
+  tenant_list = [Apartment.default_tenant]
+  Apartment::Tenant.each do |t|
+    tenant_list << t
+  end
+  tenant_list.uniq
+end

--- a/lib/apartment/custom_console.rb
+++ b/lib/apartment/custom_console.rb
@@ -5,7 +5,9 @@ module Apartment
     begin
       require 'pry-rails'
     rescue LoadError
+      # rubocop:disable Rails/Output
       puts '[Failed to load pry-rails] If you want to use Apartment custom prompt you need to add pry-rails to your gemfile'
+      # rubocop:enable Rails/Output
     end
 
     if Pry::Prompt.respond_to?(:add)

--- a/lib/apartment/custom_console.rb
+++ b/lib/apartment/custom_console.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Apartment
+  module CustomConsole
+    begin
+      require 'pry-rails'
+    rescue LoadError
+      puts '[Failed to load pry-rails] If you want to use Apartment custom prompt you need to add pry-rails to your gemfile'
+    end
+
+    if Pry::Prompt.respond_to?(:add)
+      desc = "Includes the current Rails environment and project folder name.\n" \
+            '[1] [project_name][Rails.env][Apartment::Tenant.current] pry(main)>'
+
+      Pry::Prompt.add 'ros', desc, %w[> *] do |target_self, nest_level, pry, sep|
+        "[#{pry.input_ring.size}] [#{PryRails::Prompt.formatted_env}][#{Apartment::Tenant.current}] " \
+        "#{pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+        "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
+      end
+
+      Pry.config.prompt = Pry::Prompt[:ros][:value]
+    end
+  end
+end


### PR DESCRIPTION
- Adds console methods for:
  - `tenant_list` - listing all tenants based on `Apartment.tenant_names`
  - `st(tenant_name:String)` - switch to tenant if it exists
- Adds custom pry console that shows the current tenant name and rails env. Depends on `pry-rails` gem.