### PR TITLE
Fix stale docs after search_path quoting and elevator changes

### DIFF
--- a/docs/designs/apartment-v4.md
+++ b/docs/designs/apartment-v4.md
@@ -79,10 +79,10 @@ Each tenant gets its own connection pool with tenant-specific config baked in at
 ```ruby
 def resolve_connection_config(tenant)
   base_config.merge(
-    schema_search_path: [tenant, *persistent_schemas].join(",")
+    schema_search_path: [tenant, *persistent_schemas].map { |s| %("#{s}") }.join(",")
   )
 end
-# Example: schema_search_path: "acme,ext,public"
+# Example: schema_search_path: '"acme","ext","public"'
 ```
 
 **MySQL (database_name strategy):**
@@ -389,7 +389,7 @@ Primary strategy. Pool config sets `schema_search_path` at connection creation t
 ```ruby
 def resolve_connection_config(tenant)
   base_config.merge(
-    schema_search_path: [tenant, *persistent_schemas].join(",")
+    schema_search_path: [tenant, *persistent_schemas].map { |s| %("#{s}") }.join(",")
   )
 end
 ```

--- a/docs/designs/phase-2.3-connection-handling.md
+++ b/docs/designs/phase-2.3-connection-handling.md
@@ -110,7 +110,7 @@ Each tenant pool has **immutable, tenant-specific config** baked in at creation:
 
 | Strategy | Config key | Example |
 |----------|-----------|---------|
-| PostgreSQL schema | `schema_search_path` | `"acme,ext,public"` |
+| PostgreSQL schema | `schema_search_path` | `'"acme","ext","public"'` |
 | PostgreSQL database | `database` | `"acme_production"` |
 | MySQL database | `database` | `"acme_production"` |
 | SQLite file | `database` | `"storage/acme.sqlite3"` |

--- a/docs/research/connection-handling-internals.md
+++ b/docs/research/connection-handling-internals.md
@@ -147,7 +147,7 @@ The prefix is configurable via `config.shard_key_prefix` (default: `"apartment"`
 ### Data isolation guarantee
 
 Each tenant gets its own `ConnectionPool` with tenant-specific config baked in at creation time:
-- **PostgreSQL (schema strategy)**: `schema_search_path: "acme,ext,public"` — the connection can only see tables in these schemas.
+- **PostgreSQL (schema strategy)**: `schema_search_path: '"acme","ext","public"'` — the connection can only see tables in these schemas.
 - **PostgreSQL/MySQL (database strategy)**: `database: "acme_production"` — the connection points at a different database entirely.
 - **SQLite**: `database: "storage/acme.sqlite3"` — a different file.
 

--- a/lib/apartment/elevators/CLAUDE.md
+++ b/lib/apartment/elevators/CLAUDE.md
@@ -31,11 +31,13 @@ All elevators are Rack middleware that intercept requests, extract tenant identi
 
 ### v4 Constructor Pattern
 
-v4 elevators use constructor keyword args — no class-level mutable state. Options are passed at middleware insertion time:
+v4 elevators use constructor keyword args — no class-level mutable state. The Railtie auto-inserts the elevator after `ActionDispatch::Callbacks` when `config.elevator` is set, passing `elevator_options` as keyword args.
+
+For manual positioning (skipping `config.elevator`), options are passed at middleware insertion time:
 
 ```ruby
-config.middleware.use Apartment::Elevators::Subdomain, excluded_subdomains: %w[www api]
-config.middleware.use Apartment::Elevators::Header, header: 'X-Tenant-Id'
+config.middleware.insert_before 'Warden::Manager', Apartment::Elevators::Subdomain, excluded_subdomains: %w[www api]
+config.middleware.insert_before 'Warden::Manager', Apartment::Elevators::Header, header: 'X-Tenant-Id'
 ```
 
 This replaces the v3 pattern of setting class attributes (`Subdomain.excluded_subdomains = [...]`) after adding to the stack. Each instance carries its own config.
@@ -217,10 +219,11 @@ Normalizes the header name to Rack's `HTTP_*` convention at init time. See `Head
 
 ### Configuration
 
-Pass `header:` keyword arg (defaults to `'X-Tenant-Id'`):
+Pass `header:` keyword arg (defaults to `'X-Tenant-Id'`) via `elevator_options`:
 
 ```ruby
-config.middleware.use Apartment::Elevators::Header, header: 'X-Tenant-Id'
+config.elevator = :header
+config.elevator_options = { header: 'X-Tenant-Id' }
 ```
 
 ### Security Note


### PR DESCRIPTION
## Summary

Syncs documentation with PRs #369 and #370:

- **search_path quoting** (PR #370): Update code examples in design docs and research docs to show quoted schema names (`"acme","ext","public"` not `acme,ext,public`)
- **elevator insertion** (PR #369): Update elevator CLAUDE.md to show `config.elevator` pattern and `insert_before` for manual positioning

## Files changed

- `docs/designs/apartment-v4.md` — 2 code snippets + 1 example
- `docs/designs/phase-2.3-connection-handling.md` — 1 table cell
- `docs/research/connection-handling-internals.md` — 1 example
- `lib/apartment/elevators/CLAUDE.md` — constructor pattern + header config example

Plan docs (`docs/plans/`) left as-is (historical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)