### PR TITLE
Fix ruby_version of 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - 3.0
+          - "3.0"
           - 3.1
           - 3.2
           - 3.3


### PR DESCRIPTION
https://github.com/ruby/setup-ruby/blob/943103cae7d3f1bb1e4951d5fcc7928b40e4b742/README.md#matrix-of-ruby-versions
> Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'

rails / rspec (3, 6_1) https://github.com/rails-on-services/apartment/actions/runs/9225435825/job/25382922622#step:4:23
>   ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]
