### PR TITLE
check if there is an open transaction

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -97,11 +97,16 @@ module Apartment
       end
 
       def create_tenant_command(conn, tenant)
-        schema = %(BEGIN;
-        CREATE SCHEMA "#{tenant}";
-        COMMIT;)
+        # NOTE: This was causing some tests to fail because of the database strategy for rspec
+        if ActiveRecord::Base.connection.open_transactions > 0
+          conn.execute(%(CREATE SCHEMA "#{tenant}"))
+        else
+          schema = %(BEGIN;
+          CREATE SCHEMA "#{tenant}";
+          COMMIT;)
 
-        conn.execute(schema)
+          conn.execute(schema)
+        end
       rescue *rescuable_exceptions => e
         rollback_transaction(conn)
         raise e


### PR DESCRIPTION
Resolves #123

- Before this commit, when creating a new tenant we would wrap the command around a transaction. This was leading to issues in some test scenarios where we have rspec's transactional fixtures enabled because all tests are then wrapped in a transaction by rspec.
- After this, we check if there are any open transactions before trying to create the tenant. If yes, then we simply issue the create tenant command.