### PR TITLE
[Resolves #37] Custom console deprecation warning

### DIFF
--- a/lib/apartment/console.rb
+++ b/lib/apartment/console.rb
@@ -37,11 +37,8 @@ def tenant_list
 end
 
 def tenant_info_msg
-  log_level = ActiveRecord::Base.logger.level
-  ActiveRecord::Base.logger.level = :error
   # rubocop:disable Rails/Output
   puts "Available Tenants: #{tenant_list}\n"
   puts "Use `st 'tenant'` to switch tenants & `tenant_list` to see list\n"
   # rubocop:enable Rails/Output
-  ActiveRecord::Base.logger.level = log_level
 end

--- a/lib/apartment/custom_console.rb
+++ b/lib/apartment/custom_console.rb
@@ -24,23 +24,12 @@ module Apartment
       Pry::Prompt.add 'ros', desc, %w[> *] do |target_self, nest_level, pry, sep|
         prompt_contents(pry, target_self, nest_level, sep)
       end
+      Pry.config.prompt = Pry::Prompt[:ros][:value]
     end
 
-    # if Pry::Prompt.respond_to?(:add)
-    #   desc = "Includes the current Rails environment and project folder name.\n" \
-    #         '[1] [project_name][Rails.env][Apartment::Tenant.current] pry(main)>'
-
-    #   Pry::Prompt.add 'ros', desc, %w[> *] do |target_self, nest_level, pry, sep|
-    #     "[#{pry.input_ring.size}] [#{PryRails::Prompt.formatted_env}][#{Apartment::Tenant.current}] " \
-    #     "#{pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
-    #     "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
-    #   end
-
-    #   Pry.config.prompt = Pry::Prompt[:ros][:value]
-    #   Pry.config.hooks.add_hook(:when_started, 'startup message') do
-    #     tenant_info_msg
-    #   end
-    # end
+    Pry.config.hooks.add_hook(:when_started, 'startup message') do
+      tenant_info_msg
+    end
 
     def self.prompt_contents(pry, target_self, nest_level, sep)
       "[#{pry.input_ring.size}] [#{PryRails::Prompt.formatted_env}][#{Apartment::Tenant.current}] " \

--- a/lib/apartment/custom_console.rb
+++ b/lib/apartment/custom_console.rb
@@ -10,20 +10,42 @@ module Apartment
       # rubocop:enable Rails/Output
     end
 
-    if Pry::Prompt.respond_to?(:add)
-      desc = "Includes the current Rails environment and project folder name.\n" \
-            '[1] [project_name][Rails.env][Apartment::Tenant.current] pry(main)>'
+    desc = "Includes the current Rails environment and project folder name.\n" \
+          '[1] [project_name][Rails.env][Apartment::Tenant.current] pry(main)>'
 
+    prompt_procs = [
+      proc { |target_self, nest_level, pry| prompt_contents(pry, target_self, nest_level, '>') },
+      proc { |target_self, nest_level, pry| prompt_contents(pry, target_self, nest_level, '*') }
+    ]
+
+    if Gem::Version.new(Pry::VERSION) >= Gem::Version.new('0.13')
+      Pry.config.prompt = Pry::Prompt.new 'ros', desc, prompt_procs
+    else
       Pry::Prompt.add 'ros', desc, %w[> *] do |target_self, nest_level, pry, sep|
-        "[#{pry.input_ring.size}] [#{PryRails::Prompt.formatted_env}][#{Apartment::Tenant.current}] " \
-        "#{pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
-        "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
+        prompt_contents(pry, target_self, nest_level, sep)
       end
+    end
 
-      Pry.config.prompt = Pry::Prompt[:ros][:value]
-      Pry.config.hooks.add_hook(:when_started, 'startup message') do
-        tenant_info_msg
-      end
+    # if Pry::Prompt.respond_to?(:add)
+    #   desc = "Includes the current Rails environment and project folder name.\n" \
+    #         '[1] [project_name][Rails.env][Apartment::Tenant.current] pry(main)>'
+
+    #   Pry::Prompt.add 'ros', desc, %w[> *] do |target_self, nest_level, pry, sep|
+    #     "[#{pry.input_ring.size}] [#{PryRails::Prompt.formatted_env}][#{Apartment::Tenant.current}] " \
+    #     "#{pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+    #     "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
+    #   end
+
+    #   Pry.config.prompt = Pry::Prompt[:ros][:value]
+    #   Pry.config.hooks.add_hook(:when_started, 'startup message') do
+    #     tenant_info_msg
+    #   end
+    # end
+
+    def self.prompt_contents(pry, target_self, nest_level, sep)
+      "[#{pry.input_ring.size}] [#{PryRails::Prompt.formatted_env}][#{Apartment::Tenant.current}] " \
+      "#{pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+      "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
     end
   end
 end


### PR DESCRIPTION
- Pry changed the prompt behavior from 0.12.x to 0.13.x and warning message was showing up on pry 0.13.x. Updated the custom console to check which version of pry user is running and creates the custom prompt accordingly.