### PR TITLE
[WIP] Add config for handling tenant creation on db:migrate

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -27,7 +27,7 @@ module Apartment
 
     WRITER_METHODS = %i[tenant_names database_schema_file excluded_models
                         persistent_schemas connection_class
-                        db_migrate_tenants seed_data_file
+                        db_migrate_tenants db_migrate_tenant_missing_strategy seed_data_file
                         parallel_migration_threads pg_excluded_names].freeze
 
     attr_accessor(*ACCESSOR_METHODS)
@@ -70,6 +70,21 @@ module Apartment
       return @db_migrate_tenants if defined?(@db_migrate_tenants)
 
       @db_migrate_tenants = true
+    end
+
+    # How to handle tenant missing on db:migrate
+    # defaults to :rescue_exception
+    # available options: rescue_exception, raise_exception, create_tenant
+    def db_migrate_tenant_missing_strategy
+      valid = %i[rescue_exception raise_exception create_tenant]
+      value = @db_migrate_tenant_missing_strategy || :rescue_exception
+
+      return value if valid.include?(value)
+
+      key_name  = 'config.db_migrate_tenant_missing_strategy'
+      opt_names = valid.join(', ')
+
+      raise ApartmentError, "Option #{value} not valid for `#{key_name}`. Use one of #{opt_names}"
     end
 
     # Default to empty array

--- a/lib/apartment/tasks/task_helper.rb
+++ b/lib/apartment/tasks/task_helper.rb
@@ -36,5 +36,17 @@ module Apartment
     rescue Apartment::TenantExists => e
       puts "Tried to create already existing tenant: #{e}"
     end
+
+    def self.migrate_tenant(tenant_name)
+      strategy = Apartment.db_migrate_tenant_missing_strategy
+      create_tenant(tenant_name) if strategy == :create_tenant
+
+      puts("Migrating #{tenant_name} tenant")
+      Apartment::Migrator.migrate tenant_name
+    rescue Apartment::TenantNotFound => e
+      raise e if strategy == :raise_exception
+
+      puts e.message
+    end
   end
 end

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -30,13 +30,7 @@ apartment_namespace = namespace :apartment do
   task :migrate do
     Apartment::TaskHelper.warn_if_tenants_empty
     Apartment::TaskHelper.each_tenant do |tenant|
-      begin
-        Apartment::TaskHelper.create_tenant(tenant)
-        puts("Migrating #{tenant} tenant")
-        Apartment::Migrator.migrate tenant
-      rescue Apartment::TenantNotFound => e
-        puts e.message
-      end
+      Apartment::TaskHelper.migrate_tenant(tenant)
     end
   end
 


### PR DESCRIPTION
This is a proposal to resolve issue #136 by making the create_tenant on db:migrate behavior configurable. Added config key `db_migrate_tenant_missing_strategy` defaulting to `rescue_exception` with available options:

* rescue_exception
* raise_exception
* create_tenant

The default option has the same behavior as it was before version `2.8.0`. If this is ok, I can procceed to add specs for the new config option.