### PR TITLE
Remove unnecessary current_tenant method from delegators

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,23 +33,31 @@ jobs:
           git config --local user.name "$ACTION_USERNAME"
           git add CHANGELOG.md && git commit -m 'Updated CHANGELOG.md' && echo ::set-env name=push::1 || echo "No changes to CHANGELOG.md"
 
-      - name: Push changelog to master
-        if: env.push == 1
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.CHANGELOG_GITHUB_TOKEN }}
-          branch: master
-
-      - name: Cherry-pick changelog to development
+      - name: Push changes
         if: env.push == 1
         env:
-          ACTION_EMAIL: action@github.com
-          ACTION_USERNAME: GitHub Action
+          # CI_USER: ${{ secrets.YOUR_GITHUB_USER }}
+          CI_TOKEN: ${{ secrets.CHANGELOG_GITHUB_TOKEN }}
         run: |
-          git config --local user.email "$ACTION_EMAIL"
-          git config --local user.name "$ACTION_USERNAME"
-          commit_hash=`git show HEAD | egrep commit\ .+$ | cut -d' ' -f2`
-          git checkout development
-          git pull
-          git cherry-pick $commit_hash
-          git push
+          git push "https://$GITHUB_ACTOR:$CI_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:master
+
+      # - name: Push changelog to master
+      #   if: env.push == 1
+      #   uses: ad-m/github-push-action@master
+      #   with:
+      #     github_token: ${{ secrets.CHANGELOG_GITHUB_TOKEN }}
+      #     branch: master
+
+      # - name: Cherry-pick changelog to development
+      #   if: env.push == 1
+      #   env:
+      #     ACTION_EMAIL: action@github.com
+      #     ACTION_USERNAME: GitHub Action
+      #   run: |
+      #     git config --local user.email "$ACTION_EMAIL"
+      #     git config --local user.name "$ACTION_USERNAME"
+      #     commit_hash=`git show HEAD | egrep commit\ .+$ | cut -d' ' -f2`
+      #     git checkout development
+      #     git pull
+      #     git cherry-pick $commit_hash
+      #     git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased](https://github.com/rails-on-services/apartment/tree/HEAD)
 
-[Full Changelog](https://github.com/rails-on-services/apartment/compare/v2.7.1...HEAD)
+[Full Changelog](https://github.com/rails-on-services/apartment/compare/v2.7.2...HEAD)
+
+**Closed issues:**
+
+- Improve changelog automatic generation [\#98](https://github.com/rails-on-services/apartment/issues/98)
+
+## [v2.7.2](https://github.com/rails-on-services/apartment/tree/v2.7.2) (2020-07-17)
+
+[Full Changelog](https://github.com/rails-on-services/apartment/compare/v2.7.1...v2.7.2)
 
 **Implemented enhancements:**
 
@@ -134,6 +142,7 @@
 - \[Resolves \#31\] Add latest ruby verisons to test matrix [\#32](https://github.com/rails-on-services/apartment/pull/32) ([rpbaltazar](https://github.com/rpbaltazar))
 - \[Chore\] refactored files to their names [\#29](https://github.com/rails-on-services/apartment/pull/29) ([rpbaltazar](https://github.com/rpbaltazar))
 - \[Resolves \#27\] When manually switching the connection it resets the search path [\#28](https://github.com/rails-on-services/apartment/pull/28) ([rpbaltazar](https://github.com/rpbaltazar))
+- \[Resolves \#11\] Remove old ruby and rails versions from the supported versions [\#20](https://github.com/rails-on-services/apartment/pull/20) ([rpbaltazar](https://github.com/rpbaltazar))
 - Support rails 6.1 [\#7](https://github.com/rails-on-services/apartment/pull/7) ([jean-francois-labbe](https://github.com/jean-francois-labbe))
 
 ## [2.4.0](https://github.com/rails-on-services/apartment/tree/2.4.0) (2020-04-01)
@@ -158,7 +167,6 @@
 - Cleanup travis matrix [\#23](https://github.com/rails-on-services/apartment/pull/23) ([rpbaltazar](https://github.com/rpbaltazar))
 - Prepare v2.4.0 Release [\#22](https://github.com/rails-on-services/apartment/pull/22) ([rpbaltazar](https://github.com/rpbaltazar))
 - Updated readme badges [\#21](https://github.com/rails-on-services/apartment/pull/21) ([rpbaltazar](https://github.com/rpbaltazar))
-- \[Resolves \#11\] Remove old ruby and rails versions from the supported versions [\#20](https://github.com/rails-on-services/apartment/pull/20) ([rpbaltazar](https://github.com/rpbaltazar))
 - Rescuing ActiveRecord::NoDatabaseError when dropping tenants [\#19](https://github.com/rails-on-services/apartment/pull/19) ([rpbaltazar](https://github.com/rpbaltazar))
 - Skip init if we're running webpacker:compile [\#18](https://github.com/rails-on-services/apartment/pull/18) ([rpbaltazar](https://github.com/rpbaltazar))
 - \[Resolves \#14\] Add console info about tenants and fast switches [\#17](https://github.com/rails-on-services/apartment/pull/17) ([rpbaltazar](https://github.com/rpbaltazar))

--- a/lib/apartment/tasks/task_helper.rb
+++ b/lib/apartment/tasks/task_helper.rb
@@ -29,5 +29,13 @@ module Apartment
         Note that your tenants currently haven't been migrated. You'll need to run `db:migrate` to rectify this.
       WARNING
     end
+
+    def self.create_tenant(tenant_name)
+      begin
+        Apartment::Tenant.create(tenant_name)
+      rescue Apartment::TenantExists => e
+        puts 'Tried to create already existing tenant'
+      end
+    end
   end
 end

--- a/lib/apartment/tasks/task_helper.rb
+++ b/lib/apartment/tasks/task_helper.rb
@@ -31,11 +31,9 @@ module Apartment
     end
 
     def self.create_tenant(tenant_name)
-      begin
-        Apartment::Tenant.create(tenant_name)
-      rescue Apartment::TenantExists => e
-        puts 'Tried to create already existing tenant'
-      end
+      Apartment::Tenant.create(tenant_name)
+    rescue Apartment::TenantExists => e
+      puts "Tried to create already existing tenant: #{e}"
     end
   end
 end

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -10,7 +10,7 @@ module Apartment
     extend Forwardable
 
     def_delegators :adapter, :create, :drop, :switch, :switch!, :current, :each,
-                   :reset, :init, :set_callback, :seed, :current_tenant,
+                   :reset, :init, :set_callback, :seed,
                    :default_tenant, :environmentify
 
     attr_writer :config

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -10,12 +10,7 @@ apartment_namespace = namespace :apartment do
     Apartment::TaskHelper.warn_if_tenants_empty
 
     Apartment::TaskHelper.tenants.each do |tenant|
-      begin
-        puts("Creating #{tenant} tenant")
-        Apartment::Tenant.create(tenant)
-      rescue Apartment::TenantExists => e
-        puts e.message
-      end
+      Apartment::TaskHelper.create_tenant(tenant)
     end
   end
 
@@ -36,6 +31,7 @@ apartment_namespace = namespace :apartment do
     Apartment::TaskHelper.warn_if_tenants_empty
     Apartment::TaskHelper.each_tenant do |tenant|
       begin
+        Apartment::TaskHelper.create_tenant(tenant)
         puts("Migrating #{tenant} tenant")
         Apartment::Migrator.migrate tenant
       rescue Apartment::TenantNotFound => e
@@ -45,11 +41,12 @@ apartment_namespace = namespace :apartment do
   end
 
   desc 'Seed all tenants'
-  task seed: :create do
+  task :seed do
     Apartment::TaskHelper.warn_if_tenants_empty
 
     Apartment::TaskHelper.each_tenant do |tenant|
       begin
+        Apartment::TaskHelper.create_tenant(tenant)
         puts("Seeding #{tenant} tenant")
         Apartment::Tenant.switch(tenant) do
           Apartment::Tenant.seed


### PR DESCRIPTION
- remove unnecessary method delegation as below warning

```
[1] pry(main)> Apartment::Tenant.current_tenant
     (0.5ms) SET NAMES utf8mb4 COLLATE utf8mb4_general_ci,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483  []
     (0.2ms) use `table_name`  []
     (0.2ms) use `table_name`  []
(pry):1: warning: Apartment::Tenant#current_tenant at /usr/local/lib/ruby/2.6.0/forwardable.rb:158 forwarding to private method Apartment::Adapters::Mysql2SchemaAdapter#current_tenant
NoMethodError: undefined method `current_tenant' for #<Apartment::Adapters::Mysql2SchemaAdapter:0x00007fde0e17c390>
Did you mean?  create_tenant
from /usr/local/lib/ruby/2.6.0/forwardable.rb:228:in `current_tenant'
```