### PR TITLE
Updates bold attribute to named attribute on preparation for Rails 7.2

### DIFF
--- a/lib/apartment/log_subscriber.rb
+++ b/lib/apartment/log_subscriber.rb
@@ -21,9 +21,9 @@ module Apartment
     end
 
     def apartment_log
-      database = color("[#{database_name}] ", ActiveSupport::LogSubscriber::MAGENTA, true)
+      database = color("[#{database_name}] ", ActiveSupport::LogSubscriber::MAGENTA, bold: true)
       schema = current_search_path
-      schema = color("[#{schema.tr('"', '')}] ", ActiveSupport::LogSubscriber::YELLOW, true) unless schema.nil?
+      schema = color("[#{schema.tr('"', '')}] ", ActiveSupport::LogSubscriber::YELLOW, bold: true) unless schema.nil?
       "#{database}#{schema}"
     end
 


### PR DESCRIPTION
Resolves:

> DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`).

