### PR TITLE
Fix Rails 7 connection handling

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,6 +63,7 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/integration/apartment_rake_integration_spec.rb'
+    - 'spec/integration/connection_handling_spec.rb'
     - 'spec/integration/query_caching_spec.rb'
     - 'spec/integration/use_within_an_engine_spec.rb'
     - 'spec/tasks/apartment_rake_spec.rb'

--- a/lib/apartment/active_record/connection_handling.rb
+++ b/lib/apartment/active_record/connection_handling.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-module ActiveRecord
-  # This is monkeypatching activerecord to ensure that whenever a new connection is established it
-  # switches to the same tenant as before the connection switching. This problem is more evident when
-  # using read replica in Rails 6
+module ActiveRecord # :nodoc:
   if ActiveRecord::VERSION::MAJOR >= 6
+    # This is monkeypatching Active Record to ensure that whenever a new connection is established it
+    # switches to the same tenant as before the connection switching. This problem is more evident when
+    # using read replica in Rails 6
     module ConnectionHandling
       def connected_to_with_tenant(role: nil, prevent_writes: false, &blk)
         current_tenant = Apartment::Tenant.current

--- a/lib/apartment/active_record/connection_handling.rb
+++ b/lib/apartment/active_record/connection_handling.rb
@@ -4,17 +4,19 @@ module ActiveRecord
   # This is monkeypatching activerecord to ensure that whenever a new connection is established it
   # switches to the same tenant as before the connection switching. This problem is more evident when
   # using read replica in Rails 6
-  module ConnectionHandling
-    def connected_to_with_tenant(role: nil, prevent_writes: false, &blk)
-      current_tenant = Apartment::Tenant.current
+  if ActiveRecord::VERSION::MAJOR >= 6
+    module ConnectionHandling
+      def connected_to_with_tenant(role: nil, prevent_writes: false, &blk)
+        current_tenant = Apartment::Tenant.current
 
-      connected_to_without_tenant(role: role, prevent_writes: prevent_writes) do
-        Apartment::Tenant.switch!(current_tenant)
-        yield(blk)
+        connected_to_without_tenant(role: role, prevent_writes: prevent_writes) do
+          Apartment::Tenant.switch!(current_tenant)
+          yield(blk)
+        end
       end
-    end
 
-    alias connected_to_without_tenant connected_to
-    alias connected_to connected_to_with_tenant
+      alias connected_to_without_tenant connected_to
+      alias connected_to connected_to_with_tenant
+    end
   end
 end

--- a/lib/apartment/active_record/connection_handling.rb
+++ b/lib/apartment/active_record/connection_handling.rb
@@ -5,10 +5,10 @@ module ActiveRecord
   # switches to the same tenant as before the connection switching. This problem is more evident when
   # using read replica in Rails 6
   module ConnectionHandling
-    def connected_to_with_tenant(database: nil, role: nil, prevent_writes: false, &blk)
+    def connected_to_with_tenant(role: nil, prevent_writes: false, &blk)
       current_tenant = Apartment::Tenant.current
 
-      connected_to_without_tenant(database: database, role: role, prevent_writes: prevent_writes) do
+      connected_to_without_tenant(role: role, prevent_writes: prevent_writes) do
         Apartment::Tenant.switch!(current_tenant)
         yield(blk)
       end

--- a/spec/integration/connection_handling_spec.rb
+++ b/spec/integration/connection_handling_spec.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'connection handling monkey patch' do
-  let(:db_names) { [db1, db2] }
+  let(:db_name) { db1 }
 
   before do
     Apartment.configure do |config|
@@ -12,48 +14,42 @@ describe 'connection handling monkey patch' do
 
     Apartment::Tenant.reload!(config)
 
-    db_names.each do |db_name|
-      Apartment::Tenant.create(db_name)
-      Company.create database: db_name
-      Apartment::Tenant.switch! db_name
-      User.create! name: db_name
-    end
+    Apartment::Tenant.create(db_name)
+    Company.create database: db_name
+    Apartment::Tenant.switch! db_name
+    User.create! name: db_name
   end
 
   after do
-    db_names.each { |db| Apartment::Tenant.drop(db) }
+    Apartment::Tenant.drop(db_name)
     Apartment::Tenant.reset
     Company.delete_all
   end
 
-  context 'ActiveRecord 5.x', if: ActiveRecord::VERSION::MAJOR == 5 do
+  context 'when ActiveRecord 5.x', if: ActiveRecord::VERSION::MAJOR == 5 do
     it 'is not monkey patched' do
-      expect(ActiveRecord::ConnectionHandling.instance_methods).to_not include(:connected_to_with_tenant)
+      expect(ActiveRecord::ConnectionHandling.instance_methods).not_to include(:connected_to_with_tenant)
     end
   end
 
-  context 'ActiveRecord >= 6.0', if: ActiveRecord::VERSION::MAJOR >= 6 do
+  context 'when ActiveRecord >= 6.0', if: ActiveRecord::VERSION::MAJOR >= 6 do
+    let(:role) do
+      # Choose the role depending on the ActiveRecord version.
+      case ActiveRecord::VERSION::MAJOR
+      when 6 then ActiveRecord::Base.writing_role # deprecated in Rails 7
+      else ActiveRecord.writing_role
+      end
+    end
+
     it 'is monkey patched' do
       expect(ActiveRecord::ConnectionHandling.instance_methods).to include(:connected_to_with_tenant)
     end
 
     it 'switches to the previous set tenant' do
-      # Choose the role depending on the ActiveRecord version.
-      role = case ActiveRecord::VERSION::MAJOR
-             when 6 then ActiveRecord::Base.writing_role # deprecated in Rails 7
-             else ActiveRecord.writing_role
-             end
-
-      Apartment::Tenant.switch! db_names.first
+      Apartment::Tenant.switch! db_name
       ActiveRecord::Base.connected_to(role: role) do
-        expect(Apartment::Tenant.current).to eq db_names.first
-        expect(User.find_by(name: db_names.first).name).to eq(db_names.first)
-      end
-
-      Apartment::Tenant.switch! db_names.last
-      ActiveRecord::Base.connected_to(role: role) do
-        expect(Apartment::Tenant.current).to eq db_names.last
-        expect(User.find_by(name: db_names.last).name).to eq(db_names.last)
+        expect(Apartment::Tenant.current).to eq db_name
+        expect(User.find_by(name: db_name).name).to eq(db_name)
       end
     end
   end

--- a/spec/integration/connection_handling_spec.rb
+++ b/spec/integration/connection_handling_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'connection handling monkey patch' do
+  let(:db_names) { [db1, db2] }
+
+  before do
+    Apartment.configure do |config|
+      config.excluded_models = ['Company']
+      config.tenant_names = -> { Company.pluck(:database) }
+      config.use_schemas = true
+    end
+
+    Apartment::Tenant.reload!(config)
+
+    db_names.each do |db_name|
+      Apartment::Tenant.create(db_name)
+      Company.create database: db_name
+      Apartment::Tenant.switch! db_name
+      User.create! name: db_name
+    end
+  end
+
+  after do
+    db_names.each { |db| Apartment::Tenant.drop(db) }
+    Apartment::Tenant.reset
+    Company.delete_all
+  end
+
+  context 'ActiveRecord 5.x', if: ActiveRecord::VERSION::MAJOR == 5 do
+    it 'is not monkey patched' do
+      expect(ActiveRecord::ConnectionHandling.instance_methods).to_not include(:connected_to_with_tenant)
+    end
+  end
+
+  context 'ActiveRecord >= 6.0', if: ActiveRecord::VERSION::MAJOR >= 6 do
+    it 'is monkey patched' do
+      expect(ActiveRecord::ConnectionHandling.instance_methods).to include(:connected_to_with_tenant)
+    end
+
+    it 'switches to the previous set tenant' do
+      # Choose the role depending on the ActiveRecord version.
+      role = case ActiveRecord::VERSION::MAJOR
+             when 6 then ActiveRecord::Base.writing_role # deprecated in Rails 7
+             else ActiveRecord.writing_role
+             end
+
+      Apartment::Tenant.switch! db_names.first
+      ActiveRecord::Base.connected_to(role: role) do
+        expect(Apartment::Tenant.current).to eq db_names.first
+        expect(User.find_by(name: db_names.first).name).to eq(db_names.first)
+      end
+
+      Apartment::Tenant.switch! db_names.last
+      ActiveRecord::Base.connected_to(role: role) do
+        expect(Apartment::Tenant.current).to eq db_names.last
+        expect(User.find_by(name: db_names.last).name).to eq(db_names.last)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related: #193

After trying to upgrade one of our apps to Rails 7 we saw some specs failing related to the monkey-patched `connected_to` method in [lib/apartment/active_record/connection_handling.rb](https://github.com/rails-on-services/apartment/blob/d197370f1d7f30bd041d684839936295eb2cf201/lib/apartment/active_record/connection_handling.rb). Rails 7 removed the `database:` keyword for `connected_to` (https://github.com/rails/rails/commit/ce629d9ff32216e098ee8b1ead390157a5ad419a). This means apartment is currently not compatible with Rails 7.

This PR removes the deprecated `database:` keyword from the monkey patch. I'm not sure if this has any implications for Rails 6 users.
I also changed the monkey patch to be only included for ActiveRecord >= 6 (`connected_to` was introduced in Rails 6). I also attempted to write some specs for the monkey-patch.
