### PR TITLE
Do not break cross-schema foreign keys

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -270,7 +270,8 @@ module Apartment
       end
 
       def swap_schema_qualifier(sql)
-        sql.gsub(/#{default_tenant}\.\w*/) do |match|
+        # replace public.* but keep keys referencing public.*
+        sql.gsub(/(?<!REFERENCES\s)#{default_tenant}\.\w*/) do |match|
           if Apartment.pg_excluded_names.any? { |name| match.include? name }
             match
           else


### PR DESCRIPTION
We use cross-schema foreign keys pointing from each tenant to `public.*`. Unfortunately when creating a new tenant all keys were rewritten to point to empty `tenant.*` tables.

So I've added a quick hack that prevents replacing `REFERENCES public.*` with `tenant`.