### PR TITLE
fix init after reload on development

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -39,6 +39,11 @@ module Apartment
           Apartment::Tenant.init_once
         end
       end
+
+      def arel_table
+        Apartment::Tenant.init_once
+        super
+      end
     end
     ActiveRecord::Base.singleton_class.prepend ApartmentInitializer
 


### PR DESCRIPTION
On 26fc746fc3d, init is not forced to be executed on `to_prepare`. This helps us avoid a connection at startup.
However, things break down after a reload because things like `ExcludedModel.count` don't go through
the `connection` method that we overrode, at least until after we queried the table name.

Let's make sure that we initialize before using arel too.