### PR TITLE
fix methods signatures for rails less or equal to 6.2

### DIFF
--- a/lib/apartment/active_record/connection_handling.rb
+++ b/lib/apartment/active_record/connection_handling.rb
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 module ActiveRecord # :nodoc:
-  if ActiveRecord::VERSION::MAJOR >= 6
-    # This is monkeypatching Active Record to ensure that whenever a new connection is established it
-    # switches to the same tenant as before the connection switching. This problem is more evident when
-    # using read replica in Rails 6
-    module ConnectionHandling
+  # This is monkeypatching Active Record to ensure that whenever a new connection is established it
+  # switches to the same tenant as before the connection switching. This problem is more evident when
+  # using read replica in Rails 6
+  module ConnectionHandling
+    if ActiveRecord.version.release <= Gem::Version.new('6.2')
+      def connected_to_with_tenant(database: nil, role: nil, prevent_writes: false, &blk)
+        current_tenant = Apartment::Tenant.current
+
+        connected_to_without_tenant(database: database, role: role, prevent_writes: prevent_writes) do
+          Apartment::Tenant.switch!(current_tenant)
+          yield(blk)
+        end
+      end
+    else
       def connected_to_with_tenant(role: nil, prevent_writes: false, &blk)
         current_tenant = Apartment::Tenant.current
 
@@ -14,9 +23,9 @@ module ActiveRecord # :nodoc:
           yield(blk)
         end
       end
-
-      alias connected_to_without_tenant connected_to
-      alias connected_to connected_to_with_tenant
     end
+
+    alias connected_to_without_tenant connected_to
+    alias connected_to connected_to_with_tenant
   end
 end


### PR DESCRIPTION
After merging #194 the method signature is broken for rails versions before 6.2. 
Passing database keyword argument has been a valid thing from 6.0 until 6.2 and we should keep the behaviour