### PR TITLE
Revert enhancing db:create task as it will break plugins compatiability

### DIFF
--- a/lib/apartment/tasks/enhancements.rb
+++ b/lib/apartment/tasks/enhancements.rb
@@ -7,7 +7,7 @@ module Apartment
   class RakeTaskEnhancer
     module TASKS
       ENHANCE_BEFORE = %w[db:drop].freeze
-      ENHANCE_AFTER  = %w[db:create db:migrate db:rollback db:migrate:up db:migrate:down db:migrate:redo db:seed].freeze
+      ENHANCE_AFTER  = %w[db:migrate db:rollback db:migrate:up db:migrate:down db:migrate:redo db:seed].freeze
       freeze
     end
 


### PR DESCRIPTION
Enhancing db:create with apartment db:create make schema:load to execute and have unexpected side effects including extensions like hstore incompatiability