### PR TITLE
fix: don't crash when creating the database

### DIFF
--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -23,6 +23,9 @@ module Apartment
       # before init is called
       @already_initialized = true
       init
+    rescue ActiveRecord::StatementInvalid
+      # If we are creating the database, we can't init yet because the database doesn't exist
+      @already_initialized = false
     end
 
     def reinitialize


### PR DESCRIPTION
Because we were trying to reset the connection before the database was created,
it failed with a Mysql2::Error: Unknown database 'public'.

We catch the error, and record that we haven't been initialized yet

Fixes #61 