### PR TITLE
[#170] cache key breaks when receiving a belongs to reflection

### DIFF
--- a/lib/apartment/model.rb
+++ b/lib/apartment/model.rb
@@ -17,7 +17,9 @@ module Apartment
         cache_key = if key.is_a? String
                       "#{Apartment::Tenant.current}_#{key}"
                     else
-                      [Apartment::Tenant.current] + key
+                      # NOTE: In Rails 6.0.4 we start receiving an ActiveRecord::Reflection::BelongsToReflection
+                      # as the key, which wouldn't work well with an array.
+                      [Apartment::Tenant.current] + Array.wrap(key)
                     end
         cache = @find_by_statement_cache[connection.prepared_statements]
         cache.compute_if_absent(cache_key) { ActiveRecord::StatementCache.create(connection, &block) }


### PR DESCRIPTION
Attempt to address issue reported in #170 

Tests in production application are working with this fix, but:

checked what changed between rails 6.0.3 and 6.0.4 and here is the commit that causes the changes to break: https://github.com/rails/rails/commit/45081c989b3108a629a26d0dde5d21eb06dbd8fb#diff-b1aed4985f41ad87dc1be30472b728a19f1a7354f25ce71bf6ce9a7744a9cd0dR445

rails internally uses the concurrent map implementation. [The concurrent map implementation uses ](https://github.com/ruby-concurrency/concurrent-ruby/blob/737da67d6d7d18daec798249e1da015ca17f897c/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb#L19-L25) whatever values passed as keys, so converting the reflection instance to an array with the tenant should be safe