### PR TITLE
Switch connections in PostgresqlSchemaAdapter.connect_to_new

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -72,6 +72,10 @@ module Apartment
       #
       def connect_to_new(tenant = nil)
         return reset if tenant.nil?
+
+        Apartment.establish_connection multi_tenantify(tenant, false)
+        Apartment.connection.active? # call active? to manually check if this connection is valid
+
         raise ActiveRecord::StatementInvalid, "Could not find schema #{tenant}" unless schema_exists?(tenant)
 
         @current = tenant.is_a?(Array) ? tenant.map(&:to_s) : tenant.to_s


### PR DESCRIPTION
PostgresqlSchemaAdapter has a bug that prevents it from working when different tenants are using different Postgres hosts. The adapter always connects to the same default database.yml host. This patch fixes this behavior by properly switching to the tenant's DB as defined in the config.tenant_names config map.

Closes #208