### PR TITLE
Fix Ruby 3.0 support

### DIFF
--- a/lib/apartment/log_subscriber.rb
+++ b/lib/apartment/log_subscriber.rb
@@ -14,7 +14,7 @@ module Apartment
 
     private
 
-    def debug(progname = nil, &)
+    def debug(progname = nil, &blk)
       progname = "  #{apartment_log}#{progname}" unless progname.nil?
 
       super


### PR DESCRIPTION
The 3.x releases introduced anonymous block forwarding syntax (`def x(&)`) which is not compatible with Ruby 3.0 or below. Since this project has no Ruby version requirement, I am to assume that it was introduced in error.

The issue can be observed when attempting to run a console via `bundle exec rake console`, which will immediately throw an error before this fix.