### PR TITLE
Fix ActiveStorage::Blob.find_signed! method

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -17,6 +17,10 @@ if ActiveRecord.version.release >= Gem::Version.new('6.1')
   require_relative 'apartment/active_record/internal_metadata'
 end
 
+if ActiveStorage.version.release >= Gem::Version.new('7.0')
+  require_relative 'apartment/active_storage/blob'
+end
+
 # Apartment main definitions
 module Apartment
   class << self

--- a/lib/apartment/active_storage/blob.rb
+++ b/lib/apartment/active_storage/blob.rb
@@ -1,0 +1,18 @@
+if ActiveStorage::VERSION::MAJOR >= 7
+  module ActiveStorage::SetBlob # :nodoc:
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :set_blob
+    end
+
+    private
+      def set_blob
+        current_tenant = Apartment::Tenant.current
+        Apartment::Tenant.switch!(current_tenant)
+        @blob = blob_scope.find_signed!(params[:signed_blob_id] || params[:signed_id])
+      rescue ActiveSupport::MessageVerifier::InvalidSignature
+        head :not_found
+      end
+  end
+end


### PR DESCRIPTION
Hi there - so this code is *not* yet production ready & needs specs - just wanted feedback first really, there might be a 'better' way to do this.

So I have a postgres/Rails 7 app, and my `ActiveStorage::Blob` table is replicated in each tenant schema. 

For my application, ActiveStorage::Blob is in each schema, and this worked fine in Rails 6. But after upgrading to Rails 7, Rails always chooses the public schema for calls to ActiveStorage::Blob Load

E.g.
```
[public,shared_extensions]   ActiveStorage::Blob Load (0.8ms)  SELECT "active_storage_blobs".* FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1 LIMIT $2  [["id", 28], ["LIMIT", 1]]

ActiveRecord::RecordNotFound (Couldn't find ActiveStorage::Blob with 'id'=28)
```

This code fixes that problem, but perhaps kicks up more issues. For instance, if the `ActiveStorage::Blob` table is excluded, or ActiveSupport is not even used. 

So any feedback would be welcome please. I'd really like to know why this failed between Rails 6 & 7, as i think this monkey patch is too 'far down' the stack, and maybe there's more going on, or more is failing around active storage. 