### PR TITLE
fix: reset sequence_name after tenant switch

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -37,6 +37,7 @@ module Apartment
       def reset
         @current = default_tenant
         Apartment.connection.schema_search_path = full_search_path
+        reset_sequence_names
       end
 
       def init
@@ -78,6 +79,7 @@ module Apartment
         # there is a issue for prepared statement with changing search_path.
         # https://www.postgresql.org/docs/9.3/static/sql-prepare.html
         Apartment.connection.clear_cache! if postgresql_version < 90_300
+        reset_sequence_names
       rescue *rescuable_exceptions
         raise TenantNotFound, "One of the following schema(s) is invalid: \"#{tenant}\" #{full_search_path}"
       end
@@ -108,6 +110,19 @@ module Apartment
         # ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#postgresql_version is
         # public from Rails 5.0.
         Apartment.connection.send(:postgresql_version)
+      end
+
+      def reset_sequence_names
+        # sequence_name contains the schema, so it must be reset after switch
+        # There is `reset_sequence_name`, but that method actually goes to the database
+        # to find out the new name. Therefore, we do this hack to only unset the name,
+        # and it will be dynamically found the next time it is needed
+        ActiveRecord::Base.descendants
+                          .select { |c| c.instance_variable_defined?(:@sequence_name) }
+                          .reject { |c| c.instance_variable_defined?(:@explicit_sequence_name) && c.instance_variable_get(:@explicit_sequence_name) }
+                          .each do |c|
+                            c.remove_instance_variable :@sequence_name
+                          end
       end
     end
 

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -123,9 +123,11 @@ shared_examples_for 'a schema based apartment adapter' do
     it 'connects and resets' do
       subject.switch(schema1) do
         expect(connection.schema_search_path).to start_with %("#{schema1}")
+        expect(User.sequence_name).to eq "#{schema1}.#{User.table_name}_id_seq"
       end
 
       expect(connection.schema_search_path).to start_with %("#{public_schema}")
+      expect(User.sequence_name).to eq "#{public_schema}.#{User.table_name}_id_seq"
     end
   end
 


### PR DESCRIPTION
The sequence_name contains the schema name, so after switching we point to the wrong one.

Gems such as [ActiveRecord-Import](https://github.com/zdennis/activerecord-import/blob/04cb95f02b9f594fd251ae9dc9297ac6938571f1/lib/activerecord-import/adapters/postgresql_adapter.rb#L63) use it