### PR TITLE
Remove upper bound for Ruby version

### DIFF
--- a/ros-apartment.gemspec
+++ b/ros-apartment.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true',
   }
 
-  s.required_ruby_version = '>= 3.1', '<= 3.4'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_dependency('activerecord', '>= 6.1.0', '< 8.1')
   s.add_dependency('activesupport', '>= 6.1.0', '< 8.1')


### PR DESCRIPTION
1) '<= 3.4' will not let you use Ruby 3.4.1, which was released the same day as 3.4.0: https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-1-released/
2) this gem has very low velocity (no blaming, thanks for maintenance!), so adding some artificial upper bound for Ruby is a rather strange constraint. I see the official support from your CI, and I have my own CI to check if this gem works on what ever latest Ruby I want to use

At a minimum, I expect we can do '< 3.5', since I see no point in not allowing patch updates to Ruby.

I noticed this because upgrading to Ruby 3.4.1 suddenly downgrades to an older version of this gem (3.0.2 from 3.1.0).