### PR TITLE
[Resolves #26] Support configuration for skip checking of schema existence before switching

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/BlockLength:
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
-  Max: 237
+  Max: 200
 
 # Offense count: 4
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,20 @@ Apartment.configure do |config|
 end
 ```
 
+### Skip tenant schema check
+
+This is configurable by setting: `tenant_presence_check`. It defaults to true
+in order to maintain the original gem behavior. This is only checked when using one of the PostgreSQL adapters.
+The original gem behavior, when running `switch` would look for the existence of the schema before switching. This adds an extra query on every context switch. While in the default simple scenarios this is a valid check, in high volume platforms this adds some unnecessary overhead which can be detected in some other ways on the application level.
+
+Setting this configuration value to `false` will disable the schema presence check before trying to switch the context.
+
+```ruby
+Apartment.configure do |config|
+  tenant_presence_check = false
+end
+```
+
 ### Excluding models
 
 If you have some models that should always access the 'public' tenant, you can specify this by configuring Apartment using `Apartment.configure`. This will yield a config object for you. You can set excluded models like so:

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -20,7 +20,7 @@ module Apartment
     extend Forwardable
 
     ACCESSOR_METHODS = %i[use_schemas use_sql seed_after_create prepend_environment
-                          append_environment with_multi_server_setup].freeze
+                          append_environment with_multi_server_setup tenant_presence_check].freeze
 
     WRITER_METHODS = %i[tenant_names database_schema_file excluded_models
                         default_schema persistent_schemas connection_class

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -80,7 +80,7 @@ module Apartment
       private
 
       def tenant_exists?(tenant)
-        return true unless Apartment.tenant_present_check
+        return true unless Apartment.tenant_presence_check
 
         Apartment.connection.schema_exists?(tenant)
       end

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -62,12 +62,11 @@ module Apartment
       #
       def connect_to_new(tenant = nil)
         return reset if tenant.nil?
-        # rubocop:disable Style/RaiseArgs
-        raise ActiveRecord::StatementInvalid.new("Could not find schema #{tenant}") unless Apartment.connection.schema_exists?(tenant.to_s)
 
-        # rubocop:enable Style/RaiseArgs
+        tenant = tenant.to_s
+        raise ActiveRecord::StatementInvalid, "Could not find schema #{tenant}" unless tenant_exists?(tenant)
 
-        @current = tenant.to_s
+        @current = tenant
         Apartment.connection.schema_search_path = full_search_path
 
         # When the PostgreSQL version is < 9.3,
@@ -79,6 +78,12 @@ module Apartment
       end
 
       private
+
+      def tenant_exists?(tenant)
+        return true unless Apartment.tenant_present_check
+
+        Apartment.connection.schema_exists?(tenant)
+      end
 
       def create_tenant_command(conn, tenant)
         conn.execute(%(CREATE SCHEMA "#{tenant}"))

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -18,7 +18,7 @@ module Apartment
         config.seed_after_create = false
         config.prepend_environment = false
         config.append_environment = false
-        config.tenant_present_check = true
+        config.tenant_presence_check = true
       end
 
       ActiveRecord::Migrator.migrations_paths = Rails.application.paths['db/migrate'].to_a

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -18,6 +18,7 @@ module Apartment
         config.seed_after_create = false
         config.prepend_environment = false
         config.append_environment = false
+        config.tenant_present_check = true
       end
 
       ActiveRecord::Migrator.migrations_paths = Rails.application.paths['db/migrate'].to_a

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -8,6 +8,7 @@ shared_examples_for 'a generic apartment adapter' do
   before do
     Apartment.prepend_environment = false
     Apartment.append_environment = false
+    Apartment.tenant_presence_check = true
   end
 
   describe '#init' do

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -164,6 +164,14 @@ shared_examples_for 'a schema based apartment adapter' do
   end
 
   describe '#switch!' do
+    let(:tenant_presence_check) { true }
+
+    before do
+      Apartment.configure do |config|
+        config.tenant_presence_check = tenant_presence_check
+      end
+    end
+
     it 'should connect to new schema' do
       subject.switch!(schema1)
       expect(connection.schema_search_path).to start_with %("#{schema1}")
@@ -174,10 +182,22 @@ shared_examples_for 'a schema based apartment adapter' do
       expect(connection.schema_search_path).to eq(%("#{public_schema}"))
     end
 
-    it 'should raise an error if schema is invalid' do
-      expect do
-        subject.switch! 'unknown_schema'
-      end.to raise_error(Apartment::TenantNotFound)
+    context 'when configuration checks for tenant presence before switching' do
+      it 'should raise an error if schema is invalid' do
+        expect do
+          subject.switch! 'unknown_schema'
+        end.to raise_error(Apartment::TenantNotFound)
+      end
+    end
+
+    context 'when configuration skips tenant presence check before switching' do
+      let(:tenant_presence_check) { false }
+
+      it 'should not raise any errors' do
+        expect do
+          subject.switch! 'unknown_schema'
+        end.to_not raise_error(Apartment::TenantNotFound)
+      end
     end
 
     context 'numeric databases' do

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -166,11 +166,7 @@ shared_examples_for 'a schema based apartment adapter' do
   describe '#switch!' do
     let(:tenant_presence_check) { true }
 
-    before do
-      Apartment.configure do |config|
-        config.tenant_presence_check = tenant_presence_check
-      end
-    end
+    before { Apartment.tenant_presence_check = tenant_presence_check }
 
     it 'should connect to new schema' do
       subject.switch!(schema1)


### PR DESCRIPTION
This is configurable by setting: `tenant_presence_check`. It defaults to true
in order to maintain the original gem behavior. This is only checked when using one of the PostgreSQL adapters.
The original gem behavior, when running `switch` would look for the existence of the schema before switching. This adds an extra query on every context switch. While in the default simple scenarios this is a valid check, in high volume platforms this adds some unnecessary overhead which can be detected in some other ways on the application level.

Setting this configuration value to `false` will disable the schema presence check before trying to switch the context.

```ruby
Apartment.configure do |config|
  tenant_presence_check = false
end
```