### PR TITLE
use current_database method existing in both adapter

### DIFF
--- a/lib/apartment/log_subscriber.rb
+++ b/lib/apartment/log_subscriber.rb
@@ -21,13 +21,20 @@ module Apartment
     end
 
     def apartment_log
-      database = color("[#{Apartment.connection.current_database}] ", ActiveSupport::LogSubscriber::MAGENTA, true)
+      database = color("[#{database_name}] ", ActiveSupport::LogSubscriber::MAGENTA, true)
       schema = nil
       unless Apartment.connection.schema_search_path.nil?
         schema = color("[#{Apartment.connection.schema_search_path.tr('"', '')}] ",
                        ActiveSupport::LogSubscriber::YELLOW, true)
       end
       "#{database}#{schema}"
+    end
+
+    def database_name
+      db_name = Apartment.connection.raw_connection&.db # PostgreSQL, PostGIS
+      db_name ||= Apartment.connection.raw_connection&.query_options&.dig(:database) # Mysql
+      db_name ||= Apartment.connection.current_database # Failover
+      db_name
     end
   end
 end

--- a/lib/apartment/log_subscriber.rb
+++ b/lib/apartment/log_subscriber.rb
@@ -21,7 +21,7 @@ module Apartment
     end
 
     def apartment_log
-      database = color("[#{Apartment.connection.raw_connection.db}] ", ActiveSupport::LogSubscriber::MAGENTA, true)
+      database = color("[#{Apartment.connection.current_database}] ", ActiveSupport::LogSubscriber::MAGENTA, true)
       schema = nil
       unless Apartment.connection.schema_search_path.nil?
         schema = color("[#{Apartment.connection.schema_search_path.tr('"', '')}] ",


### PR DESCRIPTION
Resolves #152

Changes the way we get the information about the database apartment is currently connected to. Instead of relying on `db` method that only exists on PG adapter, we rely on `current_database` method 