### PR TITLE
ignore the new restrict/unrestric postgresql command

### DIFF
--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -149,6 +149,7 @@ module Apartment
         /CREATE SCHEMA/i,
         /COMMENT ON SCHEMA/i,
         /SET transaction_timeout/i,                   # new in postgresql 17
+        /\\(un)?restrict/i,                           # new in postgresql 13.22, 14.19, 15.14, 16.10, 17.6
 
       ].freeze
 


### PR DESCRIPTION
This patch updates Apartment's `PostgresqlSchemaAdapter` to ignore the new `\restrict` and `\unrestrict` meta-commands introduced in `pg_dump` as part of the fix for [[CVE-2025-8714](https://www.postgresql.org/support/security/CVE-2025-8714/)](https://www.postgresql.org/support/security/CVE-2025-8714/).

These meta-commands are specific to the `psql` client (https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-META-COMMANDS). Since Apartment restores schema SQL directly via ActiveRecord (not through `psql`), any `psql`-specific meta-commands present in the dump would result in errors like:

```
ERROR: syntax error at or near "\" at character XX
```

An example of this error can be seen in the project's test suite:
<img width="1210" height="380" alt="image" src="https://github.com/user-attachments/assets/a24b3157-27f8-409b-930b-ece889513880" />

I was not entirely comfortable with that approach and proposed switching to `psql` to load the SQL generated by `pg_dump` (thus avoiding the need to explicitly filter out this meta-commands) in PR #324. But proved incompatible with transactional schema creation.


**I'd like confirmation from other reviewers that ignoring this is safe within the context of Apartment by my understanding that any meta-command present in the dump would manifest as the described error.**


Fixes #322