### PR TITLE
[Resolves #35] update cache key to use a string or an array

### DIFF
--- a/lib/apartment/model.rb
+++ b/lib/apartment/model.rb
@@ -5,14 +5,20 @@ module Apartment
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # NOTE: key is actually an array of keys. E.g. If we run the following
-      # query: `Setting.find_by(key: 'something', value: 'amazing')` key will
-      # have an array of symbols: `[:key, :something]`
+      # NOTE: key can either be an array of symbols or a single value.
+      # E.g. If we run the following query:
+      # `Setting.find_by(key: 'something', value: 'amazing')` key will have an array of symbols: `[:key, :something]`
+      # while if we run:
+      # `Setting.find(10)` key will have the value 'id'
       def cached_find_by_statement(key, &block)
         # Modifying the cache key to have a reference to the current tenant,
         # so the cached statement is referring only to the tenant in which we've
         # executed this
-        cache_key = [Apartment::Tenant.current] + key
+        cache_key = if key.is_a? String
+                      "#{Apartment::Tenant.current}_#{key}"
+                    else
+                      [Apartment::Tenant.current] + key
+                    end
         cache = @find_by_statement_cache[connection.prepared_statements]
         cache.compute_if_absent(cache_key) { ActiveRecord::StatementCache.create(connection, &block) }
       end


### PR DESCRIPTION
- Cached find by statement can also receive one single string value for `key` as "id", when running `Setting.find(10)`. This was causing the cache key to fail to build