### PR TITLE
[#127] Fixed method to get the current db name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Fixed bugs:**
 
 - New version raises an error with ActiveSupport::LogSubscriber [#128](https://github.com/rails-on-services/apartment/issues/128)
+- Weird logs when tenant fails to create [#127](<https://github.com/rails-on-services/apartment/issues/127>)
 
 **Closed issues:**
 

--- a/lib/apartment/log_subscriber.rb
+++ b/lib/apartment/log_subscriber.rb
@@ -21,7 +21,7 @@ module Apartment
     end
 
     def apartment_log
-      database = color("[#{Apartment.connection.current_database}] ", ActiveSupport::LogSubscriber::MAGENTA, true)
+      database = color("[#{Apartment.connection.raw_connection.db}] ", ActiveSupport::LogSubscriber::MAGENTA, true)
       schema = nil
       unless Apartment.connection.schema_search_path.nil?
         schema = color("[#{Apartment.connection.schema_search_path.tr('"', '')}] ",


### PR DESCRIPTION
Resolves #127 

- Create tenant is wrapped in a transaction. When it fails, the transaction is aborted. Yet the sql logger still kicks in. The way we were trying to collect the database name was trying to make another query to the database, but because the connection was already aborted, it would fail and log the weird output