### PR TITLE
Show underlying error message and class if we cannot set search path to a new schema

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -82,8 +82,8 @@ module Apartment
         # https://www.postgresql.org/docs/9.3/static/sql-prepare.html
         Apartment.connection.clear_cache! if postgresql_version < 90_300
         reset_sequence_names
-      rescue *rescuable_exceptions
-        raise TenantNotFound, "One of the following schema(s) is invalid: \"#{tenant}\" #{full_search_path}"
+      rescue *rescuable_exceptions => e
+        raise TenantNotFound, "One of the following schema(s) is invalid: \"#{tenant}\" #{full_search_path}.\nOriginal error: #{e.message}"
       end
 
       private


### PR DESCRIPTION
Relates to #166

In my app the underlying error was a `ActiveRecord::ConnectionTimeoutError: could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use` which has no relation to the schema being invalid.

This is a quick fix to inform the user what's the underlying error, but I'm more than open to suggestions on a better approach.