### PR TITLE
Remove ActiveSupport::Notifications#unsubscribe

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -47,7 +47,6 @@ module Apartment
     config.after_initialize do
       # NOTE: Load the custom log subscriber if enabled
       if Apartment.active_record_log
-        ActiveSupport::Notifications.unsubscribe 'sql.active_record'
         Apartment::LogSubscriber.attach_to :active_record
       end
     end


### PR DESCRIPTION
Hi Rails-on-Services! 👋 

I'm a developer on the New Relic Ruby Agent team. I recently discovered that the `config.active_record_log` option disables all Datastore recording for our `newrelic_rpm` gem. 

The culprit seems to be the line removed in this PR. Calling #unsubscribe on ActiveSupport::Notifications interferes with the strategy many gems use to instrument ActiveRecord's behavior. 

My intention behind this PR is to start a conversation about why the #unsubscribe method is called and if we can find another way achieve its goal.

Thanks for your time and for picking up the torch on this great library. 🔥 