### PR TITLE
[#161] overwrite sequence name to validate it matches the current schema

### DIFF
--- a/lib/apartment/model.rb
+++ b/lib/apartment/model.rb
@@ -5,6 +5,17 @@ module Apartment
     extend ActiveSupport::Concern
 
     module ClassMethods
+
+      def sequence_name
+        res = super
+        schema_prefix = "#{Apartment::Tenant.current}."
+        if !res&.starts_with?(schema_prefix) || Apartment.excluded_models.any? { |m| m.constantize.table_name == table_name }
+          res = connection.default_sequence_name(table_name, primary_key)
+        end
+
+        res
+      end
+
       # NOTE: key can either be an array of symbols or a single value.
       # E.g. If we run the following query:
       # `Setting.find_by(key: 'something', value: 'amazing')` key will have an array of symbols: `[:key, :something]`

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -39,7 +39,7 @@ shared_examples_for 'a schema based apartment adapter' do
       it 'sets the search_path correctly' do
         Apartment::Tenant.init
 
-        expect(User.connection.schema_search_path).to match(/|#{default_tenant}|/)
+        expect(UserWithTenantModel.connection.schema_search_path).to match(/|#{default_tenant}|/)
       end
     end
 
@@ -66,14 +66,14 @@ shared_examples_for 'a schema based apartment adapter' do
       @count = 0 # set our variable so its visible in and outside of blocks
 
       subject.create(schema2) do
-        @count = User.count
+        @count = UserWithTenantModel.count
         expect(connection.schema_search_path).to start_with %("#{schema2}")
-        User.create
+        UserWithTenantModel.create
       end
 
       expect(connection.schema_search_path).not_to start_with %("#{schema2}")
 
-      subject.switch(schema2) { expect(User.count).to eq(@count + 1) }
+      subject.switch(schema2) { expect(UserWithTenantModel.count).to eq(@count + 1) }
     end
 
     context 'numeric database names' do
@@ -117,13 +117,14 @@ shared_examples_for 'a schema based apartment adapter' do
 
   describe '#switch' do
     it 'connects and resets' do
+      Apartment::Tenant.init
       subject.switch(schema1) do
         expect(connection.schema_search_path).to start_with %("#{schema1}")
-        expect(User.sequence_name).to eq "#{schema1}.#{User.table_name}_id_seq"
+        expect(UserWithTenantModel.sequence_name).to eq "#{schema1}.#{UserWithTenantModel.table_name}_id_seq"
       end
 
       expect(connection.schema_search_path).to start_with %("#{public_schema}")
-      expect(User.sequence_name).to eq "#{public_schema}.#{User.table_name}_id_seq"
+      expect(UserWithTenantModel.sequence_name).to eq "#{public_schema}.#{UserWithTenantModel.table_name}_id_seq"
     end
 
     it 'allows a list of schemas' do


### PR DESCRIPTION
This intends to address the concerns raised with https://github.com/rails-on-services/apartment/pull/143/files as well as https://github.com/rails-on-services/apartment/issues/161

- Regarding the thread safety, instead of trying to reset on tenant switch, when requesting the sequence_name check if the schema prefix matches the current tenant. If it doesn't ask for the value to be recomputed from the current connection. I've ran the code suggested in https://github.com/rails-on-services/apartment/issues/161 and i have not seen any error being raised.

- With this PR, after switching to a different tenant, the sequence name is updated properly as well.

This requires that the models that are managed by apartment include the apartment::model concern. This concern does two things:
1. update the cache key for statements to include the tenant
2. overwrite the sequence name if it does not start with the same as the current tenant name