### PR TITLE
Set new schema_search_path only if needed

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -41,12 +41,18 @@ module Apartment
       #
       def reset
         @current = default_tenant
-        Apartment.connection.schema_search_path = full_search_path
+
+        if Apartment.connection.schema_search_path != full_search_path
+          Apartment.connection.schema_search_path = full_search_path
+        end
       end
 
       def init
         super
-        Apartment.connection.schema_search_path = full_search_path
+
+        if Apartment.connection.schema_search_path != full_search_path
+          Apartment.connection.schema_search_path = full_search_path
+        end
       end
 
       def current
@@ -75,7 +81,10 @@ module Apartment
         raise ActiveRecord::StatementInvalid, "Could not find schema #{tenant}" unless schema_exists?(tenant)
 
         @current = tenant.is_a?(Array) ? tenant.map(&:to_s) : tenant.to_s
-        Apartment.connection.schema_search_path = full_search_path
+
+        if Apartment.connection.schema_search_path != full_search_path
+          Apartment.connection.schema_search_path = full_search_path
+        end
 
         # When the PostgreSQL version is < 9.3,
         # there is a issue for prepared statement with changing search_path.


### PR DESCRIPTION
Changing schema search path executes the following SQL commit:

```
SET search_path TO value;
```

Based on this method [implementation in Rails](https://github.com/rails/rails/blob/9bdd29c8317a9cc2faa72cf2060758dd41b8c267/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L225), this query is executed even if the new value will be the same as previous one.

This PR introduces a change that would trigger the SQL only if new value is different. By applying this change in my project I can see less SQL queries triggered on each request. For projects with larger traffic it could translate to a significantly smaller database load. For subsequent requests that reuse the same db connection unnecessary SQL commits will not be executed.