### PR TITLE
Relax `public_suffix` dependency from `<= 6.0.1` to `< 7`

### DIFF
--- a/ros-apartment.gemspec
+++ b/ros-apartment.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '>= 6.1.0', '< 8.1')
   s.add_dependency('activesupport', '>= 6.1.0', '< 8.1')
   s.add_dependency('parallel', '< 2.0')
-  s.add_dependency('public_suffix', '>= 2.0.5', '<= 6.0.1')
+  s.add_dependency('public_suffix', '>= 2.0.5', '< 7')
   s.add_dependency('rack', '>= 1.3.6', '< 4.0')
 end


### PR DESCRIPTION
`<= 6.0.1` for `public_suffix` seems overly strict (it blocks update to `public_suffix` `6.0.2`).