### PR TITLE
Remove Travis CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apartment
 
-[![Gem Version](https://badge.fury.io/rb/ros-apartment.svg)](https://badge.fury.io/rb/apartment)
+[![Gem Version](https://badge.fury.io/rb/ros-apartment.svg)](https://badge.fury.io/rb/ros-apartment)
 [![Code Climate](https://api.codeclimate.com/v1/badges/b0dc327380bb8438f991/maintainability)](https://codeclimate.com/github/rails-on-services/apartment/maintainability)
 
 *Multitenancy for Rails and ActiveRecord*

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/ros-apartment.svg)](https://badge.fury.io/rb/apartment)
 [![Code Climate](https://api.codeclimate.com/v1/badges/b0dc327380bb8438f991/maintainability)](https://codeclimate.com/github/rails-on-services/apartment/maintainability)
-[![Build Status](https://travis-ci.org/rails-on-services/apartment.svg?branch=development)](https://travis-ci.org/rails-on-services/apartment)
 
 *Multitenancy for Rails and ActiveRecord*
 


### PR DESCRIPTION
Fix the ruby gem badge link.

Remove the Travis CI build badge now that the repo is on Github actions.  The last Travis CI build was 3 years ago.

A Github action build status badge could be inserted ![ruby build](https://github.com/rails-on-services/apartment/actions/workflows/main.yml/badge.svg) but I'm not sure there's much value.