### PR TITLE
fix: ignore transaction_timeout statement added in postgresql 17

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -152,7 +152,8 @@ module Apartment
         /SET idle_in_transaction_session_timeout/i,   # new in postgresql 9.6
         /SET default_table_access_method/i,           # new in postgresql 12
         /CREATE SCHEMA public/i,
-        /COMMENT ON SCHEMA public/i
+        /COMMENT ON SCHEMA public/i,
+        /SET transaction_timeout/i,                   # new in postgresql 17
 
       ].freeze
 


### PR DESCRIPTION
latest posgresql update adds transaction_timeout statement

https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-TRANSACTION-TIMEOUT

it causes Apartment::Tenant.create to fail with 

```
(irb):1:in `<main>': PG::UndefinedObject: ERROR:  unrecognized configuration parameter "transaction_timeout" (ActiveRecord::StatementInvalid)
rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:55:in `exec': ERROR:  unrecognized configuration parameter "transaction_timeout" (PG::UndefinedObject)
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:55:in `block (2 levels) in raw_execute'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract_adapter.rb:1027:in `block in with_raw_connection'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activesupport-7.1.4/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract_adapter.rb:999:in `with_raw_connection'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:54:in `block in raw_execute'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activesupport-7.1.4/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract_adapter.rb:1142:in `log'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:53:in `raw_execute'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:521:in `internal_execute'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:131:in `execute'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/query_cache.rb:25:in `execute'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:47:in `execute'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/ros-apartment-3.1.0/lib/apartment/adapters/postgresql_adapter.rb:182:in `clone_pg_schema'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/ros-apartment-3.1.0/lib/apartment/adapters/postgresql_adapter.rb:161:in `block in import_database_schema'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/ros-apartment-3.1.0/lib/apartment/adapters/postgresql_adapter.rb:174:in `preserving_search_path'
        from rvm-dir/.rvm/gems/ruby-3.3.5@project-gemset/gems/ros-apartment-3.1.0/lib/apartment/adapters/postgresql_adapter.rb:160:in `import_database_schema'
        ... 38 levels...
3.3.5 :002 > exit
```