### PR TITLE
fix: use ActiveRecord.dump_schema_after_migration

### DIFF
--- a/lib/apartment/tasks/schema_dumper.rb
+++ b/lib/apartment/tasks/schema_dumper.rb
@@ -99,9 +99,9 @@ module Apartment
         # Checks Rails' global schema dump setting. Older Rails versions
         # may not have this method, so we default to enabled.
         def rails_dump_schema_enabled?
-          return true unless ActiveRecord::Base.respond_to?(:dump_schema_after_migration)
+          return true unless ActiveRecord.respond_to?(:dump_schema_after_migration)
 
-          ActiveRecord::Base.dump_schema_after_migration
+          ActiveRecord.dump_schema_after_migration
         end
       end
     end

--- a/spec/unit/schema_dumper_spec.rb
+++ b/spec/unit/schema_dumper_spec.rb
@@ -12,7 +12,7 @@ describe Apartment::Tasks::SchemaDumper do
   describe '.dump_if_enabled' do
     context 'when Rails dump_schema_after_migration is false' do
       before do
-        allow(ActiveRecord::Base).to(receive(:dump_schema_after_migration).and_return(false))
+        allow(ActiveRecord).to(receive(:dump_schema_after_migration).and_return(false))
       end
 
       it 'does not dump schema' do
@@ -25,7 +25,7 @@ describe Apartment::Tasks::SchemaDumper do
       let(:db_config) { double('DatabaseConfig', configuration_hash: { schema_dump: true }) }
 
       before do
-        allow(ActiveRecord::Base).to(receive(:dump_schema_after_migration).and_return(true))
+        allow(ActiveRecord).to(receive(:dump_schema_after_migration).and_return(true))
         allow(described_class).to(receive(:find_schema_dump_config).and_return(db_config))
         allow(Apartment::Tenant).to(receive(:switch).and_yield)
         allow(Rake::Task).to(receive(:task_defined?).with('db:schema:dump').and_return(true))


### PR DESCRIPTION
For modern versions of Rails, we should use `ActiveRecord.dump_schema_after_migration`.

As far as I found, in Rails 7.2+, deprecated wrappers were removed from `ActiveRecord::Base`. So only `ActiveRecord.dump_schema_after_migration` is supported for Rails 7.2+.

Example from Rails 8.1

```ruby
ActiveRecord.dump_schema_after_migration
# true

ActiveRecord::Base.dump_schema_after_migration
# undefined method 'dump_schema_after_migration' for class ActiveRecord::Base (NoMethodError)
```

So, now the apartment silently ignores `dump_schema_after_migration` settings in Rails 7.2+ and defaults to always do dump.

Rails 7.0+ supports `ActiveRecord.dump_schema_after_migration`:
https://github.com/rails/rails/blob/984c3ef2775781d47efa9f541ce570daa2434a80/activerecord/lib/active_record.rb#L311

As Apartment supports Rails 7.0+, so `ActiveRecord.dump_schema_after_migration` is the preferred way.
