### PR TITLE
[Resolves #92] tenant switch raises exception on first call

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -27,7 +27,7 @@ module Apartment
 
     # Make sure Apartment is reconfigured when the code is reloaded
     config.to_prepare do
-      Apartment::Tenant.reinitialize
+      Apartment::Tenant.reload!
     end
 
     #

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -25,6 +25,8 @@ shared_examples_for 'a generic apartment adapter' do
       expect(num_available_connections).to eq(0)
     end
 
+    # NOTE: Bug report #92 - when the adapter is set before the railtie is actually run, the adapter class might be
+    # incorrect. This tests intends to assure that the railtie init resets the adapter to the correct one
     it 'ensures apartment_adapter is properly set during init' do
       Thread.current[:apartment_adapter] = Apartment::Adapters::AbstractAdapter.new(config)
       Apartment::Railtie.config.to_prepare_blocks.map(&:call)

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -24,6 +24,12 @@ shared_examples_for 'a generic apartment adapter' do
 
       expect(num_available_connections).to eq(0)
     end
+
+    it 'ensures apartment_adapter is properly set during init' do
+      Thread.current[:apartment_adapter] = Apartment::Adapters::AbstractAdapter.new(config)
+      Apartment::Railtie.config.to_prepare_blocks.map(&:call)
+      expect(Apartment::Tenant.adapter.class.name).to eq 'Apartment::Adapters::PostgresqlAdapter'
+    end
   end
 
   #

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -30,7 +30,7 @@ shared_examples_for 'a generic apartment adapter' do
     it 'ensures apartment_adapter is properly set during init' do
       Thread.current[:apartment_adapter] = Apartment::Adapters::AbstractAdapter.new(config)
       Apartment::Railtie.config.to_prepare_blocks.map(&:call)
-      expect(Apartment::Tenant.adapter.class.name).to eq 'Apartment::Adapters::PostgresqlAdapter'
+      expect(Apartment::Tenant.adapter.class.name).to eq subject.class.name
     end
   end
 


### PR DESCRIPTION
Resolves #92 - when the adapter is set before the railtie is initialized the adapter class set in the thread might be incorrect. We were already invoking a subset of the `reload!` logic on prepare. This ensures that the reinitialize runs without any knowledge of the adapter that should be used