### PR TITLE
[Resolves #42] After switch callback not working with nil argument

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -68,8 +68,6 @@ module Apartment
       #
       def switch!(tenant = nil)
         run_callbacks :switch do
-          return reset if tenant.nil?
-
           connect_to_new(tenant).tap do
             Apartment.connection.clear_query_cache
           end
@@ -130,14 +128,12 @@ module Apartment
       #   @return {String} tenant name with Rails environment *optionally* prepended
       #
       def environmentify(tenant)
-        if !tenant.include?(Rails.env)
-          if Apartment.prepend_environment
-            "#{Rails.env}_#{tenant}"
-          elsif Apartment.append_environment
-            "#{tenant}_#{Rails.env}"
-          else
-            tenant
-          end
+        return tenant if tenant.nil? || tenant.include?(Rails.env)
+
+        if Apartment.prepend_environment
+          "#{Rails.env}_#{tenant}"
+        elsif Apartment.append_environment
+          "#{tenant}_#{Rails.env}"
         else
           tenant
         end

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -171,6 +171,8 @@ module Apartment
       #   @param {String} tenant Database name
       #
       def connect_to_new(tenant)
+        return reset if tenant.nil?
+
         query_cache_enabled = ActiveRecord::Base.connection.query_cache_enabled
 
         Apartment.establish_connection multi_tenantify(tenant)

--- a/lib/apartment/adapters/sqlite3_adapter.rb
+++ b/lib/apartment/adapters/sqlite3_adapter.rb
@@ -33,6 +33,8 @@ module Apartment
       protected
 
       def connect_to_new(tenant)
+        return reset if tenant.nil?
+
         unless File.exist?(database_file(tenant))
           raise TenantNotFound,
                 "The tenant #{environmentify(tenant)} cannot be found."

--- a/spec/adapters/jdbc_mysql_adapter_spec.rb
+++ b/spec/adapters/jdbc_mysql_adapter_spec.rb
@@ -14,6 +14,7 @@ if defined?(JRUBY_VERSION)
 
     let(:default_tenant) { subject.switch { ActiveRecord::Base.connection.current_database } }
 
+    it_should_behave_like 'a generic apartment adapter callbacks'
     it_should_behave_like 'a generic apartment adapter'
     it_should_behave_like 'a connection based apartment adapter'
   end

--- a/spec/adapters/jdbc_postgresql_adapter_spec.rb
+++ b/spec/adapters/jdbc_postgresql_adapter_spec.rb
@@ -8,6 +8,8 @@ if defined?(JRUBY_VERSION)
   describe Apartment::Adapters::JDBCPostgresqlAdapter, database: :postgresql do
     subject { Apartment::Tenant.jdbc_postgresql_adapter config.symbolize_keys }
 
+    it_should_behave_like 'a generic apartment adapter callbacks'
+
     context 'using schemas' do
       before { Apartment.use_schemas = true }
 

--- a/spec/adapters/mysql2_adapter_spec.rb
+++ b/spec/adapters/mysql2_adapter_spec.rb
@@ -14,6 +14,8 @@ describe Apartment::Adapters::Mysql2Adapter, database: :mysql do
 
     let(:default_tenant) { subject.switch { ActiveRecord::Base.connection.current_database } }
 
+    it_should_behave_like 'a generic apartment adapter callbacks'
+
     context 'using - the equivalent of - schemas' do
       before { Apartment.use_schemas = true }
 

--- a/spec/adapters/postgresql_adapter_spec.rb
+++ b/spec/adapters/postgresql_adapter_spec.rb
@@ -8,6 +8,8 @@ describe Apartment::Adapters::PostgresqlAdapter, database: :postgresql do
 
     subject { Apartment::Tenant.postgresql_adapter config }
 
+    it_should_behave_like 'a generic apartment adapter callbacks'
+
     context 'using schemas with schema.rb' do
       before { Apartment.use_schemas = true }
 

--- a/spec/adapters/sqlite3_adapter_spec.rb
+++ b/spec/adapters/sqlite3_adapter_spec.rb
@@ -8,6 +8,8 @@ describe Apartment::Adapters::Sqlite3Adapter, database: :sqlite do
 
     subject { Apartment::Tenant.sqlite3_adapter config }
 
+    it_should_behave_like 'a generic apartment adapter callbacks'
+
     context 'using connections' do
       def tenant_names
         db_dir = File.expand_path('../dummy/db', __dir__)

--- a/spec/examples/generic_adapters_callbacks_examples.rb
+++ b/spec/examples/generic_adapters_callbacks_examples.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# NOTE: This is a dummy test because at the moment i cant think of a way to
+# ensure that the callbacks are properly called. I'm open for ideas or I'll
+# just delete this.
+shared_examples_for 'a generic apartment adapter callbacks' do
+  include Apartment::Spec::AdapterRequirements
+
+  before do
+    Apartment.prepend_environment = false
+    Apartment.append_environment = false
+  end
+
+  describe '#switch! to nil' do
+    before do
+      Apartment::Adapters::AbstractAdapter.set_callback :switch, :before do
+        puts("Before tenant switch from: #{current}")
+      end
+
+      Apartment::Adapters::AbstractAdapter.set_callback :switch, :after do
+        puts("After tenant switch to: #{current}")
+      end
+
+      Apartment::Tenant.switch!(nil)
+    end
+
+    it 'runs both before and after callbacks' do
+      expect(true).to eq true
+    end
+  end
+end

--- a/spec/examples/generic_adapters_callbacks_examples.rb
+++ b/spec/examples/generic_adapters_callbacks_examples.rb
@@ -6,6 +6,10 @@ require 'spec_helper'
 # ensure that the callbacks are properly called. I'm open for ideas or I'll
 # just delete this.
 shared_examples_for 'a generic apartment adapter callbacks' do
+  class MyProc
+    def self.call; end
+  end
+
   include Apartment::Spec::AdapterRequirements
 
   before do
@@ -13,21 +17,38 @@ shared_examples_for 'a generic apartment adapter callbacks' do
     Apartment.append_environment = false
   end
 
-  describe '#switch! to nil' do
+  describe '#switch!' do
     before do
       Apartment::Adapters::AbstractAdapter.set_callback :switch, :before do
-        puts("Before tenant switch from: #{current}")
+        MyProc.call(Apartment::Tenant.current)
       end
 
       Apartment::Adapters::AbstractAdapter.set_callback :switch, :after do
-        puts("After tenant switch to: #{current}")
+        MyProc.call(Apartment::Tenant.current)
       end
 
-      Apartment::Tenant.switch!(nil)
+      allow(MyProc).to receive(:call)
     end
 
-    it 'runs both before and after callbacks' do
-      expect(true).to eq true
+    context 'when tenant is nil' do
+      before do
+        Apartment::Tenant.switch!(nil)
+      end
+
+      it 'runs both before and after callbacks' do
+        expect(MyProc).to have_received(:call).twice
+      end
+    end
+
+    context 'when tenant is not nil' do
+      before do
+        puts db1
+        Apartment::Tenant.switch!(db1)
+      end
+
+      it 'runs both before and after callbacks' do
+        expect(MyProc).to have_received(:call).twice
+      end
     end
   end
 end

--- a/spec/examples/generic_adapters_callbacks_examples.rb
+++ b/spec/examples/generic_adapters_callbacks_examples.rb
@@ -2,12 +2,9 @@
 
 require 'spec_helper'
 
-# NOTE: This is a dummy test because at the moment i cant think of a way to
-# ensure that the callbacks are properly called. I'm open for ideas or I'll
-# just delete this.
 shared_examples_for 'a generic apartment adapter callbacks' do
   class MyProc
-    def self.call; end
+    def self.call(tenant_name); end
   end
 
   include Apartment::Spec::AdapterRequirements
@@ -30,6 +27,13 @@ shared_examples_for 'a generic apartment adapter callbacks' do
       allow(MyProc).to receive(:call)
     end
 
+    # NOTE: Part of the test setup creates and switches tenants, so we need
+    # to reset the callbacks to ensure that each test run has the correct
+    # counts
+    after do
+      Apartment::Adapters::AbstractAdapter.reset_callbacks :switch
+    end
+
     context 'when tenant is nil' do
       before do
         Apartment::Tenant.switch!(nil)
@@ -42,7 +46,6 @@ shared_examples_for 'a generic apartment adapter callbacks' do
 
     context 'when tenant is not nil' do
       before do
-        puts db1
         Apartment::Tenant.switch!(db1)
       end
 


### PR DESCRIPTION
- Each adapter is responsible for resetting the tenant info based on the way they behave
- `switch` relies on the `connect_to_new` implementation of each of the adapters
- Added test coverage for raised issue