### PR TITLE
switch to psql when importing database schema

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -181,7 +181,7 @@ module Apartment
           temp_file.write(pg_schema_sql)
           temp_file.close # Close the file so psql can read it
 
-          with_pg_env { `psql -d #{dbname} -f #{temp_file.path}` }
+          with_pg_env { system("psql", "-q", "-d", dbname, "-f", temp_file.path) }
         end
       end
 
@@ -195,7 +195,7 @@ module Apartment
           temp_file.write(pg_migrations_data)
           temp_file.close # Close the file so psql can read it
 
-          with_pg_env { `psql -d #{dbname} -f #{temp_file.path}` }
+          with_pg_env { system("psql", "-q", "-d", dbname, "-f", temp_file.path) }
         end
       end
 


### PR DESCRIPTION
Hi! This patch "adds" support for the new `\restrict` and `\unrestrict` meta-commands issued in pg_dump as part of the fix for https://github.com/advisories/GHSA-6m5q-cc57-2mj6 (see: https://www.postgresql.org/support/security/CVE-2025-8714/).

These meta-commands are specific to the `psql` (https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-META-COMMANDS), so, my first approach was to add them to `PSQL_DUMP_BLACKLISTED_STATEMENTS` because my understanding is that any meta-command present in the dump would manifest as the following error when cloning the schema:
```
ERROR: syntax error at or near "\" at character XX
```

In fact, we can find an exmple of this error in the project's test suite:
<img width="1210" height="380" alt="image" src="https://github.com/user-attachments/assets/a24b3157-27f8-409b-930b-ece889513880" />

However, I was not entirely comfortable with that approach. Therefore, I propose switching to using `psql` to load the SQL generated by `pg_dump`, as this eliminates the need for explicit blacklisting and should improve resilience to future changes in `pg_dump` output.

Fixes #322