### PR TITLE
Add Apartment.tenant_names and .excluded_models v3 compat shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ For automatic tenant propagation:
 - [apartment-sidekiq](https://github.com/rails-on-services/apartment-sidekiq)
 - [apartment-activejob](https://github.com/rails-on-services/apartment-activejob)
 
+## Convenience Methods
+
+`Apartment.tenant_names` returns the current tenant list (delegates to `config.tenants_provider.call`). Preserves the v3 API so existing call sites work without changes.
+
+`Apartment.excluded_models` returns the excluded models list (delegates to `config.excluded_models`). Deprecated in v4; use `Apartment::Model` + `pin_tenant` instead.
+
 ## Troubleshooting
 
 If tenant switching raises unexpected errors, verify that `tenants_provider` returns valid tenant names and that the tenant exists in the database.

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -16,7 +16,7 @@ v4 replaces the thread-local tenant switching model with pool-per-tenant archite
 
 ### Configuration
 
-`config.tenant_names` has been removed. Use `config.tenants_provider` instead; it must be a callable (proc or lambda).
+`config.tenant_names` has been removed. Use `config.tenants_provider` instead; it must be a callable (proc or lambda). The convenience method `Apartment.tenant_names` still works — it delegates to `config.tenants_provider.call`.
 
 `config.tenant_strategy` is now required. Supported values: `:schema` (PostgreSQL schema-per-tenant) and `:database_name` (separate database per tenant). Additional strategies (`:shard`, `:database_config`) are reserved for future use and will raise `AdapterNotFound` if configured today.
 

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -65,6 +65,22 @@ module Apartment
       @activated == true
     end
 
+    # v3 compatibility: Apartment.tenant_names returns the current tenant list.
+    # Delegates to config.tenants_provider.call.
+    def tenant_names
+      raise(ConfigurationError, 'Apartment not configured. Call Apartment.configure first.') unless @config
+
+      @config.tenants_provider.call
+    end
+
+    # v3 compatibility: Apartment.excluded_models returns the excluded models list.
+    # Deprecated in v4 (use Apartment::Model + pin_tenant instead).
+    def excluded_models
+      raise(ConfigurationError, 'Apartment not configured. Call Apartment.configure first.') unless @config
+
+      @config.excluded_models
+    end
+
     def process_pinned_model(klass)
       adapter&.process_pinned_model(klass)
     end

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -54,6 +54,40 @@ RSpec.describe(Apartment) do
     end
   end
 
+  describe '.tenant_names' do
+    it 'delegates to config.tenants_provider.call' do
+      tenants = %w[acme widgets]
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { tenants }
+      end
+
+      expect(described_class.tenant_names).to(eq(%w[acme widgets]))
+    end
+
+    it 'raises ConfigurationError when not configured' do
+      described_class.clear_config
+      expect { described_class.tenant_names }.to(raise_error(Apartment::ConfigurationError, /not configured/))
+    end
+  end
+
+  describe '.excluded_models' do
+    it 'delegates to config.excluded_models' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.excluded_models = %w[Account]
+      end
+
+      expect(described_class.excluded_models).to(eq(%w[Account]))
+    end
+
+    it 'raises ConfigurationError when not configured' do
+      described_class.clear_config
+      expect { described_class.excluded_models }.to(raise_error(Apartment::ConfigurationError, /not configured/))
+    end
+  end
+
   describe '.clear_config' do
     it 'resets the adapter' do
       described_class.configure do |config|


### PR DESCRIPTION
## Summary

- Add `Apartment.tenant_names` — delegates to `config.tenants_provider.call`
- Add `Apartment.excluded_models` — delegates to `config.excluded_models` (deprecated)
- Both raise `ConfigurationError` if called before `Apartment.configure`

These are thin delegators preserving the v3 public API. Without them, every upgrading app needs to find-and-replace ~50+ call sites for a purely mechanical change with no behavioral difference.

## Test plan

- [x] 4 new specs (delegation + unconfigured error for each method)
- [x] `bundle exec rspec spec/unit/apartment_spec.rb` — 29 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)