### PR TITLE
fix: Deprecation cannot find version error

### DIFF
--- a/lib/apartment/deprecation.rb
+++ b/lib/apartment/deprecation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/deprecation'
-
+require_relative 'version'
 module Apartment
   DEPRECATOR = ActiveSupport::Deprecation.new(Apartment::VERSION, 'Apartment')
 end

--- a/lib/apartment/deprecation.rb
+++ b/lib/apartment/deprecation.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/deprecation'
 require_relative 'version'
+
 module Apartment
   DEPRECATOR = ActiveSupport::Deprecation.new(Apartment::VERSION, 'Apartment')
 end


### PR DESCRIPTION
Issue:

While doing ` bundle exec rails generate apartment:install` we get the following error:

<img width="1275" alt="Screenshot 2024-10-09 at 12 59 24 PM" src="https://github.com/user-attachments/assets/08bec2e0-3ae3-49b1-b1dc-8e0eb72f8876">


This PR fixes the `uninitialized constant Apartment::VERSION` issue

Version: `development` branch
