### PR TITLE
Fix: ActiveRecord monkeypatch breaking Solid Cache

### DIFF
--- a/lib/apartment/active_record/connection_handling.rb
+++ b/lib/apartment/active_record/connection_handling.rb
@@ -15,10 +15,10 @@ module ActiveRecord # :nodoc:
         end
       end
     else
-      def connected_to_with_tenant(role: nil, prevent_writes: false, &blk)
+      def connected_to_with_tenant(role: nil, shard: nil, prevent_writes: false, &blk)
         current_tenant = Apartment::Tenant.current
 
-        connected_to_without_tenant(role: role, prevent_writes: prevent_writes) do
+        connected_to_without_tenant(role: role, shard: shard, prevent_writes: prevent_writes) do
           Apartment::Tenant.switch!(current_tenant)
           yield(blk)
         end


### PR DESCRIPTION
## The Problem
When trying to integrate Solid Cache into my app (which uses the ros-apartment gem), I was getting this error:

<img src="https://github.com/user-attachments/assets/2759ac3f-1842-43db-b837-a09efac21743" width="800" />

This error was being triggered from the [connection_handling monkeypatch](https://github.com/rails-on-services/apartment/blob/0c0faf1c796d89108c76856903df5c30fcd2fb50/lib/apartment/active_record/connection_handling.rb).

## The Solution
Solid Cache is attempting to pass a shard parameter through the `connected_to` function. The monkeypatch in ros-apartment should allow for the shard parameter to be passed through.
