### PR TITLE
Add nulldb adapter support

### DIFF
--- a/lib/apartment/adapters/nulldb_adapter.rb
+++ b/lib/apartment/adapters/nulldb_adapter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'apartment/adapters/abstract_adapter'
+
+module Apartment
+  module Tenant
+    def self.nulldb_adapter(config)
+      adapter = Adapters::NullDBAdapter
+      adapter.new(config)
+    end
+  end
+
+  module Adapters
+    class NullDBAdapter < AbstractAdapter
+      def init; end
+    end
+  end
+end

--- a/spec/adapters/nulldb_adapter_spec.rb
+++ b/spec/adapters/nulldb_adapter_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'apartment/adapters/nulldb_adapter'
+
+describe Apartment::Adapters::NullDBAdapter do
+  describe '#neither' do
+    it 'should create' do
+      adapter = Apartment::Adapters::NullDBAdapter.new({})
+      expect(adapter.present?).to eq true
+    end
+
+    it 'should ignore init' do
+      adapter = Apartment::Adapters::NullDBAdapter.new({})
+      adapter.init
+    end
+  end
+end


### PR DESCRIPTION
nulldb is the Rails 6.1 solution for running tasks in Docker with no database, such as `rails assets:precompile` 

This PR adds support for the nulldb adapter.