### PR TITLE
Properly reset sequence if switching with multiple schemas

### DIFF
--- a/lib/apartment/active_record/postgresql_adapter.rb
+++ b/lib/apartment/active_record/postgresql_adapter.rb
@@ -12,12 +12,13 @@ module Apartment::PostgreSqlAdapterPatch
     # for JDBC driver, if rescued in super_method, trim leading and trailing quotes
     res.delete!('"') if defined?(JRUBY_VERSION)
 
-    schema_prefix = "#{Apartment::Tenant.current}."
-    default_tenant_prefix = "#{Apartment::Tenant.default_tenant}."
+    schema_prefix = "#{sequence_schema(res)}."
 
     # NOTE: Excluded models should always access the sequence from the default
     # tenant schema
     if excluded_model?(table)
+      default_tenant_prefix = "#{Apartment::Tenant.default_tenant}."
+
       res.sub!(schema_prefix, default_tenant_prefix) if schema_prefix != default_tenant_prefix
       return res
     end
@@ -28,6 +29,13 @@ module Apartment::PostgreSqlAdapterPatch
   end
 
   private
+
+  def sequence_schema(sequence_name)
+    current = Apartment::Tenant.current
+    return current unless current.is_a?(Array)
+
+    current.find { |schema| sequence_name.starts_with?("#{schema}.") }
+  end
 
   def excluded_model?(table)
     Apartment.excluded_models.any? { |m| m.constantize.table_name == table }

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -130,6 +130,10 @@ shared_examples_for 'a schema based apartment adapter' do
 
     it 'connects and resets' do
       subject.switch(schema1) do
+        # Ensure sequence is not cached
+        Company.reset_sequence_name
+        User.reset_sequence_name
+
         expect(connection.schema_search_path).to start_with %("#{schema1}")
         expect(User.sequence_name).to eq "#{User.table_name}_id_seq"
         expect(Company.sequence_name).to eq "#{public_schema}.#{Company.table_name}_id_seq"
@@ -140,10 +144,28 @@ shared_examples_for 'a schema based apartment adapter' do
       expect(Company.sequence_name).to eq "#{public_schema}.#{Company.table_name}_id_seq"
     end
 
-    it 'allows a list of schemas' do
-      subject.switch([schema1, schema2]) do
-        expect(connection.schema_search_path).to include %("#{schema1}")
-        expect(connection.schema_search_path).to include %("#{schema2}")
+    describe 'multiple schemas' do
+      it 'allows a list of schemas' do
+        subject.switch([schema1, schema2]) do
+          expect(connection.schema_search_path).to include %("#{schema1}")
+          expect(connection.schema_search_path).to include %("#{schema2}")
+        end
+      end
+
+      it 'connects and resets' do
+        subject.switch([schema1, schema2]) do
+          # Ensure sequence is not cached
+          Company.reset_sequence_name
+          User.reset_sequence_name
+
+          expect(connection.schema_search_path).to start_with %("#{schema1}")
+          expect(User.sequence_name).to eq "#{User.table_name}_id_seq"
+          expect(Company.sequence_name).to eq "#{public_schema}.#{Company.table_name}_id_seq"
+        end
+
+        expect(connection.schema_search_path).to start_with %("#{public_schema}")
+        expect(User.sequence_name).to eq "#{User.table_name}_id_seq"
+        expect(Company.sequence_name).to eq "#{public_schema}.#{Company.table_name}_id_seq"
       end
     end
   end


### PR DESCRIPTION
The [recent change](https://github.com/rails-on-services/apartment/pull/187) to fix table sequences does not account for [multi-schema switching](https://github.com/AbleHealth/ros-apartment#multiple-tenants):

```ruby
def default_sequence_name(table, _column)
  res = super
  # Code expects a single schema not an array
  schema_prefix = "#{Apartment::Tenant.current}." # => "[\"tenant1\", \"tenant2\"]."
```

thus sequences are not scoped correctly.

Before (incorrect):
```ruby
> Apartment::Tenant.switch(['tenant1', 'tenant2']) { Foo.sequence_name }
=> tenant1.foos_id_seq
```

After:
```ruby
> Apartment::Tenant.switch(['tenant1', 'tenant2']) { Foo.sequence_name }
=> foos_id_seq
```
