### PR TITLE
Revert unsafe initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,17 @@ module Apartment
 end
 ```
 
+## Running rails console without a connection
+
+Before this fork, running rails with the gem installed would connect to the database
+which is different than the default behavior. To disable this initial
+connection, just run with `APARTMENT_DISABLE_INIT` set to something:
+
+```shell
+$ APARTMENT_DISABLE_INIT=true DATABASE_URL=postgresql://localhost:1234/buk_development bin/rails runner 'puts 1'
+# 1
+```
+
 ## Contributing
 
 * In both `spec/dummy/config` and `spec/config`, you will see `database.yml.sample` files

--- a/lib/apartment/active_record/log_subscriber.rb
+++ b/lib/apartment/active_record/log_subscriber.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   # Supports the logging configuration to prepend the database and schema in the ActiveRecord log
-  class LogSubscriber
+  class LogSubscriber < ActiveSupport::LogSubscriber
     def apartment_log
       return unless Apartment.active_record_log
 

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -33,6 +33,7 @@ module Apartment
     config.to_prepare do
       next if ARGV.any? { |arg| arg =~ /\Aassets:(?:precompile|clean)\z/ }
       next if ARGV.any? { |arg| arg == 'webpacker:compile' }
+      next if ENV["APARTMENT_DISABLE_INIT"]
 
       begin
         Apartment.connection_class.connection_pool.with_connection do

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -15,20 +15,6 @@ module Apartment
 
     attr_writer :config
 
-    def init_once
-      return if @already_initialized
-
-      # To avoid infinite loops in work init is doing,
-      # we need to set @already_initialized to true
-      # before init is called
-      @already_initialized = true
-      init
-    end
-
-    def reinitialize
-      @already_initialized = false
-    end
-
     #   Fetch the proper multi-tenant adapter based on Rails config
     #
     #   @return {subclass of Apartment::AbstractAdapter}
@@ -63,7 +49,6 @@ module Apartment
     #
     def reload!(config = nil)
       Thread.current[:apartment_adapter] = nil
-      reinitialize
       @config = config
     end
 

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -24,6 +24,24 @@ shared_examples_for 'a generic apartment adapter' do
 
       expect(num_available_connections).to eq(1)
     end
+
+    it 'should not connect if env var is set' do
+      ENV["APARTMENT_DISABLE_INIT"] = "true"
+      begin
+        ActiveRecord::Base.connection_pool.disconnect!
+
+        Apartment::Railtie.config.to_prepare_blocks.map(&:call)
+
+        num_available_connections = Apartment.connection_class.connection_pool
+          .instance_variable_get(:@available)
+          .instance_variable_get(:@queue)
+          .size
+
+        expect(num_available_connections).to eq(0)
+      ensure
+        ENV.delete("APARTMENT_DISABLE_INIT")
+      end
+    end
   end
 
   #

--- a/spec/examples/generic_adapter_examples.rb
+++ b/spec/examples/generic_adapter_examples.rb
@@ -22,15 +22,7 @@ shared_examples_for 'a generic apartment adapter' do
                                            .instance_variable_get(:@queue)
                                            .size
 
-      expect(num_available_connections).to eq(0)
-    end
-
-    # NOTE: Bug report #92 - when the adapter is set before the railtie is actually run, the adapter class might be
-    # incorrect. This tests intends to assure that the railtie init resets the adapter to the correct one
-    it 'ensures apartment_adapter is properly set during init' do
-      Thread.current[:apartment_adapter] = Apartment::Adapters::AbstractAdapter.new(config)
-      Apartment::Railtie.config.to_prepare_blocks.map(&:call)
-      expect(Apartment::Tenant.adapter.class.name).to eq subject.class.name
+      expect(num_available_connections).to eq(1)
     end
   end
 


### PR DESCRIPTION
This is related to #113, #39 and #53.

In development, after a hot reload from webpacker, `Apartment::Tenant.current` reverts to public probably to the issue explained in #113, resulting in an error in our code. We haven't had the issue in production like @fsateler, but in development it is pretty much all the time after a reload.

Given this is a fork of the old apartment and the probably number one reason it exists is to support it forward (like Rails 6), I think it makes sense to keep the behaviour of the previous gem for now.