### PR TITLE
Fix create schema between different versions of DB

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -158,6 +158,7 @@ module Apartment
         /SET lock_timeout/i,                          # new in postgresql 9.3
         /SET row_security/i,                          # new in postgresql 9.5
         /SET idle_in_transaction_session_timeout/i,   # new in postgresql 9.6
+        /SET default_table_access_method/i,           # new in postgresql 12
         /CREATE SCHEMA public/i,
         /COMMENT ON SCHEMA public/i
 


### PR DESCRIPTION
`default_table_access_method` (https://postgresqlco.nf/doc/en/param/default_table_access_method/) was introduced in PostreSQL 12.

In some edge cases, we may need to take schema from PostgreSQL 12+, but create new schemas in an earlier version.
In this case we need to clear `SET default_table_access_method=head;` line from dump.

Similar to https://github.com/rails-on-services/apartment/commit/163961baad5a661ec1a48c84a72c71ea1dcf3be6.