### PR TITLE
Bump public_suffix version range

### DIFF
--- a/ros-apartment.gemspec
+++ b/ros-apartment.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 5.0.0', '< 7.1'
   s.add_dependency 'parallel', '< 2.0'
-  s.add_dependency 'public_suffix', '>= 2.0.5', '< 5.0'
+  s.add_dependency 'public_suffix', '>= 2.0.5', '< 6.0'
   s.add_dependency 'rack', '>= 1.3.6', '< 3.0'
 
   s.add_development_dependency 'appraisal', '~> 2.2'


### PR DESCRIPTION
5.0 contains no breaking API changes, per https://github.com/weppos/publicsuffix-ruby/blob/main/CHANGELOG.md#500