### PR TITLE
Share tenant connection for pinned models on PG schema and MySQL (#367)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ github.event_name == 'workflow_dispatch' && inputs.ruby != 'all' && fromJSON(format('["{0}"]', inputs.ruby)) || fromJSON('["3.3","3.4","4.0"]') }}
-        rails: ${{ github.event_name == 'workflow_dispatch' && inputs.rails != 'all' && fromJSON(format('["{0}"]', inputs.rails)) || fromJSON('["7.2","8.0","8.1"]') }}
+        rails: ${{ github.event_name == 'workflow_dispatch' && inputs.rails != 'all' && fromJSON(format('["{0}"]', inputs.rails)) || fromJSON('["7.2","8.0","8.1","main"]') }}
+    continue-on-error: ${{ matrix.rails == 'main' }}
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_${{ matrix.rails }}_sqlite3.gemfile
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ Nested `CLAUDE.md` files exist in `lib/apartment/`, `lib/apartment/adapters/`, `
 
 Check `CLAUDE.md` before copying patterns from existing code - it documents preferred patterns, design rationale, and known pitfalls.
 
+## Author preferences (code style)
+
+Prefer **SOLID** and explicit APIs over **metaprogramming** unless there is a concrete reason to break SOLID. Metaprogramming can be concise but is easy to misuse because it is powerful (e.g. reaching into classes via `instance_variable_*`). When behavior must live on models, prefer a concern or public class methods with clear names, and keep ivar details private to that layer.
+
 ## Adding Documentation
 
 Update the appropriate `CLAUDE.md` rather than this file. This file exists only as a pointer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,7 @@ Nested `CLAUDE.md` files exist in `lib/apartment/`, `lib/apartment/adapters/`, `
 
 ## Key Principle
 
-Check `CLAUDE.md` before copying patterns from existing code - it documents preferred patterns, design rationale, and known pitfalls.
-
-## Author preferences (code style)
-
-Prefer **SOLID** and explicit APIs over **metaprogramming** unless there is a concrete reason to break SOLID. Metaprogramming can be concise but is easy to misuse because it is powerful (e.g. reaching into classes via `instance_variable_*`). When behavior must live on models, prefer a concern or public class methods with clear names, and keep ivar details private to that layer.
+Check `CLAUDE.md` before copying patterns from existing code - it documents preferred patterns, design rationale, and known pitfalls. Maintainer code-style preferences (e.g. SOLID vs metaprogramming) live in the root **`CLAUDE.md`** under **Code style**, not in this file.
 
 ## Adding Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,10 @@ See `docs/architecture.md` for v3 design decisions, `docs/adapters.md` for strat
 - **Dynamic tenant discovery**: `tenants_provider` is a callable (proc/lambda) that queries the database at runtime.
 - **Tenant name validation**: `TenantNameValidator` does pure in-memory format checks (no DB queries). Enforced in `AbstractAdapter#create` and `ConnectionHandling#connection_pool`. Engine-specific rules for PG identifiers, MySQL names, SQLite paths.
 
+## Code style
+
+Prefer **SOLID** and explicit APIs over **metaprogramming** unless there is a concrete reason to break SOLID. Metaprogramming can be concise but is easy to misuse because it is powerful (e.g. ad hoc `instance_variable_*` on arbitrary classes). When state or behavior must live on models, use a concern and named public class methods; keep ivar details encapsulated inside that layer (adapters should not reach into AR classes). See `lib/apartment/CLAUDE.md` (`concerns/model.rb`) for pinned-model APIs (`apartment_pinned?`, `apartment_explicit_table_name?`, `apartment_mark_processed!`, `apartment_restore!`, etc.).
+
 ## Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec
 DATABASE_ENGINE=mysql bundle exec appraisal rails-8.1-mysql2 rspec spec/integration/v4/ --tag rbac
 ```
 
-**CI matrix**: Ruby 3.3/3.4/4.0 × Rails 7.2/8.0/8.1 × PG 16+18, MySQL 8.4, SQLite3. See `.github/workflows/ci.yml`.
+**CI matrix**: Ruby 3.3/3.4/4.0 × Rails 7.2/8.0/8.1/main × PG 16+18, MySQL 8.4, SQLite3. Rails main is a canary (`continue-on-error`). See `.github/workflows/ci.yml`.
 
 ## Core Concepts
 
@@ -90,7 +90,7 @@ Prefer **SOLID** and explicit APIs over **metaprogramming** unless there is a co
 ## Testing
 
 ```bash
-bundle exec rspec spec/unit/                    # v4 unit tests (585 specs)
+bundle exec rspec spec/unit/                    # v4 unit tests
 bundle exec appraisal rspec spec/unit/          # across all Rails versions
 ```
 

--- a/docs/designs/v4-shared-pinned-connections.md
+++ b/docs/designs/v4-shared-pinned-connections.md
@@ -34,10 +34,10 @@ Qualification uses a hybrid approach that respects Rails' `table_name_prefix` / 
 
 ```ruby
 def qualify_pinned_table_name(klass)
-  if klass.instance_variable_get(:@table_name)
+  if explicit_table_name?(klass)
     # Model has explicit self.table_name = 'custom' — qualify directly.
-    # split('.').last strips any existing schema/db prefix.
-    table = klass.table_name.split('.').last
+    # Strips at most one leading segment (schema or database prefix).
+    table = klass.table_name.sub(/\A[^.]+\./, '')
     klass.table_name = "#{qualifier}.#{table}"
   else
     # Convention naming — set table_name_prefix, let Rails compose via
@@ -49,13 +49,31 @@ def qualify_pinned_table_name(klass)
 end
 ```
 
-Each adapter subclass implements this with its own `qualifier`: `default_tenant` for PG schema (e.g. `"public"`), `base_config['database']` for MySQL (e.g. `"myapp_production"`).
+Each adapter subclass implements this with its own `qualifier`: `default_tenant` for PG schema (e.g. `"public"`), `base_config['database']` for MySQL (e.g. `"myapp_production"`). Note: `base_config` already returns string keys (via `connection_config.transform_keys(&:to_s)`), so `base_config['database']` is safe regardless of whether the original config used symbol keys.
 
-**Why hybrid:** Rails' `table_name_prefix` is a `class_attribute` that feeds into `compute_table_name` (`full_table_name_prefix + contained + undecorated_table_name + full_table_name_suffix`). Using it means pinned models with `table_name_suffix`, nested-class naming, or module-level prefixes get composed correctly by Rails' own assembly. But `reset_table_name` overwrites `@table_name`, which destroys explicit `self.table_name = 'custom'` assignments. The `@table_name` ivar check detects this case and falls back to direct assignment.
+**Detecting explicit table names:** `@table_name` is set both by `self.table_name = 'custom'` (explicit) and by the first call to `table_name` (lazy convention computation). To distinguish these, `process_pinned_model` must run before any `table_name` access on the class. This is guaranteed by the boot order: `Tenant.init` (called from `config.after_initialize` in the Railtie) processes all registered pinned models before the app serves requests. For models autoloaded after boot (Zeitwerk), `pin_tenant` calls `process_pinned_model` immediately — before any query triggers `table_name`. The `explicit_table_name?` helper checks `klass.instance_variable_defined?(:@table_name)` *and* compares the cached value against what `compute_table_name` would produce. If they differ, the model has an explicit assignment:
+
+```ruby
+def explicit_table_name?(klass)
+  return false unless klass.instance_variable_defined?(:@table_name)
+
+  # Compare cached @table_name against what convention naming would produce.
+  # If they differ, the model has an explicit self.table_name = assignment.
+  cached = klass.instance_variable_get(:@table_name)
+  computed = klass.send(:compute_table_name)
+  cached != computed
+end
+```
+
+This is more robust than checking `@table_name` alone, which can be set by lazy convention computation. The `compute_table_name` call is cheap (string assembly, no IO).
+
+**Why hybrid:** Rails' `table_name_prefix` is a `class_attribute` that feeds into `compute_table_name` (`full_table_name_prefix + contained + undecorated_table_name + full_table_name_suffix`). Using it means pinned models with `table_name_suffix`, nested-class naming, or module-level prefixes get composed correctly by Rails' own assembly. But `reset_table_name` overwrites `@table_name`, which destroys explicit `self.table_name = 'custom'` assignments. The `explicit_table_name?` check detects this case and falls back to direct assignment.
+
+**Explicit-path prefix stripping:** Uses `sub(/\A[^.]+\./, '')` instead of `split('.').last`, stripping at most one leading `schema.` or `database.` segment. This preserves names that contain dots for other reasons (unlikely in practice, but defensive).
 
 **STI:** Subclasses use `base_class.table_name`. Once the base class is qualified, STI children inherit the qualified name automatically. `table_name_prefix` is a `class_attribute` that also inherits to subclasses, so the convention path works for STI without extra handling. `apartment_pinned?` already walks the superclass chain (model.rb:28-30), so STI children are recognized as pinned without their own `pin_tenant` call.
 
-**`class_attribute` inheritance:** Setting `table_name_prefix` on a pinned class propagates to subclasses. This is correct for STI (all subclasses share the same table). Non-pinned classes should never inherit from pinned classes — use composition instead.
+**`class_attribute` inheritance:** Setting `table_name_prefix` on a pinned class propagates to subclasses. This is correct for STI, where all subclasses share the same physical table. Only STI subclasses of pinned bases are supported; don't subclass a pinned model with a tenant-scoped model that needs its own table — use composition instead.
 
 **Limitation:** Qualification only affects AR-generated SQL via `table_name`. Raw SQL (`execute`, `find_by_sql`), Arel fragments that hardcode unqualified table names, and `FROM` clauses in custom scopes are not covered. This is the same limitation as v3's `excluded_models` and is documented rather than solved.
 
@@ -93,12 +111,21 @@ end
 
 The ivar is renamed from `@apartment_connection_established` to `@apartment_pinned_processed`; it mirrors `process_pinned_model` and is mechanism-neutral (suggested by @henkesn).
 
-**Ivar rename touchpoints** (all three must be updated):
+**Ivar rename touchpoints** (all known references to `@apartment_connection_established`):
 1. `lib/apartment/adapters/abstract_adapter.rb` — `process_pinned_model` (get and set)
 2. `lib/apartment.rb:124-127` — `clear_config` teardown (checks `defined?` then `remove_instance_variable`)
 3. `spec/unit/adapters/abstract_adapter_spec.rb` — idempotency test comment
 
-**Teardown in `clear_config`:** Beyond renaming the ivar, `clear_config` must also reset `table_name_prefix` on pinned models that used the convention path (to avoid leaking the qualifier after reconfiguration). The teardown loop should call `klass.table_name_prefix = ""` and `klass.reset_table_name` for models where the prefix was set, or track which models used which path to avoid unnecessary resets.
+Implementation must also run `rg apartment_connection_established` to catch any references in docs/plans that should be updated for consistency.
+
+**Teardown in `clear_config`:** Beyond renaming the ivar, `clear_config` must restore pinned models to their pre-qualification state. The approach depends on which qualification path was used:
+
+- **Convention path:** Reset `klass.table_name_prefix = ""` and call `klass.reset_table_name`. This recomputes the unqualified name from Rails' convention machinery.
+- **Explicit path:** The original `self.table_name` value was overwritten by direct assignment. To restore it, `process_pinned_model` stores the pre-qualification name in `@apartment_original_table_name` before qualifying. Teardown restores it via `klass.table_name = klass.instance_variable_get(:@apartment_original_table_name)`.
+
+`process_pinned_model` also sets `@apartment_qualification_path` (`:convention` or `:explicit`) so teardown knows which branch to take. Both ivars are cleaned up alongside `@apartment_pinned_processed`.
+
+`clear_config` is primarily used in test suites (reconfigure between examples) and full app reload (Zeitwerk). In production, Apartment is configured once at boot; teardown is not expected.
 
 Note: the existing shared path for schema strategy (`table_name = "#{default_tenant}.#{table}"` after `establish_connection`) is replaced — not duplicated — by the new `qualify_pinned_table_name` call. The shared path qualifies *without* `establish_connection`; the separate path calls `establish_connection` *without* qualifying (since the pinned pool's `schema_search_path` handles resolution).
 

--- a/docs/designs/v4-shared-pinned-connections.md
+++ b/docs/designs/v4-shared-pinned-connections.md
@@ -1,0 +1,139 @@
+# Shared Pinned Model Connections
+
+## Status
+
+Draft
+
+## Problem
+
+`process_pinned_model` in `AbstractAdapter` unconditionally calls `establish_connection(base_config)`, giving every pinned model its own connection pool. This causes two related bugs:
+
+**FK constraint resolution (PG schema strategy):** The `base_config` passed to `establish_connection` has no explicit `schema_search_path`. PostgreSQL defaults to `"$user",public`; if `$user` matches a tenant schema name, FK constraints on pinned model tables resolve unqualified table references against the wrong schema.
+
+**Wasted pools / broken transactional integrity:** For PG schema strategy and MySQL single-server, the separate pool is unnecessary; the engine supports cross-schema/database queries on a single connection via qualified table names. The separate pool also prevents pinned model writes from participating in the same transaction as tenant model writes. A rollback of tenant DML leaves pinned model rows behind.
+
+Both issues stem from the same code path. The fix addresses both.
+
+## Prior Art
+
+This design incorporates the architectural approach from [rails-on-services/apartment#367](https://github.com/rails-on-services/apartment/pull/367) by [@henkesn](https://github.com/henkesn), which identified the problem and proposed the `shared_connection_supported?` / `qualify_pinned_table_name` pattern. This design rewrites the implementation against the current `main` branch, adds a config opt-out (`force_separate_pinned_pool`), fixes the FK constraint resolution bug for the separate-pool path, and incorporates review feedback from that PR.
+
+## Design
+
+### Template Methods on AbstractAdapter
+
+Two new methods on `AbstractAdapter`:
+
+**`shared_pinned_connection?`** — single decision point combining engine capability and config override. Returns `false` by default (safe fallback). PG schema adapter and MySQL adapters override to return `true` unless `Apartment.config.force_separate_pinned_pool` is set. Consumers (`process_pinned_model`, `ConnectionHandling`) call this one method; no scattered `&&` checks.
+
+**`qualify_pinned_table_name(klass)`** — abstract; required when `shared_pinned_connection?` returns `true`. Sets `klass.table_name` to a fully qualified name targeting the default tenant's tables. Raises `NotImplementedError` on the base class as a guard.
+
+### Adapter Matrix
+
+| Adapter | `shared_pinned_connection?` | Table qualification | Rationale |
+|---|---|---|---|
+| PostgresqlSchemaAdapter | `true` | `"public.delayed_jobs"` | Schemas share a catalog |
+| Mysql2Adapter | `true` | `"myapp_production.delayed_jobs"` | MySQL supports `db.table` on same server |
+| TrilogyAdapter | `true` (inherited) | Inherited from Mysql2Adapter | Same engine, different driver |
+| PostgresqlDatabaseAdapter | `false` (inherited) | N/A — separate pool | PG databases are fully isolated |
+| Sqlite3Adapter | `false` (inherited) | N/A — separate pool | Separate files |
+
+When `force_separate_pinned_pool: true`, all adapters behave as separate-pool regardless of engine capability.
+
+### Modified process_pinned_model
+
+Dual-path logic:
+
+```ruby
+def process_pinned_model(klass)
+  return if klass.instance_variable_get(:@apartment_pinned_processed)
+
+  if shared_pinned_connection?
+    qualify_pinned_table_name(klass)
+  else
+    klass.establish_connection(pinned_model_config)
+  end
+
+  klass.instance_variable_set(:@apartment_pinned_processed, true)
+end
+```
+
+The ivar is renamed from `@apartment_connection_established` to `@apartment_pinned_processed`; it mirrors `process_pinned_model` and is mechanism-neutral (suggested by @henkesn).
+
+### pinned_model_config (Separate-Pool Path)
+
+New private method on `AbstractAdapter`, adjacent to `base_config`. For the separate-pool path, it builds on `base_config`:
+
+- For schema strategy: merges `schema_search_path` set to `default_tenant` plus `persistent_schemas`. This fixes FK constraint resolution; without it, the connection inherits PG's default search path and FK references may resolve against the wrong schema.
+- For database strategies: returns `base_config` unchanged; the raw config already points to the real default database.
+
+This ensures apps that set `force_separate_pinned_pool: true` on PG schema strategy still get correct FK behavior.
+
+### Modified ConnectionHandling#connection_pool
+
+The existing early return for pinned models:
+
+```ruby
+return super if self != ActiveRecord::Base && Apartment.pinned_model?(self)
+```
+
+Becomes conditional on the adapter requiring a separate pool:
+
+```ruby
+if self != ActiveRecord::Base && Apartment.pinned_model?(self) &&
+   !Apartment.adapter&.shared_pinned_connection?
+  return super
+end
+```
+
+When shared connections are supported, pinned models fall through to the tenant pool lookup, so they share the tenant's connection and participate in its transactions.
+
+### Config
+
+New boolean on `Apartment::Config`:
+
+- `force_separate_pinned_pool` — default `false`
+- Validated in `validate!`: must be `true` or `false`
+- Top-level (strategy-agnostic); applies to all adapters
+- Escape hatch for: multi-server MySQL topologies, apps that rely on pinned model writes surviving tenant transaction rollbacks
+
+No other config changes.
+
+### Upgrade Guide
+
+`docs/upgrading-to-v4.md` gets a new section covering:
+
+- What changed: pinned models on PG schema / MySQL single-server now share the tenant's connection pool via qualified table names
+- Adapter matrix showing which strategies are affected
+- Migration action: if code relies on pinned model writes surviving tenant rollbacks (e.g., enqueue-then-rollback), set `force_separate_pinned_pool: true`
+- Note that `after_commit` callbacks are unaffected
+
+## Testing
+
+### Unit Tests
+
+- `AbstractAdapter#shared_pinned_connection?` returns `false` by default
+- `AbstractAdapter#process_pinned_model`: both code paths (shared vs separate), idempotency via `@apartment_pinned_processed`
+- Each concrete adapter: `shared_pinned_connection?` return value, `qualify_pinned_table_name` output
+- `ConnectionHandling#connection_pool`: pinned model routing for both shared and separate paths
+- `Config#force_separate_pinned_pool` validation and default
+
+### Integration Tests
+
+- Pinned model queries target default tenant data during tenant switch
+- Transactional integrity: rollback rolls back both pinned and tenant writes (shared path)
+- Transactional isolation: rollback only rolls back tenant writes (`force_separate_pinned_pool: true`)
+- FK constraint resolution on PG schema strategy (both paths)
+- Idempotency of `process_pinned_models`
+
+Test cases are reimplemented from PR #367, adapted to the current test infrastructure.
+
+## Attribution
+
+Commits deriving from PR #367's design will include `Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>`. The PR description will reference and acknowledge the original contribution.
+
+## Out of Scope
+
+- Performance instrumentation on the `connection_pool` hot path (noted for future work; v4 should not regress vs v3)
+- Automatic multi-server MySQL detection (config opt-out is sufficient)
+- `shard` / `database_config` strategy support for shared connections

--- a/docs/designs/v4-shared-pinned-connections.md
+++ b/docs/designs/v4-shared-pinned-connections.md
@@ -67,6 +67,8 @@ end
 
 This is more robust than checking `@table_name` alone, which can be set by lazy convention computation. The `compute_table_name` call is cheap (string assembly, no IO).
 
+**Edge case:** If a model sets `self.table_name` to the exact string convention would compute (e.g., `self.table_name = 'delayed_jobs'` on a class named `DelayedJob`), `cached == computed` and the convention path runs. The result is still a correctly qualified name; the only difference is mechanism (prefix + reset vs direct assignment). This is acceptable — the convention path is the superset.
+
 **Why hybrid:** Rails' `table_name_prefix` is a `class_attribute` that feeds into `compute_table_name` (`full_table_name_prefix + contained + undecorated_table_name + full_table_name_suffix`). Using it means pinned models with `table_name_suffix`, nested-class naming, or module-level prefixes get composed correctly by Rails' own assembly. But `reset_table_name` overwrites `@table_name`, which destroys explicit `self.table_name = 'custom'` assignments. The `explicit_table_name?` check detects this case and falls back to direct assignment.
 
 **Explicit-path prefix stripping:** Uses `sub(/\A[^.]+\./, '')` instead of `split('.').last`, stripping at most one leading `schema.` or `database.` segment. This preserves names that contain dots for other reasons (unlikely in practice, but defensive).
@@ -116,7 +118,7 @@ The ivar is renamed from `@apartment_connection_established` to `@apartment_pinn
 2. `lib/apartment.rb:124-127` — `clear_config` teardown (checks `defined?` then `remove_instance_variable`)
 3. `spec/unit/adapters/abstract_adapter_spec.rb` — idempotency test comment
 
-Implementation must also run `rg apartment_connection_established` to catch any references in docs/plans that should be updated for consistency.
+Implementation must also run `rg apartment_connection_established` to catch any references in docs/plans that should be updated for consistency. Additionally, `clear_config` must clean up the new ivars (`@apartment_original_table_name`, `@apartment_qualification_path`) alongside `@apartment_pinned_processed`.
 
 **Teardown in `clear_config`:** Beyond renaming the ivar, `clear_config` must restore pinned models to their pre-qualification state. The approach depends on which qualification path was used:
 
@@ -192,6 +194,7 @@ Models (or abstract base classes) that use `connects_to` to point at a *differen
 - Each concrete adapter: `shared_pinned_connection?` return value, `qualify_pinned_table_name` output (including already-qualified and custom table names)
 - `qualify_pinned_table_name` hybrid paths: convention-named model uses `table_name_prefix` + `reset_table_name`; explicit `self.table_name` model uses direct assignment
 - `qualify_pinned_table_name` with `table_name_suffix` set (convention path preserves it)
+- `explicit_table_name?` helper: returns `true` when cached differs from computed, `false` when equal (convention path), `false` when `@table_name` not yet set
 - `ConnectionHandling#connection_pool`: pinned model routing for both shared and separate paths
 - `Config#force_separate_pinned_pool` validation and default
 

--- a/docs/designs/v4-shared-pinned-connections.md
+++ b/docs/designs/v4-shared-pinned-connections.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Implemented in [#374](https://github.com/rails-on-services/apartment/pull/374)
 
 ## Problem
 

--- a/docs/designs/v4-shared-pinned-connections.md
+++ b/docs/designs/v4-shared-pinned-connections.md
@@ -8,7 +8,7 @@ Draft
 
 `process_pinned_model` in `AbstractAdapter` unconditionally calls `establish_connection(base_config)`, giving every pinned model its own connection pool. This causes two related bugs:
 
-**FK constraint resolution (PG schema strategy):** The `base_config` passed to `establish_connection` has no explicit `schema_search_path`. PostgreSQL defaults to `"$user",public`; if `$user` matches a tenant schema name, FK constraints on pinned model tables resolve unqualified table references against the wrong schema.
+**FK constraint resolution (PG schema strategy):** The `base_config` passed to `establish_connection` has no explicit `schema_search_path`. PostgreSQL resolves unqualified identifiers via `search_path`, which defaults to `"$user", public` — the session user's schema first, then `public`. If the database user happens to share a name with a tenant schema, or if anything sets `search_path` on the pinned pool's connection, FK constraints that reference unqualified table names resolve against the wrong schema. This affects both DDL-time resolution (migrations, `add_reference`) and DML-time enforcement (inserts that trigger FK checks), though DDL-time is the more common failure mode since FK target OIDs are resolved at constraint creation.
 
 **Wasted pools / broken transactional integrity:** For PG schema strategy and MySQL single-server, the separate pool is unnecessary; the engine supports cross-schema/database queries on a single connection via qualified table names. The separate pool also prevents pinned model writes from participating in the same transaction as tenant model writes. A rollback of tenant DML leaves pinned model rows behind.
 
@@ -28,15 +28,21 @@ Two new methods on `AbstractAdapter`:
 
 **`qualify_pinned_table_name(klass)`** — abstract; required when `shared_pinned_connection?` returns `true`. Sets `klass.table_name` to a fully qualified name targeting the default tenant's tables. Raises `NotImplementedError` on the base class as a guard.
 
+Qualification logic: `klass.table_name.split('.').last` strips any existing prefix, then the adapter prepends the appropriate qualifier. This handles models with custom `self.table_name`, `table_name_prefix`, or `table_name_suffix` — all of which are already folded into `klass.table_name` by the time we read it. The result is a plain string (`"public.legacy_delayed_jobs"`); no `connection.quote_table_name` is applied here because ActiveRecord's query builder handles identifier quoting when it encounters the dot-separated form. This matches the existing behavior in `process_pinned_model` for the schema strategy path.
+
+**Limitation:** Qualification only affects AR-generated SQL via `table_name`. Raw SQL (`execute`, `find_by_sql`), Arel fragments that hardcode unqualified table names, and `FROM` clauses in custom scopes are not covered. This is the same limitation as v3's `excluded_models` and is documented rather than solved.
+
 ### Adapter Matrix
 
 | Adapter | `shared_pinned_connection?` | Table qualification | Rationale |
 |---|---|---|---|
-| PostgresqlSchemaAdapter | `true` | `"public.delayed_jobs"` | Schemas share a catalog |
-| Mysql2Adapter | `true` | `"myapp_production.delayed_jobs"` | MySQL supports `db.table` on same server |
+| PostgresqlSchemaAdapter | `true` | `"#{default_tenant}.#{table}"` | Schemas share a catalog |
+| Mysql2Adapter | `true` | `"#{base_config['database']}.#{table}"` | MySQL supports `db.table` on same server |
 | TrilogyAdapter | `true` (inherited) | Inherited from Mysql2Adapter | Same engine, different driver |
 | PostgresqlDatabaseAdapter | `false` (inherited) | N/A — separate pool | PG databases are fully isolated |
 | Sqlite3Adapter | `false` (inherited) | N/A — separate pool | Separate files |
+
+PG schema example: when `default_tenant` is `'public'`, qualification produces `"public.delayed_jobs"`. MySQL example: when `base_config['database']` is `'myapp_production'`, qualification produces `"myapp_production.delayed_jobs"`. The qualifier is always derived from runtime config, never hardcoded.
 
 When `force_separate_pinned_pool: true`, all adapters behave as separate-pool regardless of engine capability.
 
@@ -60,11 +66,18 @@ end
 
 The ivar is renamed from `@apartment_connection_established` to `@apartment_pinned_processed`; it mirrors `process_pinned_model` and is mechanism-neutral (suggested by @henkesn).
 
+**Ivar rename touchpoints** (all three must be updated):
+1. `lib/apartment/adapters/abstract_adapter.rb` — `process_pinned_model` (get and set)
+2. `lib/apartment.rb:124-127` — `clear_config` teardown (checks `defined?` then `remove_instance_variable`)
+3. `spec/unit/adapters/abstract_adapter_spec.rb` — idempotency test comment
+
+Note: the existing shared path for schema strategy (`table_name = "#{default_tenant}.#{table}"` after `establish_connection`) is replaced — not duplicated — by the new `qualify_pinned_table_name` call. The shared path qualifies *without* `establish_connection`; the separate path calls `establish_connection` *without* qualifying (since the pinned pool's `schema_search_path` handles resolution).
+
 ### pinned_model_config (Separate-Pool Path)
 
 New private method on `AbstractAdapter`, adjacent to `base_config`. For the separate-pool path, it builds on `base_config`:
 
-- For schema strategy: merges `schema_search_path` set to `default_tenant` plus `persistent_schemas`. This fixes FK constraint resolution; without it, the connection inherits PG's default search path and FK references may resolve against the wrong schema.
+- For schema strategy: merges `schema_search_path` set to `default_tenant` plus `persistent_schemas` (quoted). This fixes FK constraint resolution; without it, the connection inherits PG's default search path and FK references may resolve against the wrong schema.
 - For database strategies: returns `base_config` unchanged; the raw config already points to the real default database.
 
 This ensures apps that set `force_separate_pinned_pool: true` on PG schema strategy still get correct FK behavior.
@@ -88,6 +101,8 @@ end
 
 When shared connections are supported, pinned models fall through to the tenant pool lookup, so they share the tenant's connection and participate in its transactions.
 
+**Schema cache interaction:** When `schema_cache_per_tenant` is enabled, `ConnectionHandling` loads a per-tenant cache into the pool. If pinned models share the tenant pool, they share that cache instance. This is correct: the qualified table name (`public.delayed_jobs`) resolves through PG/MySQL's normal catalog lookup regardless of which schema cache is loaded. The schema cache stores metadata by table name; the pinned model's qualified name won't collide with unqualified tenant table names. No special handling needed, but integration tests should verify pinned model column lookups work with `schema_cache_per_tenant: true`.
+
 ### Config
 
 New boolean on `Apartment::Config`:
@@ -106,7 +121,11 @@ No other config changes.
 - What changed: pinned models on PG schema / MySQL single-server now share the tenant's connection pool via qualified table names
 - Adapter matrix showing which strategies are affected
 - Migration action: if code relies on pinned model writes surviving tenant rollbacks (e.g., enqueue-then-rollback), set `force_separate_pinned_pool: true`
-- Note that `after_commit` callbacks are unaffected
+- `after_commit` callbacks still fire as before; the difference is that pinned model writes are now *inside* the tenant transaction, so an `ActiveRecord::Rollback` that aborts the transaction will also roll back pinned model writes. Apps using `after_commit` for job enqueueing are unaffected (the callback fires after successful commit in both old and new behavior).
+
+### connects_to Interaction
+
+Models (or abstract base classes) that use `connects_to` to point at a *different physical database* than the tenant pool must use `pin_tenant` with `force_separate_pinned_pool: true`, or they will be routed through the tenant pool where their tables don't exist. This is already documented in CLAUDE.md as a gotcha. The shared pinned connection path assumes the pinned model's tables are reachable from the tenant's connection; `connects_to` to a separate database breaks that assumption.
 
 ## Testing
 
@@ -114,7 +133,7 @@ No other config changes.
 
 - `AbstractAdapter#shared_pinned_connection?` returns `false` by default
 - `AbstractAdapter#process_pinned_model`: both code paths (shared vs separate), idempotency via `@apartment_pinned_processed`
-- Each concrete adapter: `shared_pinned_connection?` return value, `qualify_pinned_table_name` output
+- Each concrete adapter: `shared_pinned_connection?` return value, `qualify_pinned_table_name` output (including already-qualified and custom table names)
 - `ConnectionHandling#connection_pool`: pinned model routing for both shared and separate paths
 - `Config#force_separate_pinned_pool` validation and default
 
@@ -125,8 +144,10 @@ No other config changes.
 - Transactional isolation: rollback only rolls back tenant writes (`force_separate_pinned_pool: true`)
 - FK constraint resolution on PG schema strategy (both paths)
 - Idempotency of `process_pinned_models`
+- Association join between tenant model and pinned model (e.g., `TenantModel.joins(:pinned_model)`) produces correct SQL with qualified table name
+- Schema cache interaction: pinned model column lookups with `schema_cache_per_tenant: true`
 
-Test cases are reimplemented from PR #367, adapted to the current test infrastructure.
+Test cases are reimplemented from PR #367, adapted to the current test infrastructure. Each behavior (shared vs separate) gets its own `context` block; no `if/else` within a single example.
 
 ## Attribution
 
@@ -137,3 +158,4 @@ Commits deriving from PR #367's design will include `Co-Authored-By: henkesn <14
 - Performance instrumentation on the `connection_pool` hot path (noted for future work; v4 should not regress vs v3)
 - Automatic multi-server MySQL detection (config opt-out is sufficient)
 - `shard` / `database_config` strategy support for shared connections
+- Shared pinned connections for models using `connects_to` with a different physical database (these must remain separate-pool)

--- a/docs/designs/v4-shared-pinned-connections.md
+++ b/docs/designs/v4-shared-pinned-connections.md
@@ -91,6 +91,8 @@ This is more robust than checking `@table_name` alone, which can be set by lazy 
 
 PG schema example: when `default_tenant` is `'public'`, qualification produces `"public.delayed_jobs"`. MySQL example: when `base_config['database']` is `'myapp_production'`, qualification produces `"myapp_production.delayed_jobs"`. The qualifier is always derived from runtime config, never hardcoded.
 
+**Do not apply `environmentify` to qualifiers.** `environmentify` maps tenant keys to tenant database names (e.g., `acme` → `test_acme`); it does not apply to the default connection's database/schema identifiers. `default_tenant` (PG) and `base_config['database']` (MySQL) are already the real server-side names. Environmentifying them would produce wrong names under `:prepend`/`:append` strategies.
+
 When `force_separate_pinned_pool: true`, all adapters behave as separate-pool regardless of engine capability.
 
 ### Modified process_pinned_model

--- a/docs/designs/v4-shared-pinned-connections.md
+++ b/docs/designs/v4-shared-pinned-connections.md
@@ -26,9 +26,36 @@ Two new methods on `AbstractAdapter`:
 
 **`shared_pinned_connection?`** — single decision point combining engine capability and config override. Returns `false` by default (safe fallback). PG schema adapter and MySQL adapters override to return `true` unless `Apartment.config.force_separate_pinned_pool` is set. Consumers (`process_pinned_model`, `ConnectionHandling`) call this one method; no scattered `&&` checks.
 
-**`qualify_pinned_table_name(klass)`** — abstract; required when `shared_pinned_connection?` returns `true`. Sets `klass.table_name` to a fully qualified name targeting the default tenant's tables. Raises `NotImplementedError` on the base class as a guard.
+**`qualify_pinned_table_name(klass)`** — abstract; required when `shared_pinned_connection?` returns `true`. Qualifies the model's table name so it targets the default tenant's tables from any tenant connection. Raises `NotImplementedError` on the base class as a guard. Subclasses provide the qualifier string (schema name for PG, database name for MySQL).
 
-Qualification logic: `klass.table_name.split('.').last` strips any existing prefix, then the adapter prepends the appropriate qualifier. This handles models with custom `self.table_name`, `table_name_prefix`, or `table_name_suffix` — all of which are already folded into `klass.table_name` by the time we read it. The result is a plain string (`"public.legacy_delayed_jobs"`); no `connection.quote_table_name` is applied here because ActiveRecord's query builder handles identifier quoting when it encounters the dot-separated form. This matches the existing behavior in `process_pinned_model` for the schema strategy path.
+#### Table Name Qualification Strategy (Hybrid)
+
+Qualification uses a hybrid approach that respects Rails' `table_name_prefix` / `table_name_suffix` machinery where possible, falling back to direct assignment for models with explicit `self.table_name`:
+
+```ruby
+def qualify_pinned_table_name(klass)
+  if klass.instance_variable_get(:@table_name)
+    # Model has explicit self.table_name = 'custom' — qualify directly.
+    # split('.').last strips any existing schema/db prefix.
+    table = klass.table_name.split('.').last
+    klass.table_name = "#{qualifier}.#{table}"
+  else
+    # Convention naming — set table_name_prefix, let Rails compose via
+    # compute_table_name. Preserves nested-class `contained` segments
+    # and table_name_suffix. reset_table_name recomputes @table_name.
+    klass.table_name_prefix = "#{qualifier}."
+    klass.reset_table_name
+  end
+end
+```
+
+Each adapter subclass implements this with its own `qualifier`: `default_tenant` for PG schema (e.g. `"public"`), `base_config['database']` for MySQL (e.g. `"myapp_production"`).
+
+**Why hybrid:** Rails' `table_name_prefix` is a `class_attribute` that feeds into `compute_table_name` (`full_table_name_prefix + contained + undecorated_table_name + full_table_name_suffix`). Using it means pinned models with `table_name_suffix`, nested-class naming, or module-level prefixes get composed correctly by Rails' own assembly. But `reset_table_name` overwrites `@table_name`, which destroys explicit `self.table_name = 'custom'` assignments. The `@table_name` ivar check detects this case and falls back to direct assignment.
+
+**STI:** Subclasses use `base_class.table_name`. Once the base class is qualified, STI children inherit the qualified name automatically. `table_name_prefix` is a `class_attribute` that also inherits to subclasses, so the convention path works for STI without extra handling. `apartment_pinned?` already walks the superclass chain (model.rb:28-30), so STI children are recognized as pinned without their own `pin_tenant` call.
+
+**`class_attribute` inheritance:** Setting `table_name_prefix` on a pinned class propagates to subclasses. This is correct for STI (all subclasses share the same table). Non-pinned classes should never inherit from pinned classes — use composition instead.
 
 **Limitation:** Qualification only affects AR-generated SQL via `table_name`. Raw SQL (`execute`, `find_by_sql`), Arel fragments that hardcode unqualified table names, and `FROM` clauses in custom scopes are not covered. This is the same limitation as v3's `excluded_models` and is documented rather than solved.
 
@@ -70,6 +97,8 @@ The ivar is renamed from `@apartment_connection_established` to `@apartment_pinn
 1. `lib/apartment/adapters/abstract_adapter.rb` — `process_pinned_model` (get and set)
 2. `lib/apartment.rb:124-127` — `clear_config` teardown (checks `defined?` then `remove_instance_variable`)
 3. `spec/unit/adapters/abstract_adapter_spec.rb` — idempotency test comment
+
+**Teardown in `clear_config`:** Beyond renaming the ivar, `clear_config` must also reset `table_name_prefix` on pinned models that used the convention path (to avoid leaking the qualifier after reconfiguration). The teardown loop should call `klass.table_name_prefix = ""` and `klass.reset_table_name` for models where the prefix was set, or track which models used which path to avoid unnecessary resets.
 
 Note: the existing shared path for schema strategy (`table_name = "#{default_tenant}.#{table}"` after `establish_connection`) is replaced — not duplicated — by the new `qualify_pinned_table_name` call. The shared path qualifies *without* `establish_connection`; the separate path calls `establish_connection` *without* qualifying (since the pinned pool's `schema_search_path` handles resolution).
 
@@ -134,6 +163,8 @@ Models (or abstract base classes) that use `connects_to` to point at a *differen
 - `AbstractAdapter#shared_pinned_connection?` returns `false` by default
 - `AbstractAdapter#process_pinned_model`: both code paths (shared vs separate), idempotency via `@apartment_pinned_processed`
 - Each concrete adapter: `shared_pinned_connection?` return value, `qualify_pinned_table_name` output (including already-qualified and custom table names)
+- `qualify_pinned_table_name` hybrid paths: convention-named model uses `table_name_prefix` + `reset_table_name`; explicit `self.table_name` model uses direct assignment
+- `qualify_pinned_table_name` with `table_name_suffix` set (convention path preserves it)
 - `ConnectionHandling#connection_pool`: pinned model routing for both shared and separate paths
 - `Config#force_separate_pinned_pool` validation and default
 

--- a/docs/plans/apartment-v4/shared-pinned-connections.md
+++ b/docs/plans/apartment-v4/shared-pinned-connections.md
@@ -1,0 +1,1129 @@
+# Shared Pinned Model Connections — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make pinned model connection strategy depend on whether the database engine supports cross-schema/database queries, eliminating unnecessary connection pools and enabling transactional integrity between pinned and tenant models.
+
+**Architecture:** Dual-path `process_pinned_model`: shared path (qualify table name, skip `establish_connection`) for PG schema and MySQL single-server; separate path (`establish_connection` with `pinned_model_config`) for PG database-per-tenant, SQLite, and apps that opt out via `force_separate_pinned_pool`. `ConnectionHandling#connection_pool` conditionally routes pinned models through tenant pools when shared connections are supported.
+
+**Tech Stack:** Ruby, ActiveRecord, RSpec, Appraisal (multi-Rails testing)
+
+**Design spec:** `docs/designs/v4-shared-pinned-connections.md`
+
+**Attribution:** Commits deriving from [rails-on-services/apartment#367](https://github.com/rails-on-services/apartment/pull/367) include `Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>`.
+
+---
+
+### Task 1: Add `force_separate_pinned_pool` config option
+
+**Files:**
+- Modify: `lib/apartment/config.rb:17-53` (attr_accessor, default, validation)
+- Modify: `spec/unit/config_spec.rb` (default + validation tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `spec/unit/config_spec.rb`, add within the `describe 'defaults'` block:
+
+```ruby
+it { expect(config.force_separate_pinned_pool).to(be(false)) }
+```
+
+Add a new describe block after the existing validation tests:
+
+```ruby
+describe '#force_separate_pinned_pool' do
+  it 'accepts true' do
+    config.tenant_strategy = :schema
+    config.tenants_provider = -> { [] }
+    config.force_separate_pinned_pool = true
+    expect { config.validate! }.not_to(raise_error)
+  end
+
+  it 'accepts false' do
+    config.tenant_strategy = :schema
+    config.tenants_provider = -> { [] }
+    config.force_separate_pinned_pool = false
+    expect { config.validate! }.not_to(raise_error)
+  end
+
+  it 'rejects non-boolean values' do
+    config.tenant_strategy = :schema
+    config.tenants_provider = -> { [] }
+    config.force_separate_pinned_pool = 'yes'
+    expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /force_separate_pinned_pool/))
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb --format documentation`
+Expected: 3 failures (unknown attribute, missing validation)
+
+- [ ] **Step 3: Implement the config option**
+
+In `lib/apartment/config.rb`:
+
+Add `force_separate_pinned_pool` to the `attr_accessor` list on line 17:
+
+```ruby
+attr_accessor :tenants_provider, :default_tenant,
+              :tenant_pool_size, :pool_idle_timeout, :max_total_connections,
+              :seed_after_create, :seed_data_file,
+              :schema_load_strategy, :schema_file,
+              :parallel_migration_threads,
+              :elevator, :elevator_options,
+              :tenant_not_found_handler, :active_record_log, :sql_query_tags,
+              :shard_key_prefix,
+              :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
+              :force_separate_pinned_pool
+```
+
+Add default in `initialize` (after `@check_pending_migrations = true`):
+
+```ruby
+@force_separate_pinned_pool = false
+```
+
+Add validation in `validate!` (after the `check_pending_migrations` validation block):
+
+```ruby
+unless [true, false].include?(@force_separate_pinned_pool)
+  raise(ConfigurationError,
+        "force_separate_pinned_pool must be true or false, got: #{@force_separate_pinned_pool.inspect}")
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb --format documentation`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/config.rb spec/unit/config_spec.rb
+git commit -m "Add force_separate_pinned_pool config option
+
+New boolean (default false) on Apartment::Config. Escape hatch for
+multi-server MySQL topologies and apps that rely on pinned model
+writes surviving tenant transaction rollbacks.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add `shared_pinned_connection?` and `qualify_pinned_table_name` to AbstractAdapter
+
+**Files:**
+- Modify: `lib/apartment/adapters/abstract_adapter.rb:96-130,180-186`
+- Modify: `spec/unit/adapters/abstract_adapter_spec.rb:322-397`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `spec/unit/adapters/abstract_adapter_spec.rb`, add a new describe block before the existing `#process_pinned_models` block (after line 321):
+
+```ruby
+describe '#shared_pinned_connection?' do
+  it 'returns false by default (safe fallback)' do
+    expect(adapter.shared_pinned_connection?).to(be(false))
+  end
+end
+
+describe '#qualify_pinned_table_name' do
+  it 'raises NotImplementedError on the abstract class' do
+    klass = Class.new(ActiveRecord::Base)
+    expect { adapter.qualify_pinned_table_name(klass) }.to(raise_error(
+      NotImplementedError, /qualify_pinned_table_name must be implemented/
+    ))
+  end
+end
+
+describe '#explicit_table_name? (private)' do
+  it 'returns false when @table_name is not set' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('NoTableName', klass)
+    expect(adapter.send(:explicit_table_name?, klass)).to(be(false))
+  end
+
+  it 'returns false when cached equals computed (convention naming)' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('ConventionModel', klass)
+    # Trigger lazy computation so @table_name is set
+    allow(klass).to(receive(:compute_table_name).and_return('convention_models'))
+    klass.instance_variable_set(:@table_name, 'convention_models')
+    expect(adapter.send(:explicit_table_name?, klass)).to(be(false))
+  end
+
+  it 'returns true when cached differs from computed (explicit assignment)' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('ExplicitModel', klass)
+    allow(klass).to(receive(:compute_table_name).and_return('explicit_models'))
+    klass.instance_variable_set(:@table_name, 'custom_table')
+    expect(adapter.send(:explicit_table_name?, klass)).to(be(true))
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/adapters/abstract_adapter_spec.rb --format documentation`
+Expected: failures for `shared_pinned_connection?`, `qualify_pinned_table_name`, `explicit_table_name?`
+
+- [ ] **Step 3: Implement the methods**
+
+In `lib/apartment/adapters/abstract_adapter.rb`, add after the `seed` method (after line 97) and before `process_pinned_models`:
+
+```ruby
+# Whether pinned models can share the tenant's connection pool using
+# qualified table names. When true, process_pinned_model qualifies the
+# table name instead of calling establish_connection.
+#
+# Combines engine capability with config override. Returns false by
+# default (safe fallback — separate pool). Subclasses override to
+# return true for engines that support cross-schema/database queries.
+def shared_pinned_connection?
+  false
+end
+
+# Qualify a pinned model's table_name so it targets the default
+# tenant's tables from any tenant connection. Subclasses must
+# implement when shared_pinned_connection? returns true.
+def qualify_pinned_table_name(_klass)
+  raise(NotImplementedError,
+        "#{self.class}#qualify_pinned_table_name must be implemented when shared_pinned_connection? is true")
+end
+```
+
+In the `private` section (after `base_config`, around line 186), add:
+
+```ruby
+# Detect whether a model has an explicit self.table_name = assignment
+# (as opposed to Rails' lazy convention computation).
+def explicit_table_name?(klass)
+  return false unless klass.instance_variable_defined?(:@table_name)
+
+  cached = klass.instance_variable_get(:@table_name)
+  computed = klass.send(:compute_table_name)
+  cached != computed
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/adapters/abstract_adapter_spec.rb --format documentation`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/adapters/abstract_adapter.rb spec/unit/adapters/abstract_adapter_spec.rb
+git commit -m "Add shared_pinned_connection?, qualify_pinned_table_name, explicit_table_name?
+
+Template methods on AbstractAdapter for the dual-path pinned model
+strategy. shared_pinned_connection? returns false by default (safe
+fallback). qualify_pinned_table_name raises NotImplementedError as
+guard. explicit_table_name? detects models with self.table_name =.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Implement `shared_pinned_connection?` and `qualify_pinned_table_name` in PostgresqlSchemaAdapter
+
+**Files:**
+- Modify: `lib/apartment/adapters/postgresql_schema_adapter.rb:14-21`
+- Modify: `spec/unit/adapters/postgresql_schema_adapter_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `spec/unit/adapters/postgresql_schema_adapter_spec.rb`, add after the `describe 'inheritance'` block:
+
+```ruby
+describe '#shared_pinned_connection?' do
+  it 'returns true (schemas share a catalog)' do
+    expect(adapter.shared_pinned_connection?).to(be(true))
+  end
+
+  it 'returns false when force_separate_pinned_pool is true' do
+    reconfigure { |c| c.force_separate_pinned_pool = true }
+    expect(adapter.shared_pinned_connection?).to(be(false))
+  end
+end
+
+describe '#qualify_pinned_table_name' do
+  it 'qualifies convention-named model via table_name_prefix + reset_table_name' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('DelayedJob', klass)
+
+    expect(klass).to(receive(:table_name_prefix=).with('public.'))
+    expect(klass).to(receive(:reset_table_name))
+
+    adapter.qualify_pinned_table_name(klass)
+  end
+
+  it 'qualifies explicit table_name via direct assignment' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('ExplicitPinned', klass)
+    klass.instance_variable_set(:@table_name, 'custom_jobs')
+    allow(klass).to(receive(:compute_table_name).and_return('explicit_pinneds'))
+    allow(klass).to(receive(:table_name).and_return('custom_jobs'))
+
+    expect(klass).to(receive(:table_name=).with('public.custom_jobs'))
+    expect(klass).not_to(receive(:table_name_prefix=))
+
+    adapter.qualify_pinned_table_name(klass)
+  end
+
+  it 'strips existing schema prefix before re-qualifying' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('RequalifyPinned', klass)
+    klass.instance_variable_set(:@table_name, 'old_schema.jobs')
+    allow(klass).to(receive(:compute_table_name).and_return('requalify_pinneds'))
+    allow(klass).to(receive(:table_name).and_return('old_schema.jobs'))
+
+    expect(klass).to(receive(:table_name=).with('public.jobs'))
+
+    adapter.qualify_pinned_table_name(klass)
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/adapters/postgresql_schema_adapter_spec.rb --format documentation`
+Expected: failures for `shared_pinned_connection?` and `qualify_pinned_table_name`
+
+- [ ] **Step 3: Implement the methods**
+
+In `lib/apartment/adapters/postgresql_schema_adapter.rb`, add after line 14 (`class PostgresqlSchemaAdapter < AbstractAdapter`):
+
+```ruby
+def shared_pinned_connection?
+  !Apartment.config.force_separate_pinned_pool
+end
+
+def qualify_pinned_table_name(klass)
+  if explicit_table_name?(klass)
+    klass.instance_variable_set(:@apartment_original_table_name, klass.table_name)
+    klass.instance_variable_set(:@apartment_qualification_path, :explicit)
+    table = klass.table_name.sub(/\A[^.]+\./, '')
+    klass.table_name = "#{default_tenant}.#{table}"
+  else
+    klass.instance_variable_set(:@apartment_qualification_path, :convention)
+    klass.table_name_prefix = "#{default_tenant}."
+    klass.reset_table_name
+  end
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/adapters/postgresql_schema_adapter_spec.rb --format documentation`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/adapters/postgresql_schema_adapter.rb spec/unit/adapters/postgresql_schema_adapter_spec.rb
+git commit -m "Implement shared_pinned_connection? and qualify_pinned_table_name for PG schema
+
+PostgresqlSchemaAdapter returns true for shared_pinned_connection?
+(schemas share a catalog). qualify_pinned_table_name uses hybrid
+strategy: table_name_prefix for convention-named models, direct
+table_name= for explicit self.table_name assignments.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Implement `shared_pinned_connection?` and `qualify_pinned_table_name` in Mysql2Adapter
+
+**Files:**
+- Modify: `lib/apartment/adapters/mysql2_adapter.rb`
+- Modify: `spec/unit/adapters/mysql2_adapter_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `spec/unit/adapters/mysql2_adapter_spec.rb`, add inside the `RSpec.shared_examples('a MySQL adapter')` block, after the `describe '#resolve_connection_config'` block:
+
+```ruby
+describe '#shared_pinned_connection?' do
+  it 'returns true (MySQL supports cross-database queries on same server)' do
+    expect(adapter.shared_pinned_connection?).to(be(true))
+  end
+
+  it 'returns false when force_separate_pinned_pool is true' do
+    reconfigure(force_separate_pinned_pool: true)
+    expect(adapter.shared_pinned_connection?).to(be(false))
+  end
+end
+
+describe '#qualify_pinned_table_name' do
+  it 'qualifies convention-named model with database name from base_config' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('MysqlPinned', klass)
+
+    expect(klass).to(receive(:table_name_prefix=).with('myapp.'))
+    expect(klass).to(receive(:reset_table_name))
+
+    adapter.qualify_pinned_table_name(klass)
+  end
+
+  it 'qualifies explicit table_name with database name from base_config' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('MysqlExplicit', klass)
+    klass.instance_variable_set(:@table_name, 'custom_jobs')
+    allow(klass).to(receive(:compute_table_name).and_return('mysql_explicits'))
+    allow(klass).to(receive(:table_name).and_return('custom_jobs'))
+
+    expect(klass).to(receive(:table_name=).with('myapp.custom_jobs'))
+
+    adapter.qualify_pinned_table_name(klass)
+  end
+
+  it 'strips existing database prefix before re-qualifying' do
+    klass = Class.new(ActiveRecord::Base)
+    stub_const('MysqlRequalify', klass)
+    klass.instance_variable_set(:@table_name, 'old_db.jobs')
+    allow(klass).to(receive(:compute_table_name).and_return('mysql_requalifies'))
+    allow(klass).to(receive(:table_name).and_return('old_db.jobs'))
+
+    expect(klass).to(receive(:table_name=).with('myapp.jobs'))
+
+    adapter.qualify_pinned_table_name(klass)
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/adapters/mysql2_adapter_spec.rb --format documentation`
+Expected: failures for `shared_pinned_connection?` and `qualify_pinned_table_name`
+
+- [ ] **Step 3: Implement the methods**
+
+In `lib/apartment/adapters/mysql2_adapter.rb`, add after line 11 (`class Mysql2Adapter < AbstractAdapter`):
+
+```ruby
+def shared_pinned_connection?
+  !Apartment.config.force_separate_pinned_pool
+end
+
+def qualify_pinned_table_name(klass)
+  db_name = base_config['database']
+
+  if explicit_table_name?(klass)
+    klass.instance_variable_set(:@apartment_original_table_name, klass.table_name)
+    klass.instance_variable_set(:@apartment_qualification_path, :explicit)
+    table = klass.table_name.sub(/\A[^.]+\./, '')
+    klass.table_name = "#{db_name}.#{table}"
+  else
+    klass.instance_variable_set(:@apartment_qualification_path, :convention)
+    klass.table_name_prefix = "#{db_name}."
+    klass.reset_table_name
+  end
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/adapters/mysql2_adapter_spec.rb --format documentation`
+Expected: all pass
+
+- [ ] **Step 5: Run TrilogyAdapter tests to verify inheritance**
+
+Run: `bundle exec rspec spec/unit/adapters/mysql2_adapter_spec.rb --format documentation`
+Expected: Trilogy specs pass (inherits from Mysql2Adapter)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/apartment/adapters/mysql2_adapter.rb spec/unit/adapters/mysql2_adapter_spec.rb
+git commit -m "Implement shared_pinned_connection? and qualify_pinned_table_name for MySQL
+
+Mysql2Adapter returns true for shared_pinned_connection? (MySQL
+supports cross-database queries). qualify_pinned_table_name uses
+base_config['database'] as qualifier. TrilogyAdapter inherits both.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Rewrite `process_pinned_model` with dual-path logic and `pinned_model_config`
+
+**Files:**
+- Modify: `lib/apartment/adapters/abstract_adapter.rb:108-130,183-186`
+- Modify: `spec/unit/adapters/abstract_adapter_spec.rb:323-397`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the entire `describe '#process_pinned_models'` block in `spec/unit/adapters/abstract_adapter_spec.rb` with:
+
+```ruby
+describe '#process_pinned_models' do
+  context 'when shared_pinned_connection? is false (separate pool)' do
+    it 'calls establish_connection with pinned_model_config' do
+      model_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('SeparatePinned', model_class)
+      allow(model_class).to(receive(:table_name).and_return('separate_pinned'))
+      allow(model_class).to(receive(:table_name=))
+
+      SeparatePinned.pin_tenant
+
+      # Schema strategy: pinned_model_config includes schema_search_path
+      expected_config = {
+        'adapter' => 'postgresql', 'host' => 'localhost',
+        'schema_search_path' => '"public"'
+      }
+      expect(model_class).to(receive(:establish_connection)) do |arg|
+        expect(arg).to(eq(expected_config))
+      end
+
+      adapter.process_pinned_models
+    end
+
+    it 'includes persistent schemas in pinned_model_config search_path' do
+      model_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('PersistentPinned', model_class)
+      allow(model_class).to(receive(:table_name).and_return('persistent_pinned'))
+      allow(model_class).to(receive(:table_name=))
+
+      PersistentPinned.pin_tenant
+
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { %w[t1 t2] }
+        c.default_tenant = 'public'
+        c.force_separate_pinned_pool = true
+        c.configure_postgres { |pg| pg.persistent_schemas = %w[shared ext] }
+      end
+
+      expected_config = {
+        'adapter' => 'postgresql', 'host' => 'localhost',
+        'schema_search_path' => '"public","shared","ext"'
+      }
+      expect(model_class).to(receive(:establish_connection)) do |arg|
+        expect(arg).to(eq(expected_config))
+      end
+
+      adapter.process_pinned_models
+    end
+
+    it 'uses plain base_config for database_name strategy' do
+      model_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('DbSeparatePinned', model_class)
+      allow(model_class).to(receive(:table_name).and_return('db_separate_pinned'))
+
+      DbSeparatePinned.pin_tenant
+
+      reconfigure(tenant_strategy: :database_name)
+
+      expected_config = { 'adapter' => 'postgresql', 'host' => 'localhost' }
+      expect(model_class).to(receive(:establish_connection)) do |arg|
+        expect(arg).to(eq(expected_config))
+      end
+
+      adapter.process_pinned_models
+    end
+
+    it 'does not call qualify_pinned_table_name' do
+      model_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('NoQualifyPinned', model_class)
+      allow(model_class).to(receive(:table_name).and_return('no_qualify_pinned'))
+      allow(model_class).to(receive(:establish_connection))
+
+      NoQualifyPinned.pin_tenant
+
+      expect(adapter).not_to(receive(:qualify_pinned_table_name))
+      adapter.process_pinned_models
+    end
+  end
+
+  context 'when shared_pinned_connection? is true (shared pool)' do
+    before do
+      allow(adapter).to(receive(:shared_pinned_connection?).and_return(true))
+      allow(adapter).to(receive(:qualify_pinned_table_name))
+    end
+
+    it 'does not call establish_connection' do
+      model_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('SharedPinned', model_class)
+      allow(model_class).to(receive(:table_name).and_return('shared_pinned'))
+
+      SharedPinned.pin_tenant
+
+      expect(model_class).not_to(receive(:establish_connection))
+      adapter.process_pinned_models
+    end
+
+    it 'calls qualify_pinned_table_name' do
+      model_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('QualifyPinned', model_class)
+      allow(model_class).to(receive(:table_name).and_return('qualify_pinned'))
+
+      QualifyPinned.pin_tenant
+
+      expect(adapter).to(receive(:qualify_pinned_table_name).with(model_class))
+      adapter.process_pinned_models
+    end
+  end
+
+  it 'skips models already processed (idempotent via @apartment_pinned_processed)' do
+    model_class = Class.new(ActiveRecord::Base) do
+      include Apartment::Model
+    end
+    stub_const('AlreadyPinned', model_class)
+    allow(model_class).to(receive(:table_name).and_return('already_pinned'))
+    allow(model_class).to(receive(:table_name=))
+
+    AlreadyPinned.pin_tenant
+
+    # First call processes the model
+    allow(model_class).to(receive(:establish_connection))
+    adapter.process_pinned_models
+
+    # Second call skips — @apartment_pinned_processed is set
+    expect(model_class).not_to(receive(:establish_connection))
+    adapter.process_pinned_models
+  end
+
+  it 'does nothing when no models are pinned' do
+    expect { adapter.process_pinned_models }.not_to(raise_error)
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/adapters/abstract_adapter_spec.rb --format documentation`
+Expected: failures in `process_pinned_models` tests
+
+- [ ] **Step 3: Implement the dual-path process_pinned_model and pinned_model_config**
+
+Replace the `process_pinned_model` method in `lib/apartment/adapters/abstract_adapter.rb` (lines 108-130) with:
+
+```ruby
+# Process a single pinned model. Called by process_pinned_models (batch)
+# and by Apartment::Model.pin_tenant (when activated? is true).
+#
+# When shared_pinned_connection? is true, qualifies the table name so
+# the model uses the tenant's pool (preserving transactional integrity).
+# Otherwise, establishes a separate connection pool (required when
+# cross-database queries are impossible).
+def process_pinned_model(klass)
+  return if klass.instance_variable_get(:@apartment_pinned_processed)
+
+  if shared_pinned_connection?
+    qualify_pinned_table_name(klass)
+  else
+    klass.establish_connection(pinned_model_config)
+  end
+
+  klass.instance_variable_set(:@apartment_pinned_processed, true)
+end
+```
+
+Add `pinned_model_config` in the private section (after `base_config`):
+
+```ruby
+# Connection config for pinned models on the separate-pool path.
+# For schema strategy, pins schema_search_path to the default tenant
+# (plus persistent schemas) so FK constraints resolve correctly.
+# For database strategies, returns base_config unchanged.
+def pinned_model_config
+  config = base_config
+  return config unless Apartment.config.tenant_strategy == :schema
+
+  persistent = Apartment.config.postgres_config&.persistent_schemas || []
+  search_path = [default_tenant, *persistent].map { |s| %("#{s}") }.join(',')
+  config.merge('schema_search_path' => search_path)
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/adapters/abstract_adapter_spec.rb --format documentation`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/adapters/abstract_adapter.rb spec/unit/adapters/abstract_adapter_spec.rb
+git commit -m "Rewrite process_pinned_model with dual-path logic
+
+Shared path: qualify table name, skip establish_connection.
+Separate path: establish_connection with pinned_model_config
+(includes schema_search_path for PG schema strategy FK fix).
+Ivar renamed to @apartment_pinned_processed.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Update `clear_config` teardown and ivar references
+
+**Files:**
+- Modify: `lib/apartment.rb:120-134`
+- Modify: `spec/unit/adapters/abstract_adapter_spec.rb` (idempotency test comment, already done in Task 5)
+
+- [ ] **Step 1: Update `clear_config` in `lib/apartment.rb`**
+
+Replace the `clear_config` method (lines 121-134) with:
+
+```ruby
+# Reset all configuration and stop background tasks.
+def clear_config
+  teardown_old_state
+  # Reset per-model processing flags and undo table name qualification.
+  @pinned_models&.each do |klass|
+    next unless klass.instance_variable_defined?(:@apartment_pinned_processed)
+
+    # Restore table name based on which qualification path was used.
+    case klass.instance_variable_get(:@apartment_qualification_path)
+    when :convention
+      klass.table_name_prefix = ''
+      klass.reset_table_name
+    when :explicit
+      original = klass.instance_variable_get(:@apartment_original_table_name)
+      klass.table_name = original if original
+    end
+
+    klass.remove_instance_variable(:@apartment_pinned_processed)
+    klass.remove_instance_variable(:@apartment_qualification_path) if klass.instance_variable_defined?(:@apartment_qualification_path)
+    klass.remove_instance_variable(:@apartment_original_table_name) if klass.instance_variable_defined?(:@apartment_original_table_name)
+  end
+  @config = nil
+  @pool_manager = nil
+  @pool_reaper = nil
+  @pinned_models = nil
+  @activated = false
+end
+```
+
+- [ ] **Step 2: Run full unit suite to verify nothing broke**
+
+Run: `bundle exec rspec spec/unit/ --format progress`
+Expected: all pass (613+ examples, 0 failures)
+
+- [ ] **Step 3: Run `rg apartment_connection_established` to find remaining references**
+
+Run: `rg apartment_connection_established --type ruby`
+Expected: no matches in `lib/` or `spec/` (only docs/plans which are historical)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/apartment.rb
+git commit -m "Update clear_config teardown for new pinned model ivars
+
+Restores table name qualification on clear_config: convention path
+resets table_name_prefix + reset_table_name; explicit path restores
+original table_name. Cleans up all three ivars (@apartment_pinned_processed,
+@apartment_qualification_path, @apartment_original_table_name).
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Modify ConnectionHandling to conditionally route pinned models
+
+**Files:**
+- Modify: `lib/apartment/patches/connection_handling.rb:20-24`
+- Modify: `spec/unit/patches/connection_handling_spec.rb:269-313`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the `context 'pinned model bypass'` block in `spec/unit/patches/connection_handling_spec.rb` (lines 269-313) with:
+
+```ruby
+context 'pinned model bypass' do
+  before do
+    require_relative('../../../lib/apartment/concerns/model')
+  end
+
+  context 'when shared_pinned_connection? is false (separate pool)' do
+    before do
+      allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
+    end
+
+    it 'returns the default pool for a pinned AR::Base subclass when tenant is set' do
+      pinned_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('PinnedBypassModel', pinned_class)
+      pinned_class.pin_tenant
+
+      Apartment::Current.tenant = 'acme'
+      expect(pinned_class.connection_pool).to(equal(default_pool))
+    end
+
+    it 'bypasses for STI subclass of a pinned model' do
+      parent = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('PinnedParentBypass', parent)
+      parent.pin_tenant
+
+      child = Class.new(parent)
+      stub_const('PinnedChildBypass', child)
+
+      Apartment::Current.tenant = 'acme'
+      expect(child.connection_pool).to(equal(default_pool))
+    end
+  end
+
+  context 'when shared_pinned_connection? is true (shared pool)' do
+    before do
+      allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(true))
+    end
+
+    it 'returns the tenant pool for a pinned model (transactional integrity)' do
+      pinned_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('PinnedSharedModel', pinned_class)
+      pinned_class.pin_tenant
+
+      Apartment::Current.tenant = 'acme'
+      expect(pinned_class.connection_pool).not_to(equal(default_pool))
+    end
+
+    it 'returns the tenant pool for STI subclass of a pinned model' do
+      parent = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('PinnedSharedParent', parent)
+      parent.pin_tenant
+
+      child = Class.new(parent)
+      stub_const('PinnedSharedChild', child)
+
+      Apartment::Current.tenant = 'acme'
+      expect(child.connection_pool).not_to(equal(default_pool))
+    end
+  end
+
+  it 'does not bypass for ActiveRecord::Base itself' do
+    allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
+    Apartment::Current.tenant = 'acme'
+    tenant_pool = ActiveRecord::Base.connection_pool
+    expect(tenant_pool).not_to(equal(default_pool))
+  end
+
+  it 'does not bypass for an unpinned AR::Base subclass' do
+    allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
+    unpinned = Class.new(ActiveRecord::Base)
+    stub_const('UnpinnedWidget', unpinned)
+
+    Apartment::Current.tenant = 'acme'
+    expect(unpinned.connection_pool).not_to(equal(default_pool))
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify shared-pool tests fail**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/patches/connection_handling_spec.rb --format documentation`
+Expected: shared-pool pinned model tests fail (pinned models still always bypass)
+
+- [ ] **Step 3: Implement the conditional routing**
+
+In `lib/apartment/patches/connection_handling.rb`, replace lines 20-24:
+
+```ruby
+# Skip tenant override for Apartment pinned models.
+# Uses explicit registry (not connection_specification_name heuristic)
+# because ApplicationRecord subclasses have a different spec name than
+# ActiveRecord::Base while sharing the same pool.
+return super if self != ActiveRecord::Base && Apartment.pinned_model?(self)
+```
+
+With:
+
+```ruby
+# Skip tenant override for pinned models only when the adapter requires
+# a separate pool (shared_pinned_connection? is false). When shared
+# connections are supported (PG schema, MySQL single-server), pinned
+# models fall through to the tenant pool lookup, preserving
+# transactional integrity between pinned and tenant models.
+if self != ActiveRecord::Base && Apartment.pinned_model?(self) &&
+   !Apartment.adapter&.shared_pinned_connection?
+  return super
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/patches/connection_handling_spec.rb --format documentation`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/patches/connection_handling.rb spec/unit/patches/connection_handling_spec.rb
+git commit -m "Conditionally route pinned models through tenant pool
+
+When shared_pinned_connection? is true, pinned models fall through
+to the tenant pool lookup instead of short-circuiting to the default
+pool. Preserves transactional integrity between pinned and tenant
+model writes.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Update integration tests for dual-path behavior
+
+**Files:**
+- Modify: `spec/integration/v4/excluded_models_spec.rb`
+
+- [ ] **Step 1: Update existing integration tests**
+
+In `spec/integration/v4/excluded_models_spec.rb`, replace the test at line 69:
+
+```ruby
+it 'pin_tenant establishes a dedicated connection for the model' do
+  expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+end
+```
+
+With two context-separated tests:
+
+```ruby
+context 'pinned model connection routing' do
+  it 'shares the tenant connection when shared_pinned_connection? is true' do
+    if Apartment.adapter.shared_pinned_connection?
+      expect(GlobalSetting.connection_specification_name).to(eq(ActiveRecord::Base.connection_specification_name))
+    else
+      skip 'adapter does not support shared pinned connections'
+    end
+  end
+
+  it 'uses a separate connection when shared_pinned_connection? is false' do
+    unless Apartment.adapter.shared_pinned_connection?
+      expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+    else
+      skip 'adapter supports shared pinned connections'
+    end
+  end
+end
+```
+
+Replace the idempotency test at line 73:
+
+```ruby
+it 'pin_tenant is idempotent' do
+  expect { Apartment.adapter.process_pinned_models }.not_to(raise_error)
+end
+```
+
+With:
+
+```ruby
+it 'pin_tenant is idempotent' do
+  expect { Apartment.adapter.process_pinned_models }.not_to(raise_error)
+  unless Apartment.adapter.shared_pinned_connection?
+    expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+  end
+end
+```
+
+- [ ] **Step 2: Add transactional integrity tests**
+
+Add after the `context 'ApplicationRecord topology'` block:
+
+```ruby
+context 'transactional integrity (shared connection path)' do
+  it 'rolls back both pinned and tenant model writes on transaction rollback' do
+    skip 'requires shared_pinned_connection?' unless Apartment.adapter.shared_pinned_connection?
+
+    Apartment::Tenant.switch('tenant_a') do
+      ActiveRecord::Base.transaction do
+        Widget.create!(name: 'will_be_rolled_back')
+        GlobalSetting.create!(key: 'will_be_rolled_back', value: 'yes')
+        raise ActiveRecord::Rollback
+      end
+
+      expect(Widget.count).to(eq(0))
+      expect(GlobalSetting.where(key: 'will_be_rolled_back').count).to(eq(0))
+    end
+  end
+
+  it 'commits both pinned and tenant model writes on successful transaction' do
+    skip 'requires shared_pinned_connection?' unless Apartment.adapter.shared_pinned_connection?
+
+    Apartment::Tenant.switch('tenant_a') do
+      ActiveRecord::Base.transaction do
+        Widget.create!(name: 'committed')
+        GlobalSetting.create!(key: 'committed', value: 'yes')
+      end
+
+      expect(Widget.find_by(name: 'committed')).to(be_present)
+      expect(GlobalSetting.find_by(key: 'committed')).to(be_present)
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/excluded_models_spec.rb --format documentation`
+Expected: all pass (some skipped based on adapter capability)
+
+Run (if PG available): `DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/excluded_models_spec.rb --format documentation`
+Expected: all pass including transactional integrity tests
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec/integration/v4/excluded_models_spec.rb
+git commit -m "Update integration tests for dual-path pinned model behavior
+
+Separate context blocks for shared vs separate pool. Add transactional
+integrity tests: rollback rolls back both pinned and tenant writes
+when shared connections are supported.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Update upgrade guide and docstrings
+
+**Files:**
+- Modify: `docs/upgrading-to-v4.md:119-120`
+- Modify: `lib/apartment/adapters/abstract_adapter.rb` (process_pinned_models docstring)
+
+- [ ] **Step 1: Add Pinned Model Connections section to upgrade guide**
+
+In `docs/upgrading-to-v4.md`, insert after line 119 (after "The Railtie emits a boot-time warning if `isolation_level` is `:thread`.") and before "Key config options for pool tuning:":
+
+```markdown
+### Pinned Model Connections
+
+In v3, pinned (excluded) models always received their own connection pool via `establish_connection`. This meant they never participated in the same database transaction as tenant-scoped models.
+
+v4 fixes this for strategies where the database engine supports cross-schema/database queries on a single connection:
+
+| Strategy | Pinned model connection in v4 |
+|---|---|
+| PostgreSQL schema | Shares tenant connection (qualified table name) |
+| MySQL / Trilogy single-server | Shares tenant connection (qualified table name) |
+| PostgreSQL database-per-tenant | Separate pool (unchanged from v3) |
+| SQLite | Separate pool (unchanged from v3) |
+
+For PG schema and MySQL/Trilogy, pinned models now use the tenant's connection pool with a fully qualified table name (e.g. `public.delayed_jobs`). This means pinned model writes participate in the same transaction as tenant DML.
+
+**Action required if you relied on the old behavior:**
+
+If your code assumes that pinned model writes survive a tenant transaction rollback (e.g., enqueuing a job and deliberately rolling back tenant data), set `force_separate_pinned_pool: true` in your Apartment config:
+
+```ruby
+Apartment.configure do |config|
+  config.force_separate_pinned_pool = true
+  # ...
+end
+```
+
+`after_commit` callbacks still fire as before. The difference is that pinned model writes are now inside the tenant transaction, so an `ActiveRecord::Rollback` that aborts the transaction will also roll back pinned model writes. Apps using `after_commit` for job enqueueing are unaffected.
+
+For PG database-per-tenant, SQLite, and multi-server setups, pinned model behavior is unchanged from v3.
+```
+
+- [ ] **Step 2: Update the process_pinned_models docstring**
+
+In `lib/apartment/adapters/abstract_adapter.rb`, replace the docstring above `process_pinned_models` (line 99):
+
+```ruby
+# Process all pinned models — establish separate connections pinned to default tenant.
+```
+
+With:
+
+```ruby
+# Process all pinned models. When shared_pinned_connection? is true, qualifies
+# table names for shared pool routing. Otherwise, establishes separate connections.
+```
+
+- [ ] **Step 3: Run rubocop on changed files**
+
+Run: `bundle exec rubocop lib/apartment/adapters/abstract_adapter.rb lib/apartment/patches/connection_handling.rb lib/apartment/config.rb lib/apartment.rb`
+Expected: no offenses
+
+- [ ] **Step 4: Run full unit suite**
+
+Run: `bundle exec rspec spec/unit/ --format progress`
+Expected: all pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/upgrading-to-v4.md lib/apartment/adapters/abstract_adapter.rb
+git commit -m "Update upgrade guide and docstrings for shared pinned connections
+
+Add Pinned Model Connections section to upgrading-to-v4.md with
+adapter matrix, force_separate_pinned_pool escape hatch, and
+after_commit nuance. Update process_pinned_models docstring.
+
+Co-Authored-By: henkesn <14108170+henkesn@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Final verification across all Rails versions
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run unit tests across all Rails versions**
+
+Run: `bundle exec appraisal rspec spec/unit/ --format progress`
+Expected: all pass across all Rails versions
+
+- [ ] **Step 2: Run integration tests (SQLite)**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/ --format documentation`
+Expected: all pass (shared connection tests skipped for SQLite)
+
+- [ ] **Step 3: Run integration tests (PostgreSQL, if available)**
+
+Run: `DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/ --format documentation`
+Expected: all pass including shared connection and transactional integrity tests
+
+- [ ] **Step 4: Run integration tests (MySQL, if available)**
+
+Run: `DATABASE_ENGINE=mysql bundle exec appraisal rails-8.1-mysql2 rspec spec/integration/v4/ --format documentation`
+Expected: all pass including shared connection tests
+
+- [ ] **Step 5: Run rubocop on all changed files**
+
+Run: `bundle exec rubocop lib/apartment/adapters/abstract_adapter.rb lib/apartment/adapters/postgresql_schema_adapter.rb lib/apartment/adapters/mysql2_adapter.rb lib/apartment/patches/connection_handling.rb lib/apartment/config.rb lib/apartment.rb spec/unit/adapters/abstract_adapter_spec.rb spec/unit/adapters/postgresql_schema_adapter_spec.rb spec/unit/adapters/mysql2_adapter_spec.rb spec/unit/patches/connection_handling_spec.rb spec/unit/config_spec.rb spec/integration/v4/excluded_models_spec.rb`
+Expected: no offenses

--- a/docs/plans/apartment-v4/shared-pinned-connections.md
+++ b/docs/plans/apartment-v4/shared-pinned-connections.md
@@ -754,9 +754,24 @@ Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
 
 **Files:**
 - Modify: `lib/apartment/patches/connection_handling.rb:20-24`
-- Modify: `spec/unit/patches/connection_handling_spec.rb:269-313`
+- Modify: `spec/unit/patches/connection_handling_spec.rb:47-49` (mock_adapter default)
+- Modify: `spec/unit/patches/connection_handling_spec.rb:269-349` (pinned model bypass + Tenant.each)
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Add `shared_pinned_connection?` to the default mock_adapter**
+
+In `spec/unit/patches/connection_handling_spec.rb`, update the `let(:mock_adapter)` (line 47) to include the new method:
+
+```ruby
+let(:mock_adapter) do
+  double('AbstractAdapter',
+         validated_connection_config: { 'adapter' => 'sqlite3', 'database' => ':memory:' },
+         shared_pinned_connection?: false)
+end
+```
+
+This ensures all existing tests that don't stub `shared_pinned_connection?` continue to see the default "separate pool" behavior.
+
+- [ ] **Step 2: Write the failing tests**
 
 Replace the `context 'pinned model bypass'` block in `spec/unit/patches/connection_handling_spec.rb` (lines 269-313) with:
 
@@ -846,12 +861,12 @@ context 'pinned model bypass' do
 end
 ```
 
-- [ ] **Step 2: Run tests to verify shared-pool tests fail**
+- [ ] **Step 3: Run tests to verify shared-pool tests fail**
 
 Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/patches/connection_handling_spec.rb --format documentation`
 Expected: shared-pool pinned model tests fail (pinned models still always bypass)
 
-- [ ] **Step 3: Implement the conditional routing**
+- [ ] **Step 4: Implement the conditional routing**
 
 In `lib/apartment/patches/connection_handling.rb`, replace lines 20-24:
 
@@ -877,12 +892,90 @@ if self != ActiveRecord::Base && Apartment.pinned_model?(self) &&
 end
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [ ] **Step 5: Run tests to verify they pass**
 
 Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/patches/connection_handling_spec.rb --format documentation`
 Expected: all pass
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Update `context 'pinned model inside Tenant.each'`**
+
+Replace the `context 'pinned model inside Tenant.each'` block (lines 315-349) with:
+
+```ruby
+context 'pinned model inside Tenant.each' do
+  before do
+    require_relative('../../../lib/apartment/concerns/model')
+  end
+
+  context 'when shared_pinned_connection? is false (separate pool)' do
+    before do
+      allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
+    end
+
+    it 'returns the default pool for a pinned model while iterating tenants' do
+      pinned_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('PinnedInsideEach', pinned_class)
+      pinned_class.pin_tenant
+
+      pools_during_each = []
+      Apartment::Tenant.each(%w[acme widgets]) do |_tenant|
+        pools_during_each << pinned_class.connection_pool
+      end
+
+      expect(pools_during_each).to(all(equal(default_pool)))
+    end
+  end
+
+  context 'when shared_pinned_connection? is true (shared pool)' do
+    before do
+      allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(true))
+    end
+
+    it 'returns the tenant pool for a pinned model while iterating tenants' do
+      pinned_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('PinnedSharedEach', pinned_class)
+      pinned_class.pin_tenant
+
+      pools_during_each = []
+      Apartment::Tenant.each(%w[acme widgets]) do |_tenant|
+        pools_during_each << pinned_class.connection_pool
+      end
+
+      # Pinned model should track tenant pools, not default
+      pools_during_each.each do |pool|
+        expect(pool).not_to(equal(default_pool))
+      end
+      expect(pools_during_each[0]).not_to(equal(pools_during_each[1]))
+    end
+  end
+
+  it 'routes unpinned models to tenant pools while iterating' do
+    unpinned = Class.new(ActiveRecord::Base)
+    stub_const('UnpinnedInsideEach', unpinned)
+
+    pools_during_each = []
+    Apartment::Tenant.each(%w[acme widgets]) do |_tenant|
+      pools_during_each << unpinned.connection_pool
+    end
+
+    pools_during_each.each do |pool|
+      expect(pool).not_to(equal(default_pool))
+    end
+    expect(pools_during_each[0]).not_to(equal(pools_during_each[1]))
+  end
+end
+```
+
+- [ ] **Step 7: Run tests to verify the Tenant.each tests pass**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/patches/connection_handling_spec.rb --format documentation`
+Expected: all pass
+
+- [ ] **Step 8: Commit**
 
 ```bash
 git add lib/apartment/patches/connection_handling.rb spec/unit/patches/connection_handling_spec.rb

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -118,6 +118,36 @@ config.active_support.isolation_level = :fiber
 
 The Railtie emits a boot-time warning if `isolation_level` is `:thread`.
 
+### Pinned Model Connections
+
+In v3, pinned (excluded) models always received their own connection pool via `establish_connection`. This meant they never participated in the same database transaction as tenant-scoped models.
+
+v4 fixes this for strategies where the database engine supports cross-schema/database queries on a single connection:
+
+| Strategy | Pinned model connection in v4 |
+|---|---|
+| PostgreSQL schema | Shares tenant connection (qualified table name) |
+| MySQL / Trilogy single-server | Shares tenant connection (qualified table name) |
+| PostgreSQL database-per-tenant | Separate pool (unchanged from v3) |
+| SQLite | Separate pool (unchanged from v3) |
+
+For PG schema and MySQL/Trilogy, pinned models now use the tenant's connection pool with a fully qualified table name (e.g. `public.delayed_jobs`). This means pinned model writes participate in the same transaction as tenant DML.
+
+**Action required if you relied on the old behavior:**
+
+If your code assumes that pinned model writes survive a tenant transaction rollback (e.g., enqueuing a job and deliberately rolling back tenant data), set `force_separate_pinned_pool: true` in your Apartment config:
+
+```ruby
+Apartment.configure do |config|
+  config.force_separate_pinned_pool = true
+  # ...
+end
+```
+
+`after_commit` callbacks still fire as before. The difference is that pinned model writes are now inside the tenant transaction, so an `ActiveRecord::Rollback` that aborts the transaction will also roll back pinned model writes. Apps using `after_commit` for job enqueueing are unaffected.
+
+For PG database-per-tenant, SQLite, and multi-server setups, pinned model behavior is unchanged from v3.
+
 Key config options for pool tuning:
 
 | Option | Default | Description |

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -127,7 +127,7 @@ v4 fixes this for strategies where the database engine supports cross-schema/dat
 | Strategy | Pinned model connection in v4 |
 |---|---|
 | PostgreSQL schema | Shares tenant connection (qualified table name) |
-| MySQL / Trilogy single-server | Shares tenant connection (qualified table name) |
+| MySQL / Trilogy | Shares tenant connection (qualified table name) |
 | PostgreSQL database-per-tenant | Separate pool (unchanged from v3) |
 | SQLite | Separate pool (unchanged from v3) |
 
@@ -146,7 +146,7 @@ end
 
 `after_commit` callbacks still fire as before. The difference is that pinned model writes are now inside the tenant transaction, so an `ActiveRecord::Rollback` that aborts the transaction will also roll back pinned model writes. Apps using `after_commit` for job enqueueing are unaffected.
 
-For PG database-per-tenant, SQLite, and multi-server setups, pinned model behavior is unchanged from v3.
+For PG database-per-tenant and SQLite, pinned model behavior is unchanged from v3. For MySQL multi-server setups where tenant databases are on different hosts, set `force_separate_pinned_pool: true`.
 
 Key config options for pool tuning:
 

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -122,9 +122,9 @@ module Apartment
       teardown_old_state
       # Reset per-model processing flags so re-configuration re-establishes connections.
       @pinned_models&.each do |klass|
-        next unless klass.instance_variable_defined?(:@apartment_connection_established)
+        next unless klass.instance_variable_defined?(:@apartment_pinned_processed)
 
-        klass.remove_instance_variable(:@apartment_connection_established)
+        klass.remove_instance_variable(:@apartment_pinned_processed)
       end
       @config = nil
       @pool_manager = nil

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -56,9 +56,15 @@ module Apartment
     end
 
     # Check if a class (or any of its ancestors) is a pinned model.
-    # Used by ConnectionHandling to skip tenant pool routing.
+    # Delegates to the class's own apartment_pinned? (defined by the
+    # Apartment::Model concern). Falls back to registry lookup for
+    # models registered via the excluded_models shim without the concern.
     def pinned_model?(klass)
-      klass.ancestors.any? { |a| a.is_a?(Class) && pinned_models.include?(a) }
+      if klass.respond_to?(:apartment_pinned?)
+        klass.apartment_pinned?
+      else
+        klass.ancestors.any? { |a| a.is_a?(Class) && pinned_models.include?(a) }
+      end
     end
 
     def activated?

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -34,7 +34,7 @@ loader.setup
 
 require_relative 'apartment/errors'
 
-module Apartment
+module Apartment # rubocop:disable Metrics/ModuleLength
   class << self
     attr_reader :config, :pool_manager, :pool_reaper
     attr_writer :adapter
@@ -120,24 +120,7 @@ module Apartment
     # Reset all configuration and stop background tasks.
     def clear_config
       teardown_old_state
-      # Reset per-model processing flags and undo table name qualification.
-      @pinned_models&.each do |klass|
-        next unless klass.instance_variable_defined?(:@apartment_pinned_processed)
-
-        # Restore table name based on which qualification path was used.
-        case klass.instance_variable_get(:@apartment_qualification_path)
-        when :convention
-          klass.table_name_prefix = ''
-          klass.reset_table_name
-        when :explicit
-          original = klass.instance_variable_get(:@apartment_original_table_name)
-          klass.table_name = original if original
-        end
-
-        %i[@apartment_pinned_processed @apartment_qualification_path @apartment_original_table_name].each do |ivar|
-          klass.remove_instance_variable(ivar) if klass.instance_variable_defined?(ivar)
-        end
-      end
+      @pinned_models&.each { |klass| restore_pinned_model(klass) }
       @config = nil
       @pool_manager = nil
       @pool_reaper = nil
@@ -187,6 +170,33 @@ module Apartment
     end
 
     private
+
+    # Undo table name qualification and remove tracking ivars from a pinned model.
+    # Convention path: restore original prefix so reset_table_name recomputes.
+    # Explicit path: restore the original table_name that was overwritten.
+    # nil path: separate-pool models (establish_connection only, no table name changes).
+    def restore_pinned_model(klass)
+      return unless klass.instance_variable_defined?(:@apartment_pinned_processed)
+
+      case klass.instance_variable_get(:@apartment_qualification_path)
+      when :convention
+        original_prefix = klass.instance_variable_get(:@apartment_original_table_name_prefix) || ''
+        klass.table_name_prefix = original_prefix
+        klass.reset_table_name
+      when :explicit
+        original = klass.instance_variable_get(:@apartment_original_table_name)
+        klass.table_name = original if original
+      when nil then nil # Separate-pool path — no table name qualification to undo.
+      else
+        warn "[Apartment] clear_config: #{klass.name} has unexpected qualification_path " \
+             "#{klass.instance_variable_get(:@apartment_qualification_path).inspect}"
+      end
+
+      %i[@apartment_pinned_processed @apartment_qualification_path
+         @apartment_original_table_name @apartment_original_table_name_prefix].each do |ivar|
+        klass.remove_instance_variable(ivar) if klass.instance_variable_defined?(ivar)
+      end
+    end
 
     # Safely tear down old state. Stops the reaper first (so it doesn't
     # evict mid-cleanup), then deregisters tenant pools from AR's

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -34,7 +34,7 @@ loader.setup
 
 require_relative 'apartment/errors'
 
-module Apartment # rubocop:disable Metrics/ModuleLength
+module Apartment
   class << self
     attr_reader :config, :pool_manager, :pool_reaper
     attr_writer :adapter
@@ -120,7 +120,7 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     # Reset all configuration and stop background tasks.
     def clear_config
       teardown_old_state
-      @pinned_models&.each { |klass| restore_pinned_model(klass) }
+      @pinned_models&.each { |klass| klass.apartment_restore! if klass.respond_to?(:apartment_restore!) }
       @config = nil
       @pool_manager = nil
       @pool_reaper = nil
@@ -170,33 +170,6 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     end
 
     private
-
-    # Undo table name qualification and remove tracking ivars from a pinned model.
-    # Convention path: restore original prefix so reset_table_name recomputes.
-    # Explicit path: restore the original table_name that was overwritten.
-    # nil path: separate-pool models (establish_connection only, no table name changes).
-    def restore_pinned_model(klass)
-      return unless klass.instance_variable_defined?(:@apartment_pinned_processed)
-
-      case klass.instance_variable_get(:@apartment_qualification_path)
-      when :convention
-        original_prefix = klass.instance_variable_get(:@apartment_original_table_name_prefix) || ''
-        klass.table_name_prefix = original_prefix
-        klass.reset_table_name
-      when :explicit
-        original = klass.instance_variable_get(:@apartment_original_table_name)
-        klass.table_name = original if original
-      when nil then nil # Separate-pool path — no table name qualification to undo.
-      else
-        warn "[Apartment] clear_config: #{klass.name} has unexpected qualification_path " \
-             "#{klass.instance_variable_get(:@apartment_qualification_path).inspect}"
-      end
-
-      %i[@apartment_pinned_processed @apartment_qualification_path
-         @apartment_original_table_name @apartment_original_table_name_prefix].each do |ivar|
-        klass.remove_instance_variable(ivar) if klass.instance_variable_defined?(ivar)
-      end
-    end
 
     # Safely tear down old state. Stops the reaper first (so it doesn't
     # evict mid-cleanup), then deregisters tenant pools from AR's

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -120,11 +120,23 @@ module Apartment
     # Reset all configuration and stop background tasks.
     def clear_config
       teardown_old_state
-      # Reset per-model processing flags so re-configuration re-establishes connections.
+      # Reset per-model processing flags and undo table name qualification.
       @pinned_models&.each do |klass|
         next unless klass.instance_variable_defined?(:@apartment_pinned_processed)
 
-        klass.remove_instance_variable(:@apartment_pinned_processed)
+        # Restore table name based on which qualification path was used.
+        case klass.instance_variable_get(:@apartment_qualification_path)
+        when :convention
+          klass.table_name_prefix = ''
+          klass.reset_table_name
+        when :explicit
+          original = klass.instance_variable_get(:@apartment_original_table_name)
+          klass.table_name = original if original
+        end
+
+        %i[@apartment_pinned_processed @apartment_qualification_path @apartment_original_table_name].each do |ivar|
+          klass.remove_instance_variable(ivar) if klass.instance_variable_defined?(ivar)
+        end
       end
       @config = nil
       @pool_manager = nil

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -80,7 +80,9 @@ All inherit from `AbstractAdapter`. Override `resolve_connection_config`, `creat
 
 **Table naming:** `apartment_explicit_table_name?` — whether `self.table_name` was explicitly set vs convention (compares `@table_name` to `compute_table_name`). Lives here so adapters do not read `@table_name` or call `compute_table_name` from outside; **class instance variable access for pinning is confined to this concern**.
 
-**Lifecycle:** `apartment_pinned_processed?`, `apartment_mark_processed!`, `apartment_restore!` — qualification state and teardown. Adapters call these; `Apartment.clear_config` uses `apartment_restore!` with `respond_to?` so shim-registered models without the concern still clear safely.
+**Lifecycle:** `apartment_pinned_processed?`, `apartment_mark_processed!`, `apartment_restore!` — qualification state and teardown. Adapters call these; `Apartment.clear_config` uses `apartment_restore!` with `respond_to?` so shim-registered models without the concern still clear safely. `apartment_mark_pinned!` — sets the pinned flag without triggering processing (used by `process_pinned_model` for shim classes to avoid `pin_tenant` recursion).
+
+**Shim compatibility:** `process_pinned_model` dynamically includes `Apartment::Model` on classes registered via the `excluded_models` shim that lack the concern. This is a runtime `include` on a partially-booted class — acceptable for the legacy shim path but new code should always use `include Apartment::Model` + `pin_tenant` explicitly.
 
 ### railtie.rb — v4 Rails Integration
 

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -14,7 +14,7 @@ lib/apartment/
 │   ├── trilogy_adapter.rb     # Database-per-tenant on MySQL (trilogy driver, inherits Mysql2Adapter)
 │   └── sqlite3_adapter.rb     # File-per-tenant (FileUtils lifecycle)
 ├── concerns/              # ActiveRecord concerns for tenant-aware models
-│   └── model.rb               # Apartment::Model concern: pin_tenant, apartment_pinned?
+│   └── model.rb               # Apartment::Model concern: pin_tenant, pinned identity, table-name helpers
 ├── configs/               # Database-specific config objects
 │   ├── postgresql_config.rb   # PostgresqlConfig: persistent_schemas, enforce_search_path_reset
 │   └── mysql_config.rb        # MysqlConfig: placeholder
@@ -60,7 +60,7 @@ Background `Concurrent::TimerTask` instance that evicts idle and excess tenant p
 
 ### adapters/abstract_adapter.rb — Base Adapter
 
-Lifecycle ops (`create`, `drop`, `migrate`, `seed`), `ActiveSupport::Callbacks` on `:create`/`:switch`, `resolve_connection_config` (abstract — subclasses override), `process_excluded_models`, `environmentify`, `base_config` (stringified `connection_config`), `rails_env` (guarded `Rails.env` access). Constructor takes `connection_config` (raw AR hash, not `Apartment::Config`).
+Lifecycle ops (`create`, `drop`, `migrate`, `seed`), `ActiveSupport::Callbacks` on `:create`/`:switch`, `resolve_connection_config` (abstract — subclasses override), `process_excluded_models`, `environmentify`, `base_config` (stringified `connection_config`), `rails_env` (guarded `Rails.env` access). `process_pinned_model` / `qualify_pinned_table_name` call **`Apartment::Model` class methods** (`apartment_explicit_table_name?`, `apartment_mark_processed!`, etc.); no `instance_variable_*` on arbitrary model classes. Constructor takes `connection_config` (raw AR hash, not `Apartment::Config`).
 
 ### Concrete Adapters (Phase 2.2)
 
@@ -74,7 +74,13 @@ All inherit from `AbstractAdapter`. Override `resolve_connection_config`, `creat
 
 ### concerns/model.rb — Model Pinning Concern
 
-`Apartment::Model` provides `pin_tenant` (class method) to declare a model as pinned to the default tenant. Registered models bypass the `ConnectionHandling` patch. Zeitwerk-safe: works whether called before or after `activate!`. `apartment_pinned?` checks the class and its superclass chain.
+`Apartment::Model` provides `pin_tenant` (class method) to declare a model as pinned to the default tenant. Registered models bypass the `ConnectionHandling` patch when the adapter uses a separate pool; when shared pinned connections are enabled, routing follows the tenant pool (see design docs). Zeitwerk-safe: works whether called before or after `activate!`.
+
+**Identity:** `apartment_pinned?` — the class answers whether it is pinned (ivars + superclass walk). `Apartment.pinned_model?(klass)` delegates to `klass.apartment_pinned?` when the concern is included; otherwise it falls back to registry lookup (`pinned_models`) for `excluded_models` shim classes that never included the concern.
+
+**Table naming:** `apartment_explicit_table_name?` — whether `self.table_name` was explicitly set vs convention (compares `@table_name` to `compute_table_name`). Lives here so adapters do not read `@table_name` or call `compute_table_name` from outside; **class instance variable access for pinning is confined to this concern**.
+
+**Lifecycle:** `apartment_pinned_processed?`, `apartment_mark_processed!`, `apartment_restore!` — qualification state and teardown. Adapters call these; `Apartment.clear_config` uses `apartment_restore!` with `respond_to?` so shim-registered models without the concern still clear safely.
 
 ### railtie.rb — v4 Rails Integration
 

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -221,20 +221,6 @@ module Apartment
         config.merge('schema_search_path' => search_path)
       end
 
-      # Detect whether a model has an explicit self.table_name = assignment
-      # (as opposed to Rails' lazy convention computation). Returns false if
-      # the explicit value matches what convention would produce, since the
-      # convention path handles that case correctly.
-      # NOTE: compute_table_name is a private Rails API; tested against Rails
-      # main as a canary in CI (see .github/workflows/ci.yml).
-      def explicit_table_name?(klass)
-        return false unless klass.instance_variable_defined?(:@table_name)
-
-        cached = klass.instance_variable_get(:@table_name)
-        computed = klass.send(:compute_table_name)
-        cached != computed
-      end
-
       def rails_env
         unless defined?(Rails)
           raise(Apartment::ConfigurationError,

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -135,15 +135,14 @@ module Apartment
       # Otherwise, establishes a separate connection pool (required when
       # cross-database queries are impossible).
       def process_pinned_model(klass)
-        return if klass.instance_variable_get(:@apartment_pinned_processed)
+        return if klass.apartment_pinned_processed?
 
         if shared_pinned_connection?
           qualify_pinned_table_name(klass)
         else
           klass.establish_connection(pinned_model_config)
+          klass.apartment_mark_processed!
         end
-
-        klass.instance_variable_set(:@apartment_pinned_processed, true)
       end
 
       # Deprecated: use process_pinned_models instead.

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -97,12 +97,11 @@ module Apartment
       end
 
       # Whether pinned models can share the tenant's connection pool using
-      # qualified table names. When true, process_pinned_model qualifies the
-      # table name instead of calling establish_connection.
+      # qualified table names instead of establish_connection.
       #
-      # Combines engine capability with config override. Returns false by
-      # default (safe fallback — separate pool). Subclasses override to
-      # return true for engines that support cross-schema/database queries.
+      # Returns false by default (separate pool). Subclasses override to
+      # return true when the engine supports cross-schema/database queries,
+      # gated by config.force_separate_pinned_pool.
       def shared_pinned_connection?
         false
       end
@@ -122,6 +121,9 @@ module Apartment
 
         Apartment.pinned_models.each do |klass|
           process_pinned_model(klass)
+        rescue StandardError => e
+          raise(Apartment::ConfigurationError,
+                "Failed to process pinned model #{klass.name}: #{e.class}: #{e.message}")
         end
       end
 
@@ -208,7 +210,8 @@ module Apartment
 
       # Connection config for pinned models on the separate-pool path.
       # For schema strategy, pins schema_search_path to the default tenant
-      # (plus persistent schemas) so FK constraints resolve correctly.
+      # (plus persistent schemas) so the connection resolves tables and FK
+      # constraints in the correct schema.
       # For database strategies, returns base_config unchanged.
       def pinned_model_config
         config = base_config
@@ -220,7 +223,11 @@ module Apartment
       end
 
       # Detect whether a model has an explicit self.table_name = assignment
-      # (as opposed to Rails' lazy convention computation).
+      # (as opposed to Rails' lazy convention computation). Returns false if
+      # the explicit value matches what convention would produce, since the
+      # convention path handles that case correctly.
+      # NOTE: compute_table_name is a private Rails API; tested against Rails
+      # main as a canary in CI (see .github/workflows/ci.yml).
       def explicit_table_name?(klass)
         return false unless klass.instance_variable_defined?(:@table_name)
 

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -135,6 +135,14 @@ module Apartment
       # Otherwise, establishes a separate connection pool (required when
       # cross-database queries are impossible).
       def process_pinned_model(klass)
+        # Ensure the concern is included — models registered via the
+        # excluded_models shim may not have it yet. Uses apartment_mark_pinned!
+        # (not pin_tenant) to avoid recursion back into process_pinned_model.
+        unless klass.respond_to?(:apartment_pinned_processed?)
+          klass.include(Apartment::Model)
+          klass.apartment_mark_pinned!
+        end
+
         return if klass.apartment_pinned_processed?
 
         if shared_pinned_connection?

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -96,6 +96,25 @@ module Apartment
         end
       end
 
+      # Whether pinned models can share the tenant's connection pool using
+      # qualified table names. When true, process_pinned_model qualifies the
+      # table name instead of calling establish_connection.
+      #
+      # Combines engine capability with config override. Returns false by
+      # default (safe fallback — separate pool). Subclasses override to
+      # return true for engines that support cross-schema/database queries.
+      def shared_pinned_connection?
+        false
+      end
+
+      # Qualify a pinned model's table_name so it targets the default
+      # tenant's tables from any tenant connection. Subclasses must
+      # implement when shared_pinned_connection? returns true.
+      def qualify_pinned_table_name(_klass)
+        raise(NotImplementedError,
+              "#{self.class}#qualify_pinned_table_name must be implemented when shared_pinned_connection? is true")
+      end
+
       # Process all pinned models — establish separate connections pinned to default tenant.
       def process_pinned_models
         return if Apartment.pinned_models.empty?
@@ -189,6 +208,16 @@ module Apartment
       # Connection config with string keys (used by subclasses to build tenant configs).
       def base_config
         connection_config.transform_keys(&:to_s)
+      end
+
+      # Detect whether a model has an explicit self.table_name = assignment
+      # (as opposed to Rails' lazy convention computation).
+      def explicit_table_name?(klass)
+        return false unless klass.instance_variable_defined?(:@table_name)
+
+        cached = klass.instance_variable_get(:@table_name)
+        computed = klass.send(:compute_table_name)
+        cached != computed
       end
 
       def rails_env

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -115,7 +115,8 @@ module Apartment
               "#{self.class}#qualify_pinned_table_name must be implemented when shared_pinned_connection? is true")
       end
 
-      # Process all pinned models — establish separate connections pinned to default tenant.
+      # Process all pinned models. When shared_pinned_connection? is true, qualifies
+      # table names for shared pool routing. Otherwise, establishes separate connections.
       def process_pinned_models
         return if Apartment.pinned_models.empty?
 
@@ -126,26 +127,21 @@ module Apartment
 
       # Process a single pinned model. Called by process_pinned_models (batch)
       # and by Apartment::Model.pin_tenant (when activated? is true).
+      #
+      # When shared_pinned_connection? is true, qualifies the table name so
+      # the model uses the tenant's pool (preserving transactional integrity).
+      # Otherwise, establishes a separate connection pool (required when
+      # cross-database queries are impossible).
       def process_pinned_model(klass)
-        # Idempotent: skip if already processed. Uses a class-level flag rather
-        # than connection_specification_name comparison — the spec name differs
-        # from ActiveRecord::Base for ApplicationRecord subclasses even before
-        # establish_connection, so it's not a reliable "already processed" signal.
-        return if klass.instance_variable_get(:@apartment_connection_established)
+        return if klass.instance_variable_get(:@apartment_pinned_processed)
 
-        # Use base_config (the adapter's raw connection config) rather than
-        # resolve_connection_config(default_tenant). For database-per-tenant
-        # strategies (MySQL, SQLite), resolve_connection_config would set the
-        # database key to the default tenant NAME (e.g. 'default'), not the
-        # actual default database (e.g. 'apartment_v4_test'). base_config
-        # points to the real default database.
-        klass.establish_connection(base_config)
-        klass.instance_variable_set(:@apartment_connection_established, true)
+        if shared_pinned_connection?
+          qualify_pinned_table_name(klass)
+        else
+          klass.establish_connection(pinned_model_config)
+        end
 
-        return unless Apartment.config.tenant_strategy == :schema
-
-        table = klass.table_name.split('.').last
-        klass.table_name = "#{default_tenant}.#{table}"
+        klass.instance_variable_set(:@apartment_pinned_processed, true)
       end
 
       # Deprecated: use process_pinned_models instead.
@@ -208,6 +204,19 @@ module Apartment
       # Connection config with string keys (used by subclasses to build tenant configs).
       def base_config
         connection_config.transform_keys(&:to_s)
+      end
+
+      # Connection config for pinned models on the separate-pool path.
+      # For schema strategy, pins schema_search_path to the default tenant
+      # (plus persistent schemas) so FK constraints resolve correctly.
+      # For database strategies, returns base_config unchanged.
+      def pinned_model_config
+        config = base_config
+        return config unless Apartment.config.tenant_strategy == :schema
+
+        persistent = Apartment.config.postgres_config&.persistent_schemas || []
+        search_path = [default_tenant, *persistent].map { |s| %("#{s}") }.join(',')
+        config.merge('schema_search_path' => search_path)
       end
 
       # Detect whether a model has an explicit self.table_name = assignment

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -10,6 +10,25 @@ module Apartment
     # to the environmentified tenant name. Lifecycle operations (create/drop)
     # execute DDL against the default connection.
     class Mysql2Adapter < AbstractAdapter
+      def shared_pinned_connection?
+        !Apartment.config.force_separate_pinned_pool
+      end
+
+      def qualify_pinned_table_name(klass)
+        db_name = base_config['database']
+
+        if explicit_table_name?(klass)
+          klass.instance_variable_set(:@apartment_original_table_name, klass.table_name)
+          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
+          table = klass.table_name.sub(/\A[^.]+\./, '')
+          klass.table_name = "#{db_name}.#{table}"
+        else
+          klass.instance_variable_set(:@apartment_qualification_path, :convention)
+          klass.table_name_prefix = "#{db_name}."
+          klass.reset_table_name
+        end
+      end
+
       def resolve_connection_config(tenant, base_config: nil)
         config = base_config || send(:base_config)
         config.merge('database' => environmentify(tenant))

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -17,7 +17,7 @@ module Apartment
       def qualify_pinned_table_name(klass)
         db_name = base_config['database']
 
-        if explicit_table_name?(klass)
+        if klass.apartment_explicit_table_name?
           original = klass.table_name
           table = original.sub(/\A[^.]+\./, '')
           klass.table_name = "#{db_name}.#{table}"

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -18,14 +18,17 @@ module Apartment
         db_name = base_config['database']
 
         if explicit_table_name?(klass)
-          klass.instance_variable_set(:@apartment_original_table_name, klass.table_name)
-          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
-          table = klass.table_name.sub(/\A[^.]+\./, '')
+          original = klass.table_name
+          table = original.sub(/\A[^.]+\./, '')
           klass.table_name = "#{db_name}.#{table}"
+          klass.instance_variable_set(:@apartment_original_table_name, original)
+          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
         else
-          klass.instance_variable_set(:@apartment_qualification_path, :convention)
+          original_prefix = klass.table_name_prefix
           klass.table_name_prefix = "#{db_name}."
           klass.reset_table_name
+          klass.instance_variable_set(:@apartment_original_table_name_prefix, original_prefix)
+          klass.instance_variable_set(:@apartment_qualification_path, :convention)
         end
       end
 

--- a/lib/apartment/adapters/mysql2_adapter.rb
+++ b/lib/apartment/adapters/mysql2_adapter.rb
@@ -21,14 +21,12 @@ module Apartment
           original = klass.table_name
           table = original.sub(/\A[^.]+\./, '')
           klass.table_name = "#{db_name}.#{table}"
-          klass.instance_variable_set(:@apartment_original_table_name, original)
-          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
+          klass.apartment_mark_processed!(:explicit, original)
         else
           original_prefix = klass.table_name_prefix
           klass.table_name_prefix = "#{db_name}."
           klass.reset_table_name
-          klass.instance_variable_set(:@apartment_original_table_name_prefix, original_prefix)
-          klass.instance_variable_set(:@apartment_qualification_path, :convention)
+          klass.apartment_mark_processed!(:convention, original_prefix)
         end
       end
 

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -18,14 +18,18 @@ module Apartment
 
       def qualify_pinned_table_name(klass)
         if explicit_table_name?(klass)
-          klass.instance_variable_set(:@apartment_original_table_name, klass.table_name)
-          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
-          table = klass.table_name.sub(/\A[^.]+\./, '')
+          original = klass.table_name
+          table = original.sub(/\A[^.]+\./, '')
           klass.table_name = "#{default_tenant}.#{table}"
+          # Set tracking ivars after mutation succeeds to avoid inconsistent state on failure.
+          klass.instance_variable_set(:@apartment_original_table_name, original)
+          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
         else
-          klass.instance_variable_set(:@apartment_qualification_path, :convention)
+          original_prefix = klass.table_name_prefix
           klass.table_name_prefix = "#{default_tenant}."
           klass.reset_table_name
+          klass.instance_variable_set(:@apartment_original_table_name_prefix, original_prefix)
+          klass.instance_variable_set(:@apartment_qualification_path, :convention)
         end
       end
 

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -12,6 +12,23 @@ module Apartment
     # Apartment.config.postgres_config. Lifecycle operations (create/drop)
     # execute DDL against the default connection.
     class PostgresqlSchemaAdapter < AbstractAdapter
+      def shared_pinned_connection?
+        !Apartment.config.force_separate_pinned_pool
+      end
+
+      def qualify_pinned_table_name(klass)
+        if explicit_table_name?(klass)
+          klass.instance_variable_set(:@apartment_original_table_name, klass.table_name)
+          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
+          table = klass.table_name.sub(/\A[^.]+\./, '')
+          klass.table_name = "#{default_tenant}.#{table}"
+        else
+          klass.instance_variable_set(:@apartment_qualification_path, :convention)
+          klass.table_name_prefix = "#{default_tenant}."
+          klass.reset_table_name
+        end
+      end
+
       def resolve_connection_config(tenant, base_config: nil)
         config = base_config || send(:base_config)
         persistent = Apartment.config.postgres_config&.persistent_schemas || []

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -17,7 +17,7 @@ module Apartment
       end
 
       def qualify_pinned_table_name(klass)
-        if explicit_table_name?(klass)
+        if klass.apartment_explicit_table_name?
           original = klass.table_name
           table = original.sub(/\A[^.]+\./, '')
           klass.table_name = "#{default_tenant}.#{table}"

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -21,15 +21,12 @@ module Apartment
           original = klass.table_name
           table = original.sub(/\A[^.]+\./, '')
           klass.table_name = "#{default_tenant}.#{table}"
-          # Set tracking ivars after mutation succeeds to avoid inconsistent state on failure.
-          klass.instance_variable_set(:@apartment_original_table_name, original)
-          klass.instance_variable_set(:@apartment_qualification_path, :explicit)
+          klass.apartment_mark_processed!(:explicit, original)
         else
           original_prefix = klass.table_name_prefix
           klass.table_name_prefix = "#{default_tenant}."
           klass.reset_table_name
-          klass.instance_variable_set(:@apartment_original_table_name_prefix, original_prefix)
-          klass.instance_variable_set(:@apartment_qualification_path, :convention)
+          klass.apartment_mark_processed!(:convention, original_prefix)
         end
       end
 

--- a/lib/apartment/concerns/model.rb
+++ b/lib/apartment/concerns/model.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
+# Class instance variables are the intended pattern here: each AR model class
+# tracks its own pinned state. Disabling for the entire file.
+# rubocop:disable ThreadSafety/ClassInstanceVariable
+
 require 'active_support/concern'
 
 module Apartment
   module Model
     extend ActiveSupport::Concern
 
-    class_methods do
+    class_methods do # rubocop:disable Metrics/BlockLength
       # Declare this model as pinned to the default tenant.
       # Pinned models bypass tenant switching in ConnectionHandling —
       # their connection always targets the default tenant's database/schema.
@@ -16,7 +20,7 @@ module Apartment
       def pin_tenant
         return if apartment_pinned?
 
-        @apartment_pinned = true # rubocop:disable ThreadSafety/ClassInstanceVariable
+        @apartment_pinned = true
         Apartment.register_pinned_model(self)
 
         # If Apartment is already activated, process immediately (Zeitwerk autoload path).
@@ -25,11 +29,53 @@ module Apartment
       end
 
       def apartment_pinned?
-        return true if @apartment_pinned == true # rubocop:disable ThreadSafety/ClassInstanceVariable
+        return true if @apartment_pinned == true
         return false unless superclass.respond_to?(:apartment_pinned?)
 
         superclass.apartment_pinned?
       end
+
+      # Whether process_pinned_model has already run for this class.
+      def apartment_pinned_processed?
+        @apartment_pinned_processed == true
+      end
+
+      # Record that qualification has been applied, and what path was used.
+      # Called by qualify_pinned_table_name (adapters) after mutations succeed,
+      # or by process_pinned_model after establish_connection on separate-pool path.
+      def apartment_mark_processed!(path = nil, original_value = nil)
+        @apartment_pinned_processed = true
+        @apartment_qualification_path = path
+        case path
+        when :explicit then @apartment_original_table_name = original_value
+        when :convention then @apartment_original_table_name_prefix = original_value
+        end
+      end
+
+      # Undo table name qualification and clear tracking state.
+      # Convention path: restore original prefix so reset_table_name recomputes.
+      # Explicit path: restore the original table_name that was overwritten.
+      # nil path: separate-pool models — no table name changes to undo.
+      def apartment_restore!
+        return unless @apartment_pinned_processed
+
+        case @apartment_qualification_path
+        when :convention
+          self.table_name_prefix = @apartment_original_table_name_prefix || ''
+          reset_table_name
+        when :explicit
+          self.table_name = @apartment_original_table_name if @apartment_original_table_name
+        when nil then nil
+        else
+          warn "[Apartment] #{name}: unexpected qualification_path #{@apartment_qualification_path.inspect}"
+        end
+
+        @apartment_pinned_processed = nil
+        @apartment_qualification_path = nil
+        @apartment_original_table_name = nil
+        @apartment_original_table_name_prefix = nil
+      end
     end
   end
 end
+# rubocop:enable ThreadSafety/ClassInstanceVariable

--- a/lib/apartment/concerns/model.rb
+++ b/lib/apartment/concerns/model.rb
@@ -28,6 +28,13 @@ module Apartment
         Apartment.process_pinned_model(self) if Apartment.activated?
       end
 
+      # Mark this class as pinned without triggering processing.
+      # Used by process_pinned_model for shim-registered models that
+      # need the concern included but are already being processed.
+      def apartment_mark_pinned!
+        @apartment_pinned = true
+      end
+
       def apartment_pinned?
         return true if @apartment_pinned == true
         return false unless superclass.respond_to?(:apartment_pinned?)

--- a/lib/apartment/concerns/model.rb
+++ b/lib/apartment/concerns/model.rb
@@ -35,6 +35,18 @@ module Apartment
         superclass.apartment_pinned?
       end
 
+      # Whether this model has an explicit self.table_name = assignment
+      # (as opposed to Rails' lazy convention computation). Returns false
+      # if the explicit value matches what convention would produce, since
+      # the convention path handles that case correctly.
+      # NOTE: compute_table_name is a private Rails API; tested against
+      # Rails main as a canary in CI.
+      def apartment_explicit_table_name?
+        return false unless instance_variable_defined?(:@table_name)
+
+        instance_variable_get(:@table_name) != send(:compute_table_name)
+      end
+
       # Whether process_pinned_model has already run for this class.
       def apartment_pinned_processed?
         @apartment_pinned_processed == true

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -22,7 +22,8 @@ module Apartment
                   :elevator, :elevator_options,
                   :tenant_not_found_handler, :active_record_log, :sql_query_tags,
                   :shard_key_prefix,
-                  :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations
+                  :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
+                  :force_separate_pinned_pool
 
     def initialize # rubocop:disable Metrics/AbcSize
       @tenant_strategy = nil
@@ -50,6 +51,7 @@ module Apartment
       @app_role = nil
       @schema_cache_per_tenant = false
       @check_pending_migrations = true
+      @force_separate_pinned_pool = false
     end
 
     def excluded_models=(list)
@@ -159,6 +161,11 @@ module Apartment
       unless [true, false].include?(@check_pending_migrations)
         raise(ConfigurationError,
               "check_pending_migrations must be true or false, got: #{@check_pending_migrations.inspect}")
+      end
+
+      unless [true, false].include?(@force_separate_pinned_pool)
+        raise(ConfigurationError,
+              "force_separate_pinned_pool must be true or false, got: #{@force_separate_pinned_pool.inspect}")
       end
 
       return if @shard_key_prefix.is_a?(String) && @shard_key_prefix.match?(/\A[a-z_][a-z0-9_]*\z/)

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -17,11 +17,15 @@ module Apartment
         return super if tenant.to_s == cfg.default_tenant.to_s
         return super unless Apartment.pool_manager
 
-        # Skip tenant override for Apartment pinned models.
-        # Uses explicit registry (not connection_specification_name heuristic)
-        # because ApplicationRecord subclasses have a different spec name than
-        # ActiveRecord::Base while sharing the same pool.
-        return super if self != ActiveRecord::Base && Apartment.pinned_model?(self)
+        # Skip tenant override for pinned models only when the adapter requires
+        # a separate pool (shared_pinned_connection? is false). When shared
+        # connections are supported (PG schema, MySQL single-server), pinned
+        # models fall through to the tenant pool lookup, preserving
+        # transactional integrity between pinned and tenant models.
+        if self != ActiveRecord::Base && Apartment.pinned_model?(self) &&
+           !Apartment.adapter&.shared_pinned_connection?
+          return super
+        end
 
         role = ActiveRecord::Base.current_role
         pool_key = "#{tenant}:#{role}"

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -19,11 +19,12 @@ module Apartment
 
         # Skip tenant override for pinned models only when the adapter requires
         # a separate pool (shared_pinned_connection? is false). When shared
-        # connections are supported (PG schema, MySQL single-server), pinned
-        # models fall through to the tenant pool lookup, preserving
-        # transactional integrity between pinned and tenant models.
+        # connections are supported (PG schema, MySQL), pinned models fall
+        # through to the tenant pool lookup, preserving transactional integrity.
+        # When adapter is nil (unconfigured), falls back to separate pool (safe default).
+        adapter = Apartment.adapter
         if self != ActiveRecord::Base && Apartment.pinned_model?(self) &&
-           !Apartment.adapter&.shared_pinned_connection?
+           (adapter.nil? || !adapter.shared_pinned_connection?)
           return super
         end
 

--- a/spec/integration/v4/excluded_models_spec.rb
+++ b/spec/integration/v4/excluded_models_spec.rb
@@ -66,13 +66,29 @@ RSpec.describe('v4 Pinned models integration (Apartment::Model)', :integration,
     end
   end
 
-  it 'pin_tenant establishes a dedicated connection for the model' do
-    expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+  context 'pinned model connection routing' do
+    it 'shares the tenant connection when shared_pinned_connection? is true' do
+      if Apartment.adapter.shared_pinned_connection?
+        expect(GlobalSetting.connection_specification_name).to(eq(ActiveRecord::Base.connection_specification_name))
+      else
+        skip 'adapter does not support shared pinned connections'
+      end
+    end
+
+    it 'uses a separate connection when shared_pinned_connection? is false' do
+      if Apartment.adapter.shared_pinned_connection?
+        skip 'adapter supports shared pinned connections'
+      else
+        expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+      end
+    end
   end
 
   it 'pin_tenant is idempotent' do
     expect { Apartment.adapter.process_pinned_models }.not_to(raise_error)
-    expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+    unless Apartment.adapter.shared_pinned_connection?
+      expect(GlobalSetting.connection_specification_name).not_to(eq(ActiveRecord::Base.connection_specification_name))
+    end
   end
 
   it 'pinned model queries always target the default database' do
@@ -122,6 +138,37 @@ RSpec.describe('v4 Pinned models integration (Apartment::Model)', :integration,
       Apartment::Tenant.switch('tenant_a') do
         Widget.create!(name: 'routed_correctly')
         expect(Widget.count).to(eq(1))
+      end
+    end
+  end
+
+  context 'transactional integrity (shared connection path)' do
+    it 'rolls back both pinned and tenant model writes on transaction rollback' do
+      skip 'requires shared_pinned_connection?' unless Apartment.adapter.shared_pinned_connection?
+
+      Apartment::Tenant.switch('tenant_a') do
+        ActiveRecord::Base.transaction do
+          Widget.create!(name: 'will_be_rolled_back')
+          GlobalSetting.create!(key: 'will_be_rolled_back', value: 'yes')
+          raise ActiveRecord::Rollback
+        end
+
+        expect(Widget.count).to(eq(0))
+        expect(GlobalSetting.where(key: 'will_be_rolled_back').count).to(eq(0))
+      end
+    end
+
+    it 'commits both pinned and tenant model writes on successful transaction' do
+      skip 'requires shared_pinned_connection?' unless Apartment.adapter.shared_pinned_connection?
+
+      Apartment::Tenant.switch('tenant_a') do
+        ActiveRecord::Base.transaction do
+          Widget.create!(name: 'committed')
+          GlobalSetting.create!(key: 'committed', value: 'yes')
+        end
+
+        expect(Widget.find_by(name: 'committed')).to(be_present)
+        expect(GlobalSetting.find_by(key: 'committed')).to(be_present)
       end
     end
   end

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -360,28 +360,126 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
   end
 
   describe '#process_pinned_models' do
-    it 'establishes connections for each pinned model' do
-      model_class = Class.new(ActiveRecord::Base) do
-        include Apartment::Model
+    context 'when shared_pinned_connection? is false (separate pool)' do
+      it 'calls establish_connection with pinned_model_config' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('SeparatePinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('separate_pinned'))
+        allow(model_class).to(receive(:table_name=))
+
+        SeparatePinned.pin_tenant
+
+        # Schema strategy: pinned_model_config includes schema_search_path
+        expected_config = {
+          'adapter' => 'postgresql', 'host' => 'localhost',
+          'schema_search_path' => '"public"'
+        }
+        expect(model_class).to(receive(:establish_connection)) do |arg|
+          expect(arg).to(eq(expected_config))
+        end
+
+        adapter.process_pinned_models
       end
-      stub_const('PinnedSetting', model_class)
-      allow(model_class).to(receive(:table_name).and_return('pinned_settings'))
-      allow(model_class).to(receive(:table_name=))
 
-      PinnedSetting.pin_tenant
+      it 'includes persistent schemas in pinned_model_config search_path' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('PersistentPinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('persistent_pinned'))
+        allow(model_class).to(receive(:table_name=))
 
-      # Pinned models use base_config (the adapter's raw connection config),
-      # not resolve_connection_config(default_tenant) — avoids database-per-tenant
-      # strategies setting database key to the tenant name instead of the real DB.
-      expected_config = { 'adapter' => 'postgresql', 'host' => 'localhost' }
-      expect(model_class).to(receive(:establish_connection)) do |arg|
-        expect(arg).to(eq(expected_config))
+        PersistentPinned.pin_tenant
+
+        Apartment.configure do |c|
+          c.tenant_strategy = :schema
+          c.tenants_provider = -> { %w[t1 t2] }
+          c.default_tenant = 'public'
+          c.force_separate_pinned_pool = true
+          c.configure_postgres { |pg| pg.persistent_schemas = %w[shared ext] }
+        end
+
+        expected_config = {
+          'adapter' => 'postgresql', 'host' => 'localhost',
+          'schema_search_path' => '"public","shared","ext"'
+        }
+        expect(model_class).to(receive(:establish_connection)) do |arg|
+          expect(arg).to(eq(expected_config))
+        end
+
+        adapter.process_pinned_models
       end
 
-      adapter.process_pinned_models
+      it 'uses plain base_config for database_name strategy' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('DbSeparatePinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('db_separate_pinned'))
+
+        DbSeparatePinned.pin_tenant
+
+        reconfigure(tenant_strategy: :database_name)
+
+        expected_config = { 'adapter' => 'postgresql', 'host' => 'localhost' }
+        expect(model_class).to(receive(:establish_connection)) do |arg|
+          expect(arg).to(eq(expected_config))
+        end
+
+        adapter.process_pinned_models
+      end
+
+      it 'does not call qualify_pinned_table_name' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('NoQualifyPinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('no_qualify_pinned'))
+        allow(model_class).to(receive(:establish_connection))
+
+        NoQualifyPinned.pin_tenant
+
+        expect(adapter).not_to(receive(:qualify_pinned_table_name))
+        adapter.process_pinned_models
+      end
     end
 
-    it 'skips models already processed (idempotent)' do
+    context 'when shared_pinned_connection? is true (shared pool)' do
+      before do
+        allow(adapter).to(receive(:shared_pinned_connection?).and_return(true))
+        allow(adapter).to(receive(:qualify_pinned_table_name))
+      end
+
+      it 'does not call establish_connection' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('SharedPinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('shared_pinned'))
+
+        SharedPinned.pin_tenant
+
+        expect(model_class).not_to(receive(:establish_connection))
+        adapter.process_pinned_models
+      end
+
+      it 'calls qualify_pinned_table_name' do
+        model_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('QualifyPinned', model_class)
+        allow(model_class).to(receive(:table_name).and_return('qualify_pinned'))
+
+        QualifyPinned.pin_tenant
+
+        expect(adapter).to(receive(:qualify_pinned_table_name).with(model_class))
+        adapter.process_pinned_models
+      end
+    end
+
+    it 'skips models already processed (idempotent via @apartment_pinned_processed)' do
       model_class = Class.new(ActiveRecord::Base) do
         include Apartment::Model
       end
@@ -395,38 +493,8 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
       allow(model_class).to(receive(:establish_connection))
       adapter.process_pinned_models
 
-      # Second call skips — @apartment_connection_established is set
+      # Second call skips — @apartment_pinned_processed is set
       expect(model_class).not_to(receive(:establish_connection))
-      adapter.process_pinned_models
-    end
-
-    it 'prefixes table name with default schema for schema strategy' do
-      model_class = Class.new(ActiveRecord::Base) do
-        include Apartment::Model
-      end
-      stub_const('SchemaPinned', model_class)
-      allow(model_class).to(receive(:establish_connection))
-      allow(model_class).to(receive(:table_name).and_return('schema_pinned'))
-
-      SchemaPinned.pin_tenant
-
-      expect(model_class).to(receive(:table_name=).with('public.schema_pinned'))
-      adapter.process_pinned_models
-    end
-
-    it 'does not prefix table name for database_name strategy' do
-      model_class = Class.new(ActiveRecord::Base) do
-        include Apartment::Model
-      end
-      stub_const('DbPinned', model_class)
-      allow(model_class).to(receive(:establish_connection))
-      allow(model_class).to(receive(:table_name).and_return('db_pinned'))
-
-      DbPinned.pin_tenant
-
-      reconfigure(tenant_strategy: :database_name)
-
-      expect(model_class).not_to(receive(:table_name=))
       adapter.process_pinned_models
     end
 

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -501,6 +501,22 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
     it 'does nothing when no models are pinned' do
       expect { adapter.process_pinned_models }.not_to(raise_error)
     end
+
+    it 'wraps errors with model-identifying context' do
+      model_class = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('BrokenPinned', model_class)
+
+      BrokenPinned.pin_tenant
+
+      allow(adapter).to(receive(:shared_pinned_connection?).and_return(true))
+      allow(adapter).to(receive(:qualify_pinned_table_name).and_raise(StandardError, 'boom'))
+
+      expect { adapter.process_pinned_models }.to(raise_error(
+        Apartment::ConfigurationError, /Failed to process pinned model BrokenPinned.*boom/
+      ))
+    end
   end
 
   describe '#process_excluded_models (deprecated)' do

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -493,6 +493,21 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
         raise_error(Apartment::ConfigurationError, /Failed to process pinned model BrokenPinned.*boom/)
       )
     end
+
+    it 'includes Apartment::Model and marks pinned for shim-registered models without the concern' do
+      # Simulate excluded_models shim: register without including the concern
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('ShimModel', klass)
+      Apartment.register_pinned_model(klass)
+
+      allow(klass).to(receive(:establish_connection))
+
+      adapter.process_pinned_models
+
+      expect(klass.respond_to?(:apartment_pinned?)).to(be(true))
+      expect(klass.apartment_pinned?).to(be(true))
+      expect(klass.apartment_pinned_processed?).to(be(true))
+    end
   end
 
   describe '#process_excluded_models (deprecated)' do

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -479,7 +479,7 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
       end
     end
 
-    it 'skips models already processed (idempotent via @apartment_pinned_processed)' do
+    it 'skips models already processed (idempotent via apartment_pinned_processed?)' do
       model_class = Class.new(ActiveRecord::Base) do
         include Apartment::Model
       end
@@ -493,7 +493,7 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
       allow(model_class).to(receive(:establish_connection))
       adapter.process_pinned_models
 
-      # Second call skips — @apartment_pinned_processed is set
+      # Second call skips — apartment_pinned_processed? returns true
       expect(model_class).not_to(receive(:establish_connection))
       adapter.process_pinned_models
     end

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -335,30 +335,6 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
     end
   end
 
-  describe '#explicit_table_name? (private)' do
-    it 'returns false when @table_name is not set' do
-      klass = Class.new(ActiveRecord::Base)
-      stub_const('NoTableName', klass)
-      expect(adapter.send(:explicit_table_name?, klass)).to(be(false))
-    end
-
-    it 'returns false when cached equals computed (convention naming)' do
-      klass = Class.new(ActiveRecord::Base)
-      stub_const('ConventionModel', klass)
-      allow(klass).to(receive(:compute_table_name).and_return('convention_models'))
-      klass.instance_variable_set(:@table_name, 'convention_models')
-      expect(adapter.send(:explicit_table_name?, klass)).to(be(false))
-    end
-
-    it 'returns true when cached differs from computed (explicit assignment)' do
-      klass = Class.new(ActiveRecord::Base)
-      stub_const('ExplicitModel', klass)
-      allow(klass).to(receive(:compute_table_name).and_return('explicit_models'))
-      klass.instance_variable_set(:@table_name, 'custom_table')
-      expect(adapter.send(:explicit_table_name?, klass)).to(be(true))
-    end
-  end
-
   describe '#process_pinned_models' do
     context 'when shared_pinned_connection? is false (separate pool)' do
       it 'calls establish_connection with pinned_model_config' do

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -513,9 +513,9 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
       allow(adapter).to(receive(:shared_pinned_connection?).and_return(true))
       allow(adapter).to(receive(:qualify_pinned_table_name).and_raise(StandardError, 'boom'))
 
-      expect { adapter.process_pinned_models }.to(raise_error(
-        Apartment::ConfigurationError, /Failed to process pinned model BrokenPinned.*boom/
-      ))
+      expect { adapter.process_pinned_models }.to(
+        raise_error(Apartment::ConfigurationError, /Failed to process pinned model BrokenPinned.*boom/)
+      )
     end
   end
 

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -329,9 +329,9 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
   describe '#qualify_pinned_table_name' do
     it 'raises NotImplementedError on the abstract class' do
       klass = Class.new(ActiveRecord::Base)
-      expect { adapter.qualify_pinned_table_name(klass) }.to(raise_error(
-        NotImplementedError, /qualify_pinned_table_name must be implemented/
-      ))
+      expect { adapter.qualify_pinned_table_name(klass) }.to(
+        raise_error(NotImplementedError, /qualify_pinned_table_name must be implemented/)
+      )
     end
   end
 

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -320,6 +320,45 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter) do
     end
   end
 
+  describe '#shared_pinned_connection?' do
+    it 'returns false by default (safe fallback)' do
+      expect(adapter.shared_pinned_connection?).to(be(false))
+    end
+  end
+
+  describe '#qualify_pinned_table_name' do
+    it 'raises NotImplementedError on the abstract class' do
+      klass = Class.new(ActiveRecord::Base)
+      expect { adapter.qualify_pinned_table_name(klass) }.to(raise_error(
+        NotImplementedError, /qualify_pinned_table_name must be implemented/
+      ))
+    end
+  end
+
+  describe '#explicit_table_name? (private)' do
+    it 'returns false when @table_name is not set' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('NoTableName', klass)
+      expect(adapter.send(:explicit_table_name?, klass)).to(be(false))
+    end
+
+    it 'returns false when cached equals computed (convention naming)' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('ConventionModel', klass)
+      allow(klass).to(receive(:compute_table_name).and_return('convention_models'))
+      klass.instance_variable_set(:@table_name, 'convention_models')
+      expect(adapter.send(:explicit_table_name?, klass)).to(be(false))
+    end
+
+    it 'returns true when cached differs from computed (explicit assignment)' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('ExplicitModel', klass)
+      allow(klass).to(receive(:compute_table_name).and_return('explicit_models'))
+      klass.instance_variable_set(:@table_name, 'custom_table')
+      expect(adapter.send(:explicit_table_name?, klass)).to(be(true))
+    end
+  end
+
   describe '#process_pinned_models' do
     it 'establishes connections for each pinned model' do
       model_class = Class.new(ActiveRecord::Base) do

--- a/spec/unit/adapters/mysql2_adapter_spec.rb
+++ b/spec/unit/adapters/mysql2_adapter_spec.rb
@@ -115,7 +115,7 @@ RSpec.shared_examples('a MySQL adapter') do
 
   describe '#qualify_pinned_table_name' do
     it 'qualifies convention-named model with database name from base_config' do
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('MysqlPinned', klass)
 
       expect(klass).to(receive(:table_name_prefix=).with('myapp.'))
@@ -125,7 +125,7 @@ RSpec.shared_examples('a MySQL adapter') do
     end
 
     it 'qualifies explicit table_name with database name from base_config' do
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('MysqlExplicit', klass)
       klass.instance_variable_set(:@table_name, 'custom_jobs')
       allow(klass).to(receive_messages(compute_table_name: 'mysql_explicits', table_name: 'custom_jobs'))
@@ -136,7 +136,7 @@ RSpec.shared_examples('a MySQL adapter') do
     end
 
     it 'strips existing database prefix before re-qualifying' do
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('MysqlRequalify', klass)
       klass.instance_variable_set(:@table_name, 'old_db.jobs')
       allow(klass).to(receive_messages(compute_table_name: 'mysql_requalifies', table_name: 'old_db.jobs'))

--- a/spec/unit/adapters/mysql2_adapter_spec.rb
+++ b/spec/unit/adapters/mysql2_adapter_spec.rb
@@ -102,6 +102,51 @@ RSpec.shared_examples('a MySQL adapter') do
     end
   end
 
+  describe '#shared_pinned_connection?' do
+    it 'returns true (MySQL supports cross-database queries on same server)' do
+      expect(adapter.shared_pinned_connection?).to(be(true))
+    end
+
+    it 'returns false when force_separate_pinned_pool is true' do
+      reconfigure(force_separate_pinned_pool: true)
+      expect(adapter.shared_pinned_connection?).to(be(false))
+    end
+  end
+
+  describe '#qualify_pinned_table_name' do
+    it 'qualifies convention-named model with database name from base_config' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('MysqlPinned', klass)
+
+      expect(klass).to(receive(:table_name_prefix=).with('myapp.'))
+      expect(klass).to(receive(:reset_table_name))
+
+      adapter.qualify_pinned_table_name(klass)
+    end
+
+    it 'qualifies explicit table_name with database name from base_config' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('MysqlExplicit', klass)
+      klass.instance_variable_set(:@table_name, 'custom_jobs')
+      allow(klass).to(receive_messages(compute_table_name: 'mysql_explicits', table_name: 'custom_jobs'))
+
+      expect(klass).to(receive(:table_name=).with('myapp.custom_jobs'))
+
+      adapter.qualify_pinned_table_name(klass)
+    end
+
+    it 'strips existing database prefix before re-qualifying' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('MysqlRequalify', klass)
+      klass.instance_variable_set(:@table_name, 'old_db.jobs')
+      allow(klass).to(receive_messages(compute_table_name: 'mysql_requalifies', table_name: 'old_db.jobs'))
+
+      expect(klass).to(receive(:table_name=).with('myapp.jobs'))
+
+      adapter.qualify_pinned_table_name(klass)
+    end
+  end
+
   describe '#create (via create_tenant)' do
     let(:connection) { double('Connection') }
 

--- a/spec/unit/adapters/postgresql_schema_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_schema_adapter_spec.rb
@@ -46,6 +46,52 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
     end
   end
 
+  describe '#shared_pinned_connection?' do
+    it 'returns true (schemas share a catalog)' do
+      expect(adapter.shared_pinned_connection?).to(be(true))
+    end
+
+    it 'returns false when force_separate_pinned_pool is true' do
+      reconfigure { |c| c.force_separate_pinned_pool = true }
+      expect(adapter.shared_pinned_connection?).to(be(false))
+    end
+  end
+
+  describe '#qualify_pinned_table_name' do
+    it 'qualifies convention-named model via table_name_prefix + reset_table_name' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('DelayedJob', klass)
+
+      expect(klass).to(receive(:table_name_prefix=).with('public.'))
+      expect(klass).to(receive(:reset_table_name))
+
+      adapter.qualify_pinned_table_name(klass)
+    end
+
+    it 'qualifies explicit table_name via direct assignment' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('ExplicitPinned', klass)
+      klass.instance_variable_set(:@table_name, 'custom_jobs')
+      allow(klass).to(receive_messages(compute_table_name: 'explicit_pinneds', table_name: 'custom_jobs'))
+
+      expect(klass).to(receive(:table_name=).with('public.custom_jobs'))
+      expect(klass).not_to(receive(:table_name_prefix=))
+
+      adapter.qualify_pinned_table_name(klass)
+    end
+
+    it 'strips existing schema prefix before re-qualifying' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('RequalifyPinned', klass)
+      klass.instance_variable_set(:@table_name, 'old_schema.jobs')
+      allow(klass).to(receive_messages(compute_table_name: 'requalify_pinneds', table_name: 'old_schema.jobs'))
+
+      expect(klass).to(receive(:table_name=).with('public.jobs'))
+
+      adapter.qualify_pinned_table_name(klass)
+    end
+  end
+
   describe '#resolve_connection_config' do
     it 'returns config with schema_search_path set to tenant name' do
       result = adapter.resolve_connection_config('acme')

--- a/spec/unit/adapters/postgresql_schema_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_schema_adapter_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
 
   describe '#qualify_pinned_table_name' do
     it 'qualifies convention-named model via table_name_prefix + reset_table_name' do
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('DelayedJob', klass)
 
       expect(klass).to(receive(:table_name_prefix=).with('public.'))
@@ -69,7 +69,7 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
     end
 
     it 'qualifies explicit table_name via direct assignment' do
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('ExplicitPinned', klass)
       klass.instance_variable_set(:@table_name, 'custom_jobs')
       allow(klass).to(receive_messages(compute_table_name: 'explicit_pinneds', table_name: 'custom_jobs'))
@@ -81,7 +81,7 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
     end
 
     it 'strips existing schema prefix before re-qualifying' do
-      klass = Class.new(ActiveRecord::Base)
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('RequalifyPinned', klass)
       klass.instance_variable_set(:@table_name, 'old_schema.jobs')
       allow(klass).to(receive_messages(compute_table_name: 'requalify_pinneds', table_name: 'old_schema.jobs'))
@@ -91,8 +91,8 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
       adapter.qualify_pinned_table_name(klass)
     end
 
-    it 'saves original table_name_prefix on convention path' do
-      klass = Class.new(ActiveRecord::Base)
+    it 'marks model as processed with original prefix on convention path' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('PrefixPinned', klass)
       allow(klass).to(receive(:table_name_prefix).and_return('myapp_'))
       allow(klass).to(receive(:table_name_prefix=))
@@ -100,11 +100,11 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
 
       adapter.qualify_pinned_table_name(klass)
 
-      expect(klass.instance_variable_get(:@apartment_original_table_name_prefix)).to(eq('myapp_'))
+      expect(klass.apartment_pinned_processed?).to(be(true))
     end
 
-    it 'sets ivars after mutation on explicit path' do
-      klass = Class.new(ActiveRecord::Base)
+    it 'marks model as processed after mutation on explicit path' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
       stub_const('IvarOrderPinned', klass)
       klass.instance_variable_set(:@table_name, 'custom_jobs')
       allow(klass).to(receive_messages(compute_table_name: 'ivar_order_pinneds', table_name: 'custom_jobs'))
@@ -112,8 +112,7 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
 
       adapter.qualify_pinned_table_name(klass)
 
-      expect(klass.instance_variable_get(:@apartment_original_table_name)).to(eq('custom_jobs'))
-      expect(klass.instance_variable_get(:@apartment_qualification_path)).to(eq(:explicit))
+      expect(klass.apartment_pinned_processed?).to(be(true))
     end
   end
 

--- a/spec/unit/adapters/postgresql_schema_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_schema_adapter_spec.rb
@@ -90,6 +90,31 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
 
       adapter.qualify_pinned_table_name(klass)
     end
+
+    it 'saves original table_name_prefix on convention path' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('PrefixPinned', klass)
+      allow(klass).to(receive(:table_name_prefix).and_return('myapp_'))
+      allow(klass).to(receive(:table_name_prefix=))
+      allow(klass).to(receive(:reset_table_name))
+
+      adapter.qualify_pinned_table_name(klass)
+
+      expect(klass.instance_variable_get(:@apartment_original_table_name_prefix)).to(eq('myapp_'))
+    end
+
+    it 'sets ivars after mutation on explicit path' do
+      klass = Class.new(ActiveRecord::Base)
+      stub_const('IvarOrderPinned', klass)
+      klass.instance_variable_set(:@table_name, 'custom_jobs')
+      allow(klass).to(receive_messages(compute_table_name: 'ivar_order_pinneds', table_name: 'custom_jobs'))
+      allow(klass).to(receive(:table_name=))
+
+      adapter.qualify_pinned_table_name(klass)
+
+      expect(klass.instance_variable_get(:@apartment_original_table_name)).to(eq('custom_jobs'))
+      expect(klass.instance_variable_get(:@apartment_qualification_path)).to(eq(:explicit))
+    end
   end
 
   describe '#resolve_connection_config' do

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -100,6 +100,63 @@ RSpec.describe(Apartment) do
 
       expect { described_class.adapter }.to(raise_error(Apartment::ConfigurationError))
     end
+
+    it 'restores convention-path table_name_prefix on pinned models' do
+      klass = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('ConventionTeardown', klass)
+      allow(klass).to(receive(:table_name_prefix).and_return(''))
+      allow(klass).to(receive(:table_name_prefix=))
+      allow(klass).to(receive(:reset_table_name))
+
+      ConventionTeardown.pin_tenant
+      # Simulate convention-path qualification
+      klass.instance_variable_set(:@apartment_pinned_processed, true)
+      klass.instance_variable_set(:@apartment_qualification_path, :convention)
+      klass.instance_variable_set(:@apartment_original_table_name_prefix, 'myapp_')
+
+      described_class.clear_config
+
+      expect(klass).to(have_received(:table_name_prefix=).with('myapp_'))
+      expect(klass).to(have_received(:reset_table_name))
+      expect(klass.instance_variable_defined?(:@apartment_pinned_processed)).to(be(false))
+      expect(klass.instance_variable_defined?(:@apartment_qualification_path)).to(be(false))
+      expect(klass.instance_variable_defined?(:@apartment_original_table_name_prefix)).to(be(false))
+    end
+
+    it 'restores explicit-path table_name on pinned models' do
+      klass = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('ExplicitTeardown', klass)
+      allow(klass).to(receive(:table_name=))
+
+      ExplicitTeardown.pin_tenant
+      klass.instance_variable_set(:@apartment_pinned_processed, true)
+      klass.instance_variable_set(:@apartment_qualification_path, :explicit)
+      klass.instance_variable_set(:@apartment_original_table_name, 'custom_jobs')
+
+      described_class.clear_config
+
+      expect(klass).to(have_received(:table_name=).with('custom_jobs'))
+      expect(klass.instance_variable_defined?(:@apartment_pinned_processed)).to(be(false))
+      expect(klass.instance_variable_defined?(:@apartment_original_table_name)).to(be(false))
+    end
+
+    it 'handles separate-pool path (nil qualification_path) without error' do
+      klass = Class.new(ActiveRecord::Base) do
+        include Apartment::Model
+      end
+      stub_const('SeparatePoolTeardown', klass)
+
+      SeparatePoolTeardown.pin_tenant
+      klass.instance_variable_set(:@apartment_pinned_processed, true)
+      # No @apartment_qualification_path set (separate-pool path)
+
+      expect { described_class.clear_config }.not_to(raise_error)
+      expect(klass.instance_variable_defined?(:@apartment_pinned_processed)).to(be(false))
+    end
   end
 
   describe '.configure' do

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -111,18 +111,13 @@ RSpec.describe(Apartment) do
       allow(klass).to(receive(:reset_table_name))
 
       ConventionTeardown.pin_tenant
-      # Simulate convention-path qualification
-      klass.instance_variable_set(:@apartment_pinned_processed, true)
-      klass.instance_variable_set(:@apartment_qualification_path, :convention)
-      klass.instance_variable_set(:@apartment_original_table_name_prefix, 'myapp_')
+      klass.apartment_mark_processed!(:convention, 'myapp_')
 
       described_class.clear_config
 
       expect(klass).to(have_received(:table_name_prefix=).with('myapp_'))
       expect(klass).to(have_received(:reset_table_name))
-      expect(klass.instance_variable_defined?(:@apartment_pinned_processed)).to(be(false))
-      expect(klass.instance_variable_defined?(:@apartment_qualification_path)).to(be(false))
-      expect(klass.instance_variable_defined?(:@apartment_original_table_name_prefix)).to(be(false))
+      expect(klass.apartment_pinned_processed?).to(be(false))
     end
 
     it 'restores explicit-path table_name on pinned models' do
@@ -133,15 +128,12 @@ RSpec.describe(Apartment) do
       allow(klass).to(receive(:table_name=))
 
       ExplicitTeardown.pin_tenant
-      klass.instance_variable_set(:@apartment_pinned_processed, true)
-      klass.instance_variable_set(:@apartment_qualification_path, :explicit)
-      klass.instance_variable_set(:@apartment_original_table_name, 'custom_jobs')
+      klass.apartment_mark_processed!(:explicit, 'custom_jobs')
 
       described_class.clear_config
 
       expect(klass).to(have_received(:table_name=).with('custom_jobs'))
-      expect(klass.instance_variable_defined?(:@apartment_pinned_processed)).to(be(false))
-      expect(klass.instance_variable_defined?(:@apartment_original_table_name)).to(be(false))
+      expect(klass.apartment_pinned_processed?).to(be(false))
     end
 
     it 'handles separate-pool path (nil qualification_path) without error' do
@@ -151,11 +143,10 @@ RSpec.describe(Apartment) do
       stub_const('SeparatePoolTeardown', klass)
 
       SeparatePoolTeardown.pin_tenant
-      klass.instance_variable_set(:@apartment_pinned_processed, true)
-      # No @apartment_qualification_path set (separate-pool path)
+      klass.apartment_mark_processed!
 
       expect { described_class.clear_config }.not_to(raise_error)
-      expect(klass.instance_variable_defined?(:@apartment_pinned_processed)).to(be(false))
+      expect(klass.apartment_pinned_processed?).to(be(false))
     end
   end
 

--- a/spec/unit/concerns/model_spec.rb
+++ b/spec/unit/concerns/model_spec.rb
@@ -103,4 +103,82 @@ RSpec.describe(Apartment::Model) do
       expect(klass.respond_to?(:apartment_pinned?)).to(be(false))
     end
   end
+
+  describe '.apartment_pinned_processed?' do
+    it 'returns false before processing' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      expect(klass.apartment_pinned_processed?).to(be(false))
+    end
+
+    it 'returns true after apartment_mark_processed!' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      klass.apartment_mark_processed!
+      expect(klass.apartment_pinned_processed?).to(be(true))
+    end
+  end
+
+  describe '.apartment_mark_processed!' do
+    it 'records convention path with original prefix' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      klass.apartment_mark_processed!(:convention, 'myapp_')
+
+      expect(klass.apartment_pinned_processed?).to(be(true))
+    end
+
+    it 'records explicit path with original table name' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      klass.apartment_mark_processed!(:explicit, 'custom_jobs')
+
+      expect(klass.apartment_pinned_processed?).to(be(true))
+    end
+
+    it 'records nil path for separate-pool models' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      klass.apartment_mark_processed!
+
+      expect(klass.apartment_pinned_processed?).to(be(true))
+    end
+  end
+
+  describe '.apartment_restore!' do
+    it 'restores convention-path prefix and resets table name' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      stub_const('ConventionRestore', klass)
+      allow(klass).to(receive(:table_name_prefix=))
+      allow(klass).to(receive(:reset_table_name))
+
+      klass.apartment_mark_processed!(:convention, 'myapp_')
+      klass.apartment_restore!
+
+      expect(klass).to(have_received(:table_name_prefix=).with('myapp_'))
+      expect(klass).to(have_received(:reset_table_name))
+      expect(klass.apartment_pinned_processed?).to(be(false))
+    end
+
+    it 'restores explicit-path original table name' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      stub_const('ExplicitRestore', klass)
+      allow(klass).to(receive(:table_name=))
+
+      klass.apartment_mark_processed!(:explicit, 'custom_jobs')
+      klass.apartment_restore!
+
+      expect(klass).to(have_received(:table_name=).with('custom_jobs'))
+      expect(klass.apartment_pinned_processed?).to(be(false))
+    end
+
+    it 'is a no-op for separate-pool path' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      stub_const('SeparateRestore', klass)
+
+      klass.apartment_mark_processed!
+      expect { klass.apartment_restore! }.not_to(raise_error)
+      expect(klass.apartment_pinned_processed?).to(be(false))
+    end
+
+    it 'is a no-op when not processed' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      expect { klass.apartment_restore! }.not_to(raise_error)
+    end
+  end
 end

--- a/spec/unit/concerns/model_spec.rb
+++ b/spec/unit/concerns/model_spec.rb
@@ -65,6 +65,30 @@ RSpec.describe(Apartment::Model) do
     end
   end
 
+  describe '.apartment_explicit_table_name?' do
+    it 'returns false when @table_name is not set' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      stub_const('NoTableName', klass)
+      expect(klass.apartment_explicit_table_name?).to(be(false))
+    end
+
+    it 'returns false when cached equals computed (convention naming)' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      stub_const('ConventionModel', klass)
+      allow(klass).to(receive(:compute_table_name).and_return('convention_models'))
+      klass.instance_variable_set(:@table_name, 'convention_models')
+      expect(klass.apartment_explicit_table_name?).to(be(false))
+    end
+
+    it 'returns true when cached differs from computed (explicit assignment)' do
+      klass = Class.new(ActiveRecord::Base) { include Apartment::Model }
+      stub_const('ExplicitModel', klass)
+      allow(klass).to(receive(:compute_table_name).and_return('explicit_models'))
+      klass.instance_variable_set(:@table_name, 'custom_table')
+      expect(klass.apartment_explicit_table_name?).to(be(true))
+    end
+  end
+
   describe '.apartment_pinned?' do
     it 'returns false for unpinned models' do
       klass = Class.new(ActiveRecord::Base) do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.postgres_config).to(be_nil) }
     it { expect(config.mysql_config).to(be_nil) }
     it { expect(config.shard_key_prefix).to(eq('apartment')) }
+    it { expect(config.force_separate_pinned_pool).to(be(false)) }
   end
 
   describe '#tenant_strategy=' do
@@ -266,6 +267,29 @@ RSpec.describe(Apartment::Config) do
       it 'accepts false' do
         config.check_pending_migrations = false
         expect { config.validate! }.not_to(raise_error)
+      end
+    end
+
+    describe '#force_separate_pinned_pool' do
+      it 'accepts true' do
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.force_separate_pinned_pool = true
+        expect { config.validate! }.not_to(raise_error)
+      end
+
+      it 'accepts false' do
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.force_separate_pinned_pool = false
+        expect { config.validate! }.not_to(raise_error)
+      end
+
+      it 'rejects non-boolean values' do
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.force_separate_pinned_pool = 'yes'
+        expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /force_separate_pinned_pool/))
       end
     end
   end

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
 
   let(:mock_adapter) do
     double('AbstractAdapter',
-           validated_connection_config: { 'adapter' => 'sqlite3', 'database' => ':memory:' })
+           validated_connection_config: { 'adapter' => 'sqlite3', 'database' => ':memory:' },
+           shared_pinned_connection?: false)
   end
 
   # Capture the default pool with no tenant set, for comparison in tests.
@@ -271,39 +272,77 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
         require_relative('../../../lib/apartment/concerns/model')
       end
 
-      it 'returns the default pool for a pinned AR::Base subclass when tenant is set' do
-        pinned_class = Class.new(ActiveRecord::Base) do
-          include Apartment::Model
+      context 'when shared_pinned_connection? is false (separate pool)' do
+        before do
+          allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
         end
-        stub_const('PinnedBypassModel', pinned_class)
-        pinned_class.pin_tenant
 
-        Apartment::Current.tenant = 'acme'
-        # Pinned class must use super (default pool), not the tenant pool
-        expect(pinned_class.connection_pool).to(equal(default_pool))
+        it 'returns the default pool for a pinned AR::Base subclass when tenant is set' do
+          pinned_class = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedBypassModel', pinned_class)
+          pinned_class.pin_tenant
+
+          Apartment::Current.tenant = 'acme'
+          expect(pinned_class.connection_pool).to(equal(default_pool))
+        end
+
+        it 'bypasses for STI subclass of a pinned model' do
+          parent = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedParentBypass', parent)
+          parent.pin_tenant
+
+          child = Class.new(parent)
+          stub_const('PinnedChildBypass', child)
+
+          Apartment::Current.tenant = 'acme'
+          expect(child.connection_pool).to(equal(default_pool))
+        end
+      end
+
+      context 'when shared_pinned_connection? is true (shared pool)' do
+        before do
+          allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(true))
+        end
+
+        it 'returns the tenant pool for a pinned model (transactional integrity)' do
+          pinned_class = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedSharedModel', pinned_class)
+          pinned_class.pin_tenant
+
+          Apartment::Current.tenant = 'acme'
+          expect(pinned_class.connection_pool).not_to(equal(default_pool))
+        end
+
+        it 'returns the tenant pool for STI subclass of a pinned model' do
+          parent = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedSharedParent', parent)
+          parent.pin_tenant
+
+          child = Class.new(parent)
+          stub_const('PinnedSharedChild', child)
+
+          Apartment::Current.tenant = 'acme'
+          expect(child.connection_pool).not_to(equal(default_pool))
+        end
       end
 
       it 'does not bypass for ActiveRecord::Base itself' do
+        allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
         Apartment::Current.tenant = 'acme'
         tenant_pool = ActiveRecord::Base.connection_pool
         expect(tenant_pool).not_to(equal(default_pool))
       end
 
-      it 'bypasses for STI subclass of a pinned model' do
-        parent = Class.new(ActiveRecord::Base) do
-          include Apartment::Model
-        end
-        stub_const('PinnedParentBypass', parent)
-        parent.pin_tenant
-
-        child = Class.new(parent)
-        stub_const('PinnedChildBypass', child)
-
-        Apartment::Current.tenant = 'acme'
-        expect(child.connection_pool).to(equal(default_pool))
-      end
-
       it 'does not bypass for an unpinned AR::Base subclass' do
+        allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
         unpinned = Class.new(ActiveRecord::Base)
         stub_const('UnpinnedWidget', unpinned)
 
@@ -317,19 +356,49 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
         require_relative('../../../lib/apartment/concerns/model')
       end
 
-      it 'returns the default pool for a pinned model while iterating tenants' do
-        pinned_class = Class.new(ActiveRecord::Base) do
-          include Apartment::Model
-        end
-        stub_const('PinnedInsideEach', pinned_class)
-        pinned_class.pin_tenant
-
-        pools_during_each = []
-        Apartment::Tenant.each(%w[acme widgets]) do |_tenant|
-          pools_during_each << pinned_class.connection_pool
+      context 'when shared_pinned_connection? is false (separate pool)' do
+        before do
+          allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(false))
         end
 
-        expect(pools_during_each).to(all(equal(default_pool)))
+        it 'returns the default pool for a pinned model while iterating tenants' do
+          pinned_class = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedInsideEach', pinned_class)
+          pinned_class.pin_tenant
+
+          pools_during_each = []
+          Apartment::Tenant.each(%w[acme widgets]) do |_tenant|
+            pools_during_each << pinned_class.connection_pool
+          end
+
+          expect(pools_during_each).to(all(equal(default_pool)))
+        end
+      end
+
+      context 'when shared_pinned_connection? is true (shared pool)' do
+        before do
+          allow(mock_adapter).to(receive(:shared_pinned_connection?).and_return(true))
+        end
+
+        it 'returns the tenant pool for a pinned model while iterating tenants' do
+          pinned_class = Class.new(ActiveRecord::Base) do
+            include Apartment::Model
+          end
+          stub_const('PinnedSharedEach', pinned_class)
+          pinned_class.pin_tenant
+
+          pools_during_each = []
+          Apartment::Tenant.each(%w[acme widgets]) do |_tenant|
+            pools_during_each << pinned_class.connection_pool
+          end
+
+          pools_during_each.each do |pool|
+            expect(pool).not_to(equal(default_pool))
+          end
+          expect(pools_during_each[0]).not_to(equal(pools_during_each[1]))
+        end
       end
 
       it 'routes unpinned models to tenant pools while iterating' do


### PR DESCRIPTION
## Summary

Pinned models on PG schema and MySQL now share the tenant's connection pool via qualified table names instead of getting their own pool via `establish_connection`. This enables transactional integrity between pinned and tenant model writes and fixes FK constraint resolution on the separate-pool path.

Incorporates the architectural approach from #367 by @henkesn. Reimplemented against current `main` with review feedback applied.

Closes #367

## What changed

**Core: dual-path pinned model connections**
- `shared_pinned_connection?` template method on adapters — single decision point combining engine capability + `force_separate_pinned_pool` config override
- Shared path (PG schema, MySQL): `qualify_pinned_table_name` qualifies the table name; model stays on the tenant's connection pool
- Separate path (PG database, SQLite, or `force_separate_pinned_pool: true`): `establish_connection(pinned_model_config)` with `schema_search_path` FK fix
- `ConnectionHandling#connection_pool` conditionally routes pinned models through tenant pools

**Hybrid table name qualification**
- Convention-named models: sets `table_name_prefix` + `reset_table_name` (preserves Rails' `compute_table_name` assembly including suffix and nested-class segments)
- Explicit `self.table_name` models: direct `table_name=` assignment with single-segment prefix stripping
- `apartment_explicit_table_name?` detects which path to use (compares `@table_name` vs `compute_table_name`)

**SOLID encapsulation in `Apartment::Model` concern**
- All pinned model state management moved from external ivar manipulation into the concern's own class methods
- `apartment_pinned_processed?` / `apartment_mark_processed!` / `apartment_restore!` — qualification lifecycle
- `apartment_explicit_table_name?` — table name detection (was private method on adapter reaching into model ivars)
- `apartment_mark_pinned!` — sets pinned flag without triggering processing (avoids `pin_tenant` recursion for shim models)
- `Apartment.pinned_model?` now delegates to `klass.apartment_pinned?` (class answers its own question)
- `clear_config` calls `klass.apartment_restore!` — one line, no `instance_variable_*` from outside

**Shim compatibility (`excluded_models`)**
- `process_pinned_model` dynamically includes `Apartment::Model` on shim-registered classes that lack the concern, then calls `apartment_mark_pinned!` to set the pinned flag without recursion
- New code should use `include Apartment::Model` + `pin_tenant` explicitly; dynamic include is a legacy shim accommodation

**Config + escape hatch**
- `force_separate_pinned_pool` boolean (default `false`) — opt out of shared connections for multi-server MySQL or apps needing pinned writes to survive tenant rollbacks

**CI**
- Rails main added to unit test matrix as canary for `compute_table_name` private API (`continue-on-error`, all Ruby versions)

## Files changed (22 files, +2275 / -113)

| Area | Files | Change |
|---|---|---|
| Config | `lib/apartment/config.rb` | `force_separate_pinned_pool` option |
| Core | `lib/apartment/adapters/abstract_adapter.rb` | `shared_pinned_connection?`, dual-path `process_pinned_model`, `pinned_model_config`, error context wrapper, shim include |
| Core | `lib/apartment/concerns/model.rb` | `apartment_explicit_table_name?`, `apartment_mark_processed!`, `apartment_restore!`, `apartment_pinned_processed?`, `apartment_mark_pinned!` |
| Adapters | `lib/apartment/adapters/postgresql_schema_adapter.rb` | `shared_pinned_connection?` + `qualify_pinned_table_name` (schema prefix) |
| Adapters | `lib/apartment/adapters/mysql2_adapter.rb` | `shared_pinned_connection?` + `qualify_pinned_table_name` (database prefix) |
| Routing | `lib/apartment/patches/connection_handling.rb` | Conditional pinned model routing with explicit nil guard |
| Teardown | `lib/apartment.rb` | `clear_config` delegates to `apartment_restore!`; `pinned_model?` delegates to concern |
| CI | `.github/workflows/ci.yml` | Rails main canary in unit test matrix |
| Docs | `CLAUDE.md`, `AGENTS.md`, `lib/apartment/CLAUDE.md` | Code style section, Model concern API docs, shim compatibility note |
| Docs | `docs/upgrading-to-v4.md` | Pinned Model Connections upgrade section |
| Docs | `docs/designs/v4-shared-pinned-connections.md` | Design spec status → Implemented |
| Tests | `spec/unit/**` (8 files) | 100+ new examples across adapters, config, model concern, connection handling |
| Tests | `spec/integration/v4/excluded_models_spec.rb` | Dual-path routing + transactional integrity tests |

## Test plan

- [x] Unit tests pass: `bundle exec appraisal rspec spec/unit/` (657 examples, 0 failures)
- [x] Integration tests pass (SQLite): `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/` (116 examples, 0 failures)
- [x] Integration tests pass (PostgreSQL): transactional integrity tests exercise shared path
- [x] Integration tests pass (MySQL): shared connection tests exercise `db.table` qualification
- [x] Rubocop clean on all changed files

Co-Authored-By: @henkesn

🤖 Generated with [Claude Code](https://claude.com/claude-code)