### PR TITLE
Explicitly state Ruby version constraints in gemspec

### DIFF
--- a/ros-apartment.gemspec
+++ b/ros-apartment.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'parallel', '< 2.0'
   s.add_dependency 'public_suffix', '>= 2.0.5', '< 6.0'
   s.add_dependency 'rack', '>= 1.3.6', '< 4.0'
+  s.add_dependency 'ruby', '>= 3.0', '< 3.4'
 
   s.add_development_dependency 'appraisal', '~> 2.2'
   s.add_development_dependency 'bundler', '>= 1.3', '< 3.0'

--- a/ros-apartment.gemspec
+++ b/ros-apartment.gemspec
@@ -30,11 +30,12 @@ Gem::Specification.new do |s|
     'github_repo' => 'ssh://github.com/rails-on-services/apartment'
   }
 
+  s.required_ruby_version = '>= 3.0', '< 3.4'
+
   s.add_dependency 'activerecord', '>= 6.1.0', '< 7.2'
   s.add_dependency 'parallel', '< 2.0'
   s.add_dependency 'public_suffix', '>= 2.0.5', '< 6.0'
   s.add_dependency 'rack', '>= 1.3.6', '< 4.0'
-  s.add_dependency 'ruby', '>= 3.0', '< 3.4'
 
   s.add_development_dependency 'appraisal', '~> 2.2'
   s.add_development_dependency 'bundler', '>= 1.3', '< 3.0'


### PR DESCRIPTION
This pull request adds explicit version constraints for the Ruby dependency in the gemspec file. This ensures that the gem is compatible with Ruby versions between 3.0 (inclusive) and 3.4 (exclusive).