### PR TITLE
Auto-default default_tenant to 'public' for schema strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The generated initializer at `config/initializers/apartment.rb` configures Apart
 Apartment.configure do |config|
   config.tenant_strategy = :schema          # :schema (PostgreSQL) or :database_name (MySQL/SQLite)
   config.tenants_provider = -> { Customer.pluck(:subdomain) }
-  # config.default_tenant = 'public'       # auto-defaults to 'public' for :schema strategy
+  config.default_tenant = 'public'          # auto-defaults for :schema; required for :database_name
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The generated initializer at `config/initializers/apartment.rb` configures Apart
 Apartment.configure do |config|
   config.tenant_strategy = :schema          # :schema (PostgreSQL) or :database_name (MySQL/SQLite)
   config.tenants_provider = -> { Customer.pluck(:subdomain) }
-  config.default_tenant = 'public'
+  # config.default_tenant = 'public'       # auto-defaults to 'public' for :schema strategy
 end
 ```
 

--- a/docs/designs/apartment-v4.md
+++ b/docs/designs/apartment-v4.md
@@ -272,8 +272,8 @@ Apartment.configure do |config|
   # Required: callable returning current tenant list
   config.tenants_provider = -> { Company.pluck(:subdomain) }
 
-  # Default tenant (PostgreSQL: "public", MySQL: derived from database.yml)
-  config.default_tenant = "public"
+  # Default tenant (auto-defaults to "public" for :schema strategy)
+  # config.default_tenant = "public"
 
   # Models in shared/default tenant
   config.excluded_models = %w[User Company]

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -41,7 +41,9 @@ Apartment.configure do |config|
 end
 ```
 
-`default_tenant` auto-defaults to `'public'` for `:schema` strategy. If you previously set it explicitly, you can remove the line. For `:database_name` strategy, you still need to set it.
+`default_tenant` auto-defaults to `'public'` for `:schema` strategy. If you previously set it explicitly, you can remove the line. If your primary schema is something other than `public` (e.g., `shared`), set `config.default_tenant` to match. For `:database_name` strategy, you still need to set it.
+
+**Note:** Code that previously observed `Apartment::Tenant.current` as `nil` before the first `switch` will now see `'public'` (or your configured value). Update any introspection or assertions that relied on the `nil` state.
 
 ### Tenant API
 

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -38,9 +38,10 @@ end
 Apartment.configure do |config|
   config.tenant_strategy = :schema
   config.tenants_provider = -> { Customer.pluck(:subdomain) }
-  # default_tenant auto-defaults to 'public' for :schema strategy
 end
 ```
+
+`default_tenant` auto-defaults to `'public'` for `:schema` strategy. If you previously set it explicitly, you can remove the line. For `:database_name` strategy, you still need to set it.
 
 ### Tenant API
 
@@ -143,7 +144,6 @@ end
 Apartment.configure do |config|
   config.tenant_strategy = :schema
   config.tenants_provider = -> { Customer.pluck(:subdomain) }
-  # default_tenant auto-defaults to 'public' for :schema strategy
 
   # Optional: auto-load schema into new tenants
   # config.schema_load_strategy = :schema_rb

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -38,7 +38,7 @@ end
 Apartment.configure do |config|
   config.tenant_strategy = :schema
   config.tenants_provider = -> { Customer.pluck(:subdomain) }
-  config.default_tenant = 'public'
+  # default_tenant auto-defaults to 'public' for :schema strategy
 end
 ```
 
@@ -143,7 +143,7 @@ end
 Apartment.configure do |config|
   config.tenant_strategy = :schema
   config.tenants_provider = -> { Customer.pluck(:subdomain) }
-  config.default_tenant = 'public'
+  # default_tenant auto-defaults to 'public' for :schema strategy
 
   # Optional: auto-load schema into new tenants
   # config.schema_load_strategy = :schema_rb

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -41,9 +41,7 @@ Apartment.configure do |config|
 end
 ```
 
-`default_tenant` auto-defaults to `'public'` for `:schema` strategy. If you previously set it explicitly, you can remove the line. If your primary schema is something other than `public` (e.g., `shared`), set `config.default_tenant` to match. For `:database_name` strategy, you still need to set it.
-
-**Note:** Code that previously observed `Apartment::Tenant.current` as `nil` before the first `switch` will now see `'public'` (or your configured value). Update any introspection or assertions that relied on the `nil` state.
+`default_tenant` auto-defaults to `'public'` for `:schema` strategy, matching v3 behavior. If you previously set it explicitly, you can remove the line. If your primary schema is something other than `public` (e.g., `shared`), set `config.default_tenant` to match. For `:database_name` strategy, you still need to set it.
 
 ### Tenant API
 

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -110,7 +110,7 @@ module Apartment
     def validate! # rubocop:disable Metrics/AbcSize
       raise(ConfigurationError, 'tenant_strategy is required') unless @tenant_strategy
 
-      # Schema strategy uses PostgreSQL schemas; default to 'public' if not set.
+      # PostgreSQL's default schema is 'public'; avoid forcing every user to set it.
       @default_tenant ||= 'public' if @tenant_strategy == :schema
 
       unless @tenants_provider.respond_to?(:call)

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -110,6 +110,9 @@ module Apartment
     def validate! # rubocop:disable Metrics/AbcSize
       raise(ConfigurationError, 'tenant_strategy is required') unless @tenant_strategy
 
+      # Schema strategy uses PostgreSQL schemas; default to 'public' if not set.
+      @default_tenant ||= 'public' if @tenant_strategy == :schema
+
       unless @tenants_provider.respond_to?(:call)
         raise(ConfigurationError, 'tenants_provider must be a callable (e.g., -> { Tenant.pluck(:name) })')
       end

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -113,6 +113,10 @@ module Apartment
       # PostgreSQL's default schema is 'public'; avoid forcing every user to set it.
       @default_tenant ||= 'public' if @tenant_strategy == :schema
 
+      if @default_tenant.is_a?(String) && @default_tenant.strip.empty?
+        raise(ConfigurationError, 'default_tenant cannot be an empty string')
+      end
+
       unless @tenants_provider.respond_to?(:call)
         raise(ConfigurationError, 'tenants_provider must be a callable (e.g., -> { Tenant.pluck(:name) })')
       end

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -94,7 +94,7 @@ module Apartment
     # Migrate the primary (default) tenant using AR::Base's existing pool.
     # No tenant switch needed — the default connection is already correct.
     def migrate_primary # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      tenant_name = Apartment.config.default_tenant || 'public'
+      tenant_name = Apartment.config.default_tenant
       start = monotonic_now
 
       context = ActiveRecord::Base.connection_pool.migration_context

--- a/spec/unit/cli/tenants_spec.rb
+++ b/spec/unit/cli/tenants_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe(Apartment::CLI::Tenants) do
 
     it 'prints none when no tenant context' do
       Apartment.configure do |c|
-        c.tenant_strategy = :schema
+        c.tenant_strategy = :database_name
         c.tenants_provider = -> { [] }
       end
       output = run_command('current')

--- a/spec/unit/cli/tenants_spec.rb
+++ b/spec/unit/cli/tenants_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe(Apartment::CLI::Tenants) do
     end
 
     it 'prints none when no tenant context' do
+      # Use :database_name because :schema auto-defaults default_tenant to 'public'
       Apartment.configure do |c|
         c.tenant_strategy = :database_name
         c.tenants_provider = -> { [] }

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -139,6 +139,31 @@ RSpec.describe(Apartment::Config) do
       expect { config.validate! }.not_to(raise_error)
     end
 
+    context 'default_tenant auto-defaulting' do
+      before do
+        config.tenants_provider = -> { [] }
+      end
+
+      it 'defaults to public for schema strategy when not set' do
+        config.tenant_strategy = :schema
+        config.validate!
+        expect(config.default_tenant).to(eq('public'))
+      end
+
+      it 'preserves explicit default_tenant for schema strategy' do
+        config.tenant_strategy = :schema
+        config.default_tenant = 'custom'
+        config.validate!
+        expect(config.default_tenant).to(eq('custom'))
+      end
+
+      it 'does not default for database_name strategy' do
+        config.tenant_strategy = :database_name
+        config.validate!
+        expect(config.default_tenant).to(be_nil)
+      end
+    end
+
     context 'migration_role validation' do
       before do
         config.tenant_strategy = :schema

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -162,6 +162,18 @@ RSpec.describe(Apartment::Config) do
         config.validate!
         expect(config.default_tenant).to(be_nil)
       end
+
+      it 'rejects an empty string' do
+        config.tenant_strategy = :schema
+        config.default_tenant = ''
+        expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /empty string/))
+      end
+
+      it 'rejects a whitespace-only string' do
+        config.tenant_strategy = :schema
+        config.default_tenant = '  '
+        expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /empty string/))
+      end
     end
 
     context 'migration_role validation' do


### PR DESCRIPTION
## Summary

- Schema strategy (PostgreSQL) now auto-defaults `default_tenant` to `'public'` during `validate!` when no explicit value is set
- Other strategies (`:database_name`, `:shard`, `:database_config`) are unaffected — they keep `nil`
- Removes a silent upgrade footgun: without this, `Apartment::Tenant.current` returned `nil` before any switch, cascading into FK violations and nil errors for every PG schema user

## Changes

- `lib/apartment/config.rb` — one-line default in `validate!`
- `spec/unit/config_spec.rb` — three new tests (auto-default, explicit override preserved, non-schema unaffected)
- `spec/unit/cli/tenants_spec.rb` — "no tenant context" test uses `:database_name` strategy (schema now correctly returns `'public'`)
- `README.md`, `docs/upgrading-to-v4.md` — `default_tenant` shown as optional for schema strategy

## Test plan

- [ ] `bundle exec rspec spec/unit/` passes (609 examples, 0 failures)
- [ ] `bundle exec rubocop` clean on changed files
- [ ] CI matrix (PG/MySQL/SQLite × Rails versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)