### PR TITLE
Add Ruby 3 to build matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,5 +66,8 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby_version: ["ruby:2.6-buster", "ruby:2.7-buster"]
+              ruby_version: ["ruby:2.6-buster", "ruby:2.7-buster", "ruby:3.0-buster"]
               gemfile: ["gemfiles/rails_5_2.gemfile", "gemfiles/rails_6_0.gemfile", "gemfiles/rails_6_1.gemfile"]
+            exclude:
+              - ruby_version: "ruby:3.0-buster"
+                gemfile: "gemfiles/rails_5_2.gemfile"


### PR DESCRIPTION
We're already running our app with ruby 3 without issues related to apartment.

Rails 5.2 doesn't support Ruby 3, that is why I excluded the combination from the matrix.