### PR TITLE
fix: share tenant connection for pinned models on single-server setups

### DIFF
--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -117,6 +117,31 @@ config.active_support.isolation_level = :fiber
 
 The Railtie emits a boot-time warning if `isolation_level` is `:thread`.
 
+### Pinned Model Connections
+
+In v3, pinned (excluded) models always received their own connection pool via `establish_connection`. This meant they never participated in the same database transaction as tenant-scoped models. The behavior was also inconsistent: direct access (`Delayed::Job.create!`) used the separate pool, while JOINs initiated from a tenant model (`Order.joins(:delayed_jobs)`) accidentally ran on the tenant's connection.
+
+v4 fixes this for strategies where the database engine supports cross-schema/database queries on a single connection:
+
+| Strategy | Pinned model connection in v4 |
+|---|---|
+| PostgreSQL schema | Shares tenant connection (qualified table name) |
+| MySQL / Trilogy single-server | Shares tenant connection (qualified table name) |
+| PostgreSQL database-per-tenant | Separate pool (unchanged from v3) |
+| SQLite | Separate pool (unchanged from v3) |
+| Multi-server | Separate pool (unchanged from v3) |
+
+For MySQL/Trilogy and PG schema tenancy, pinned models now use the tenant's connection pool with a fully qualified table name (e.g. `default_db.delayed_jobs`). This means pinned model writes participate in the same transaction as tenant DML — a rollback rolls back both.
+
+**Action required if you relied on the old behavior:**
+
+If your code assumes that pinned model writes survive a tenant transaction rollback (e.g., enqueuing a job and deliberately rolling back tenant data), this will no longer work. Common patterns to check:
+
+- `after_commit` callbacks that enqueue jobs — these still work correctly and are the recommended pattern. No changes needed.
+- Manual transaction coordination where a pinned model write was expected to persist independently of the tenant transaction — wrap the pinned model write in its own `ActiveRecord::Base.transaction` on the pinned model's class if you need this isolation.
+
+For PG database-per-tenant, SQLite, and multi-server setups, pinned model behavior is unchanged from v3.
+
 Key config options for pool tuning:
 
 | Option | Default | Description |
@@ -175,6 +200,8 @@ end
 Once all models are converted, delete the `config.excluded_models` line entirely.
 
 For third-party gem models you cannot modify directly, `config.excluded_models` remains available as a transitional escape hatch.
+
+If your pinned models are used inside `ActiveRecord::Base.transaction` blocks alongside tenant models, verify that your transaction boundaries are still correct. In v4, pinned model writes on MySQL/Trilogy and PG schema tenancy now participate in the tenant's transaction (they didn't in v3). This is usually the desired behavior, but review any code where you intentionally relied on pinned models being outside the transaction scope.
 
 ### Step 3: Update Tenant Switching
 

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -96,6 +96,21 @@ module Apartment
         end
       end
 
+      # Whether this adapter can route pinned model queries through the tenant's
+      # connection pool using fully qualified table names. When true,
+      # process_pinned_model qualifies the table name instead of calling
+      # establish_connection, so pinned and tenant models share a transaction.
+      #
+      # Returns true for strategies where the default tenant's tables are
+      # reachable from any tenant connection (PG schemas in one catalog,
+      # MySQL databases on one server). Returns false when cross-database
+      # queries are impossible (PG database-per-tenant, SQLite, multi-server).
+      #
+      # Subclasses override. Default: false (separate pool, safe fallback).
+      def shared_connection_supported?
+        false
+      end
+
       # Process all pinned models — establish separate connections pinned to default tenant.
       def process_pinned_models
         return if Apartment.pinned_models.empty?
@@ -107,6 +122,11 @@ module Apartment
 
       # Process a single pinned model. Called by process_pinned_models (batch)
       # and by Apartment::Model.pin_tenant (when activated? is true).
+      #
+      # When shared_connection_supported? is true, only qualifies the table name
+      # so the model uses the tenant's pool (preserving transactional integrity).
+      # Otherwise, establishes a separate connection pool (required when
+      # cross-database queries are impossible).
       def process_pinned_model(klass)
         # Idempotent: skip if already processed. Uses a class-level flag rather
         # than connection_specification_name comparison — the spec name differs
@@ -114,19 +134,19 @@ module Apartment
         # establish_connection, so it's not a reliable "already processed" signal.
         return if klass.instance_variable_get(:@apartment_connection_established)
 
-        # Use base_config (the adapter's raw connection config) rather than
-        # resolve_connection_config(default_tenant). For database-per-tenant
-        # strategies (MySQL, SQLite), resolve_connection_config would set the
-        # database key to the default tenant NAME (e.g. 'default'), not the
-        # actual default database (e.g. 'apartment_v4_test'). base_config
-        # points to the real default database.
-        klass.establish_connection(base_config)
+        if shared_connection_supported?
+          qualify_pinned_table_name(klass)
+        else
+          # Use base_config (the adapter's raw connection config) rather than
+          # resolve_connection_config(default_tenant). For database-per-tenant
+          # strategies (MySQL, SQLite), resolve_connection_config would set the
+          # database key to the default tenant NAME (e.g. 'default'), not the
+          # actual default database (e.g. 'apartment_v4_test'). base_config
+          # points to the real default database.
+          klass.establish_connection(base_config)
+        end
+
         klass.instance_variable_set(:@apartment_connection_established, true)
-
-        return unless Apartment.config.tenant_strategy == :schema
-
-        table = klass.table_name.split('.').last
-        klass.table_name = "#{default_tenant}.#{table}"
       end
 
       # Deprecated: use process_pinned_models instead.
@@ -184,6 +204,14 @@ module Apartment
       # No-op base implementation — PG schema and MySQL adapters override.
       def grant_privileges(tenant, connection, role_name)
         # intentional no-op
+      end
+
+      # Qualify a pinned model's table_name so it targets the default tenant's
+      # tables from any tenant connection. Subclasses override for strategy-
+      # specific prefixes (schema name for PG, database name for MySQL).
+      def qualify_pinned_table_name(klass)
+        raise(NotImplementedError,
+              "#{self.class}#qualify_pinned_table_name must be implemented when shared_connection_supported? is true")
       end
 
       # Connection config with string keys (used by subclasses to build tenant configs).

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -10,6 +10,12 @@ module Apartment
     # to the environmentified tenant name. Lifecycle operations (create/drop)
     # execute DDL against the default connection.
     class Mysql2Adapter < AbstractAdapter
+      # MySQL supports cross-database queries on the same server connection
+      # (e.g. default_db.delayed_jobs from any USE database context).
+      def shared_connection_supported?
+        true
+      end
+
       def resolve_connection_config(tenant, base_config: nil)
         config = base_config || send(:base_config)
         config.merge('database' => environmentify(tenant))
@@ -30,6 +36,13 @@ module Apartment
       end
 
       private
+
+      # Qualify with the actual default database name from base_config
+      # (e.g. "apartment_v4_test.delayed_jobs").
+      def qualify_pinned_table_name(klass)
+        table = klass.table_name.split('.').last
+        klass.table_name = "#{base_config['database']}.#{table}"
+      end
 
       def grant_privileges(tenant, connection, role_name)
         db_name = environmentify(tenant)

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -12,6 +12,12 @@ module Apartment
     # Apartment.config.postgres_config. Lifecycle operations (create/drop)
     # execute DDL against the default connection.
     class PostgresqlSchemaAdapter < AbstractAdapter
+      # PG schemas live in the same catalog — cross-schema queries work on
+      # a single connection (e.g. public.delayed_jobs from any search_path).
+      def shared_connection_supported?
+        true
+      end
+
       def resolve_connection_config(tenant, base_config: nil)
         config = base_config || send(:base_config)
         persistent = Apartment.config.postgres_config&.persistent_schemas || []
@@ -33,6 +39,12 @@ module Apartment
       end
 
       private
+
+      # Qualify with the default schema (e.g. "public.delayed_jobs").
+      def qualify_pinned_table_name(klass)
+        table = klass.table_name.split('.').last
+        klass.table_name = "#{default_tenant}.#{table}"
+      end
 
       def grant_privileges(tenant, connection, role_name) # rubocop:disable Metrics/MethodLength
         quoted_schema = connection.quote_table_name(tenant)

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -17,11 +17,15 @@ module Apartment
         return super if tenant.to_s == cfg.default_tenant.to_s
         return super unless Apartment.pool_manager
 
-        # Skip tenant override for Apartment pinned models.
-        # Uses explicit registry (not connection_specification_name heuristic)
-        # because ApplicationRecord subclasses have a different spec name than
-        # ActiveRecord::Base while sharing the same pool.
-        return super if self != ActiveRecord::Base && Apartment.pinned_model?(self)
+        # Skip tenant override for Apartment pinned models — but only when the
+        # adapter requires a separate pool (shared_connection_supported? is false).
+        # When shared connections are supported (PG schema, MySQL single-server),
+        # pinned models use the tenant's pool with a fully qualified table name,
+        # preserving transactional integrity between pinned and tenant models.
+        if self != ActiveRecord::Base && Apartment.pinned_model?(self) &&
+           !Apartment.adapter&.shared_connection_supported?
+          return super
+        end
 
         role = ActiveRecord::Base.current_role
         pool_key = "#{tenant}:#{role}"

--- a/spec/integration/v4/excluded_models_spec.rb
+++ b/spec/integration/v4/excluded_models_spec.rb
@@ -66,13 +66,18 @@ RSpec.describe('v4 Pinned models integration (Apartment::Model)', :integration,
     end
   end
 
-  it 'pin_tenant establishes a dedicated connection for the model' do
-    expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+  it 'pin_tenant does not establish a separate connection when shared connection is supported' do
+    if Apartment.adapter.shared_connection_supported?
+      # Shared connection: pinned model uses the same pool as AR::Base
+      expect(GlobalSetting.connection_specification_name).to(eq(ActiveRecord::Base.connection_specification_name))
+    else
+      # Separate pool: pinned model has its own connection
+      expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+    end
   end
 
   it 'pin_tenant is idempotent' do
     expect { Apartment.adapter.process_pinned_models }.not_to(raise_error)
-    expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
   end
 
   it 'pinned model queries always target the default database' do
@@ -101,6 +106,41 @@ RSpec.describe('v4 Pinned models integration (Apartment::Model)', :integration,
     end
 
     expect(GlobalSetting.find_by(key: 'inside_tenant')).to(be_present)
+  end
+
+  context 'transactional integrity', skip: (
+    V4_INTEGRATION_AVAILABLE && V4IntegrationHelper.sqlite? &&
+    'SQLite uses separate files — cross-database transactions not supported'
+  ) do
+    it 'rolls back both pinned and tenant model writes on transaction rollback' do
+      skip 'requires shared_connection_supported?' unless Apartment.adapter.shared_connection_supported?
+
+      Apartment::Tenant.switch('tenant_a') do
+        ActiveRecord::Base.transaction do
+          Widget.create!(name: 'will_be_rolled_back')
+          GlobalSetting.create!(key: 'will_be_rolled_back', value: 'yes')
+          raise ActiveRecord::Rollback
+        end
+
+        # Both writes should be rolled back since they share the same connection
+        expect(Widget.count).to(eq(0))
+        expect(GlobalSetting.where(key: 'will_be_rolled_back').count).to(eq(0))
+      end
+    end
+
+    it 'commits both pinned and tenant model writes on successful transaction' do
+      skip 'requires shared_connection_supported?' unless Apartment.adapter.shared_connection_supported?
+
+      Apartment::Tenant.switch('tenant_a') do
+        ActiveRecord::Base.transaction do
+          Widget.create!(name: 'committed')
+          GlobalSetting.create!(key: 'committed', value: 'yes')
+        end
+
+        expect(Widget.find_by(name: 'committed')).to(be_present)
+        expect(GlobalSetting.find_by(key: 'committed')).to(be_present)
+      end
+    end
   end
 
   it 'tenant model (Widget) still routes through tenant pool during switch' do

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -320,26 +320,83 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
     end
   end
 
+  describe '#shared_connection_supported?' do
+    it 'returns false by default (safe fallback)' do
+      expect(adapter.shared_connection_supported?).to(be(false))
+    end
+  end
+
   describe '#process_pinned_models' do
-    it 'establishes connections for each pinned model' do
-      model_class = Class.new(ActiveRecord::Base) do
-        include Apartment::Model
+    context 'when shared_connection_supported? is false (separate pool)' do
+      it 'establishes connections for each pinned model' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('PinnedSetting', model_class)
+        allow(model_class).to(receive(:table_name).and_return('pinned_settings'))
+        allow(model_class).to(receive(:table_name=))
+
+        PinnedSetting.pin_tenant
+
+        # Pinned models use base_config (the adapter's raw connection config),
+        # not resolve_connection_config(default_tenant) — avoids database-per-tenant
+        # strategies setting database key to the tenant name instead of the real DB.
+        expected_config = { 'adapter' => 'postgresql', 'host' => 'localhost' }
+        expect(model_class).to(receive(:establish_connection)) do |arg|
+          expect(arg).to(eq(expected_config))
+        end
+
+        adapter.process_pinned_models
       end
-      stub_const('PinnedSetting', model_class)
-      allow(model_class).to(receive(:table_name).and_return('pinned_settings'))
-      allow(model_class).to(receive(:table_name=))
 
-      PinnedSetting.pin_tenant
+      it 'does not prefix table name for database_name strategy' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('DbPinned', model_class)
+        allow(model_class).to(receive(:establish_connection))
+        allow(model_class).to(receive(:table_name).and_return('db_pinned'))
 
-      # Pinned models use base_config (the adapter's raw connection config),
-      # not resolve_connection_config(default_tenant) — avoids database-per-tenant
-      # strategies setting database key to the tenant name instead of the real DB.
-      expected_config = { 'adapter' => 'postgresql', 'host' => 'localhost' }
-      expect(model_class).to(receive(:establish_connection)) do |arg|
-        expect(arg).to(eq(expected_config))
+        DbPinned.pin_tenant
+
+        reconfigure(tenant_strategy: :database_name)
+
+        expect(model_class).not_to(receive(:table_name=))
+        adapter.process_pinned_models
+      end
+    end
+
+    context 'when shared_connection_supported? is true (shared pool)' do
+      before do
+        allow(adapter).to(receive(:shared_connection_supported?).and_return(true))
+        allow(adapter).to(receive(:qualify_pinned_table_name))
       end
 
-      adapter.process_pinned_models
+      it 'does not call establish_connection' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('SharedPinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('shared_pinned'))
+
+        SharedPinned.pin_tenant
+
+        expect(model_class).not_to(receive(:establish_connection))
+        adapter.process_pinned_models
+      end
+
+      it 'calls qualify_pinned_table_name' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('QualifyPinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('qualify_pinned'))
+
+        QualifyPinned.pin_tenant
+
+        expect(adapter).to(receive(:qualify_pinned_table_name).with(model_class))
+        adapter.process_pinned_models
+      end
     end
 
     it 'skips models already processed (idempotent)' do
@@ -358,36 +415,6 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
 
       # Second call skips — @apartment_connection_established is set
       expect(model_class).not_to(receive(:establish_connection))
-      adapter.process_pinned_models
-    end
-
-    it 'prefixes table name with default schema for schema strategy' do
-      model_class = Class.new(ActiveRecord::Base) do
-        include Apartment::Model
-      end
-      stub_const('SchemaPinned', model_class)
-      allow(model_class).to(receive(:establish_connection))
-      allow(model_class).to(receive(:table_name).and_return('schema_pinned'))
-
-      SchemaPinned.pin_tenant
-
-      expect(model_class).to(receive(:table_name=).with('public.schema_pinned'))
-      adapter.process_pinned_models
-    end
-
-    it 'does not prefix table name for database_name strategy' do
-      model_class = Class.new(ActiveRecord::Base) do
-        include Apartment::Model
-      end
-      stub_const('DbPinned', model_class)
-      allow(model_class).to(receive(:establish_connection))
-      allow(model_class).to(receive(:table_name).and_return('db_pinned'))
-
-      DbPinned.pin_tenant
-
-      reconfigure(tenant_strategy: :database_name)
-
-      expect(model_class).not_to(receive(:table_name=))
       adapter.process_pinned_models
     end
 

--- a/spec/unit/adapters/mysql2_adapter_spec.rb
+++ b/spec/unit/adapters/mysql2_adapter_spec.rb
@@ -220,6 +220,54 @@ RSpec.describe(Apartment::Adapters::Mysql2Adapter) do
     end
   end
 
+  describe '#shared_connection_supported?' do
+    let(:connection_config) { { adapter: 'mysql2', host: 'localhost', database: 'myapp' } }
+    let(:adapter) { described_class.new(connection_config) }
+
+    before do
+      Apartment.configure do |c|
+        c.tenant_strategy = :database_name
+        c.tenants_provider = -> { %w[t1 t2] }
+        c.default_tenant = 'myapp'
+        c.schema_load_strategy = nil
+      end
+    end
+
+    it 'returns true (MySQL supports cross-database queries on same server)' do
+      expect(adapter.shared_connection_supported?).to(be(true))
+    end
+  end
+
+  describe '#qualify_pinned_table_name (private)' do
+    let(:connection_config) { { adapter: 'mysql2', host: 'localhost', database: 'myapp' } }
+    let(:adapter) { described_class.new(connection_config) }
+
+    before do
+      Apartment.configure do |c|
+        c.tenant_strategy = :database_name
+        c.tenants_provider = -> { %w[t1 t2] }
+        c.default_tenant = 'myapp'
+        c.schema_load_strategy = nil
+      end
+    end
+
+    it 'prefixes table name with the default database from base_config' do
+      model_class = Class.new
+      allow(model_class).to(receive(:table_name).and_return('delayed_jobs'))
+      expect(model_class).to(receive(:table_name=).with('myapp.delayed_jobs'))
+
+      adapter.send(:qualify_pinned_table_name, model_class)
+    end
+
+    it 'strips existing database prefix before re-qualifying' do
+      model_class = Class.new
+      allow(model_class).to(receive(:table_name).and_return('old_db.delayed_jobs'))
+      expect(model_class).to(receive(:table_name=).with('myapp.delayed_jobs'))
+
+      adapter.send(:qualify_pinned_table_name, model_class)
+    end
+  end
+
   it_behaves_like 'a MySQL adapter' do
     let(:adapter_name) { 'mysql2' }
   end
@@ -233,6 +281,24 @@ RSpec.describe(Apartment::Adapters::TrilogyAdapter) do
 
     it 'is a subclass of AbstractAdapter' do
       expect(described_class).to(be < Apartment::Adapters::AbstractAdapter)
+    end
+  end
+
+  describe '#shared_connection_supported?' do
+    let(:connection_config) { { adapter: 'trilogy', host: 'localhost', database: 'myapp' } }
+    let(:adapter) { described_class.new(connection_config) }
+
+    before do
+      Apartment.configure do |c|
+        c.tenant_strategy = :database_name
+        c.tenants_provider = -> { %w[t1 t2] }
+        c.default_tenant = 'myapp'
+        c.schema_load_strategy = nil
+      end
+    end
+
+    it 'inherits true from Mysql2Adapter' do
+      expect(adapter.shared_connection_supported?).to(be(true))
     end
   end
 

--- a/spec/unit/adapters/postgresql_database_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_database_adapter_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe(Apartment::Adapters::PostgresqlDatabaseAdapter) do
     end
   end
 
+  describe '#shared_connection_supported?' do
+    it 'returns false (PG fully isolates databases)' do
+      expect(adapter.shared_connection_supported?).to(be(false))
+    end
+  end
+
   describe '#resolve_connection_config' do
     it 'returns config with database key set to tenant name (nil strategy = plain name)' do
       result = adapter.resolve_connection_config('acme')

--- a/spec/unit/adapters/postgresql_schema_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_schema_adapter_spec.rb
@@ -46,6 +46,30 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
     end
   end
 
+  describe '#shared_connection_supported?' do
+    it 'returns true (schemas live in the same catalog)' do
+      expect(adapter.shared_connection_supported?).to(be(true))
+    end
+  end
+
+  describe '#qualify_pinned_table_name (private)' do
+    it 'prefixes table name with default schema' do
+      model_class = Class.new
+      allow(model_class).to(receive(:table_name).and_return('delayed_jobs'))
+      expect(model_class).to(receive(:table_name=).with('public.delayed_jobs'))
+
+      adapter.send(:qualify_pinned_table_name, model_class)
+    end
+
+    it 'strips existing schema prefix before re-qualifying' do
+      model_class = Class.new
+      allow(model_class).to(receive(:table_name).and_return('old_schema.delayed_jobs'))
+      expect(model_class).to(receive(:table_name=).with('public.delayed_jobs'))
+
+      adapter.send(:qualify_pinned_table_name, model_class)
+    end
+  end
+
   describe '#resolve_connection_config' do
     it 'returns config with schema_search_path set to tenant name' do
       result = adapter.resolve_connection_config('acme')

--- a/spec/unit/adapters/sqlite3_adapter_spec.rb
+++ b/spec/unit/adapters/sqlite3_adapter_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe(Apartment::Adapters::Sqlite3Adapter) do
     end
   end
 
+  describe '#shared_connection_supported?' do
+    it 'returns false (separate files, no cross-database transactions)' do
+      expect(adapter.shared_connection_supported?).to(be(false))
+    end
+  end
+
   describe '#resolve_connection_config' do
     it 'returns config with database key set to file path' do
       result = adapter.resolve_connection_config('acme')

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -271,36 +271,74 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
         require_relative('../../../lib/apartment/concerns/model')
       end
 
-      it 'returns the default pool for a pinned AR::Base subclass when tenant is set' do
-        pinned_class = Class.new(ActiveRecord::Base) do
-          include Apartment::Model
+      context 'when shared_connection_supported? is false (separate pool)' do
+        before do
+          allow(mock_adapter).to(receive(:shared_connection_supported?).and_return(false))
         end
-        stub_const('PinnedBypassModel', pinned_class)
-        pinned_class.pin_tenant
 
-        Apartment::Current.tenant = 'acme'
-        # Pinned class must use super (default pool), not the tenant pool
-        expect(pinned_class.connection_pool).to(equal(default_pool))
+        it 'returns the default pool for a pinned AR::Base subclass when tenant is set' do
+          pinned_class = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedBypassModel', pinned_class)
+          pinned_class.pin_tenant
+
+          Apartment::Current.tenant = 'acme'
+          # Pinned class must use super (default pool), not the tenant pool
+          expect(pinned_class.connection_pool).to(equal(default_pool))
+        end
+
+        it 'bypasses for STI subclass of a pinned model' do
+          parent = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedParentBypass', parent)
+          parent.pin_tenant
+
+          child = Class.new(parent)
+          stub_const('PinnedChildBypass', child)
+
+          Apartment::Current.tenant = 'acme'
+          expect(child.connection_pool).to(equal(default_pool))
+        end
+      end
+
+      context 'when shared_connection_supported? is true (shared pool)' do
+        before do
+          allow(mock_adapter).to(receive(:shared_connection_supported?).and_return(true))
+        end
+
+        it 'returns the tenant pool for a pinned model (transactional integrity)' do
+          pinned_class = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedSharedModel', pinned_class)
+          pinned_class.pin_tenant
+
+          Apartment::Current.tenant = 'acme'
+          # Pinned model should use the tenant pool, not the default pool
+          expect(pinned_class.connection_pool).not_to(equal(default_pool))
+        end
+
+        it 'returns the tenant pool for STI subclass of a pinned model' do
+          parent = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedSharedParent', parent)
+          parent.pin_tenant
+
+          child = Class.new(parent)
+          stub_const('PinnedSharedChild', child)
+
+          Apartment::Current.tenant = 'acme'
+          expect(child.connection_pool).not_to(equal(default_pool))
+        end
       end
 
       it 'does not bypass for ActiveRecord::Base itself' do
         Apartment::Current.tenant = 'acme'
         tenant_pool = ActiveRecord::Base.connection_pool
         expect(tenant_pool).not_to(equal(default_pool))
-      end
-
-      it 'bypasses for STI subclass of a pinned model' do
-        parent = Class.new(ActiveRecord::Base) do
-          include Apartment::Model
-        end
-        stub_const('PinnedParentBypass', parent)
-        parent.pin_tenant
-
-        child = Class.new(parent)
-        stub_const('PinnedChildBypass', child)
-
-        Apartment::Current.tenant = 'acme'
-        expect(child.connection_pool).to(equal(default_pool))
       end
 
       it 'does not bypass for an unpinned AR::Base subclass' do


### PR DESCRIPTION
# Fix: Pinned models share tenant connection where supported

Closes #XXX

## Problem

`process_pinned_model` unconditionally calls `establish_connection`, giving every pinned model its own connection pool. This makes it impossible for pinned model writes (e.g. `Delayed::Job.enqueue`) to participate in the same transaction as tenant-scoped models. A rollback of tenant DML leaves pinned model rows behind.

In v3, this was already inconsistent: direct access (`Delayed::Job.create!`) used the separate pool, but JOINs from a tenant model accidentally ran on the tenant's connection. v4 inherits the same `establish_connection` call without addressing the inconsistency.

## Fix

Make the pinned model connection strategy dependent on whether the database engine supports cross-schema/database queries on a single connection:

**Shared connection** (MySQL/Trilogy single-server, PG schema): Skip `establish_connection`. Only qualify the table name (`default_db.delayed_jobs` / `public.delayed_jobs`). Let pinned models use the tenant's connection pool. Adjust `ConnectionHandling#connection_pool` to not bail out for pinned models in this mode.

**Separate connection** (PG database-per-tenant, SQLite, multi-server): Preserve existing behavior — `establish_connection` creates a dedicated pool, because cross-database queries are not possible.

## Changes

- `AbstractAdapter#process_pinned_model`: branch on `shared_connection_supported?`
- `AbstractAdapter#shared_connection_supported?`: returns `true` for schema strategy and single-server MySQL/Trilogy
- `ConnectionHandling#connection_pool`: skip early return for pinned models when shared connections are supported
- Added/updated specs for both code paths
- Updated `docs/upgrading-to-v4.md` with migration notes

## Risk

Low for the shared-connection path — the fully qualified table name mechanism already existed for schema tenancy. For the separate-connection path, behavior is unchanged.

Apps that relied on pinned models being outside the tenant transaction (e.g. manual `after_commit` coordination) should review those callsites — see upgrade guide.
