### PR TITLE
[#56] Db rollback uses second latest migration

### DIFF
--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -121,9 +121,13 @@ apartment_namespace = namespace :apartment do
   end
 
   def each_tenant(&block)
-    Parallel.each(tenants, in_threads: Apartment.parallel_migration_threads) do |tenant|
+    Parallel.each(tenants_without_default, in_threads: Apartment.parallel_migration_threads) do |tenant|
       block.call(tenant)
     end
+  end
+
+  def tenants_without_default
+    tenants - [Apartment.default_schema]
   end
 
   def tenants


### PR DESCRIPTION
If we have a default schema set as part of the list of the tenants, the tasks will run twice for the default schema. once for the default rails behavior and the other by iterating over all tenants. 
This ensures that if the default schema is part of the tenant_list it is excluded when running the tasks