### PR TITLE
Fix ArgumentError from TestFixtures setup_shared_connection_pool

### DIFF
--- a/docs/designs/v4-test-fixtures-compatibility.md
+++ b/docs/designs/v4-test-fixtures-compatibility.md
@@ -1,0 +1,169 @@
+# TestFixtures Compatibility Patch
+
+## Problem
+
+Rails' `ActiveRecord::TestFixtures#setup_shared_connection_pool` iterates all shards registered in the ConnectionHandler and assumes every shard has a `:writing` pool_config. Apartment registers tenant pools under role-specific custom shard keys (e.g., shard `:apartment_acme:reading` under role `:reading`) that may not have a `:writing` counterpart for the same shard.
+
+When the fixture setup encounters such a shard, `writing_pool_config` resolves to nil, and `set_pool_config(role, shard, nil)` raises `ArgumentError`.
+
+### The Rails assumption
+
+From `ActiveRecord::TestFixtures#setup_shared_connection_pool` ([v8.0.3 source](https://github.com/rails/rails/blob/v8.0.3/activerecord/lib/active_record/test_fixtures.rb)):
+
+```ruby
+def setup_shared_connection_pool
+  handler = ActiveRecord::Base.connection_handler
+  handler.connection_pool_names.each do |name|
+    pool_manager = handler.send(:connection_name_to_pool_manager)[name]
+    pool_manager.shard_names.each do |shard_name|
+      writing_pool_config = pool_manager.get_pool_config(ActiveRecord.writing_role, shard_name)
+      @saved_pool_configs[name][shard_name] ||= {}
+      pool_manager.role_names.each do |role|
+        next unless pool_config = pool_manager.get_pool_config(role, shard_name)
+        next if pool_config == writing_pool_config
+        @saved_pool_configs[name][shard_name][role] = pool_config
+        pool_manager.set_pool_config(role, shard_name, writing_pool_config) # nil when no :writing entry
+      end
+    end
+  end
+end
+```
+
+`shard_names` returns all unique shards across all roles. If apartment registered shard `:apartment_acme:reading` under role `:reading` only, the `:writing` lookup for that shard returns nil. The `next unless` guard passes (the `:reading` entry exists), and `set_pool_config` receives nil as the pool_config argument.
+
+### When it surfaces
+
+1. A `before(:all)` block (or prior test) triggers the elevator, creating a tenant pool under a non-writing role (e.g., `connected_to(role: :reading)` during a request)
+2. A subsequent test example's fixture setup (Minitest's `before_setup`, or the equivalent RSpec fixture lifecycle via `RSpec::Rails::FixtureSupport`) calls `setup_transactional_fixtures` -> `setup_shared_connection_pool`
+3. The fixture machinery discovers the apartment shard, tries to map it across roles, raises `ArgumentError`
+
+The writing role is unaffected because `writing_pool_config` is non-nil for shards created under `:writing`, making the `next if pool_config == writing_pool_config` guard short-circuit correctly.
+
+## Design
+
+### Approach: auto-wire via Railtie
+
+Prepend a module (via `ActiveSupport.on_load(:active_record_fixtures)`) on the class that includes `ActiveRecord::TestFixtures`, overriding `setup_shared_connection_pool` to deregister apartment's tenant pools before the fixture machinery iterates them. Pools are lazy; they rebuild on the next `connection_pool` call.
+
+**Why auto-wire, not opt-in**: `activerecord-tenanted` (Basecamp) sets the precedent for auto-wiring fixture integration via Railtie: it uses the same `:active_record_fixtures` hook point to prepend a module that adjusts fixture behavior for tenant pools (overriding `transactional_tests_for_pool?`, not `setup_shared_connection_pool` -- different fix, same hook and delivery mechanism). The incompatibility is a framework-level invariant violation (Rails assumes every shard has a `:writing` pool_config), not an application-level concern. Users shouldn't need to know that `setup_shared_connection_pool` cross-joins shards and roles.
+
+**Escape hatch**: `config.test_fixture_cleanup` defaults to `true`. Set to `false` to disable the auto-wire.
+
+### Components
+
+#### 1. `Apartment::TestFixtures` module
+
+New file: `lib/apartment/test_fixtures.rb`
+
+Prepended on the class that includes `ActiveRecord::TestFixtures` (see Railtie wiring below for why). Overrides the private `setup_shared_connection_pool` method:
+
+```ruby
+module Apartment
+  module TestFixtures
+    private
+
+    def setup_shared_connection_pool
+      unless @apartment_fixtures_cleaned
+        @apartment_fixtures_cleaned = true
+        if Apartment.pool_manager
+          Apartment.send(:deregister_all_tenant_pools)
+          Apartment.pool_manager.clear
+          Apartment::Current.reset
+        end
+      end
+      super
+    end
+
+    def teardown_shared_connection_pool
+      @apartment_fixtures_cleaned = false
+      super
+    end
+  end
+end
+```
+
+The cleanup runs once per setup/teardown cycle, guarded by `@apartment_fixtures_cleaned`. This prevents re-entry: `setup_transactional_fixtures` registers a `!connection.active_record` notification subscriber that calls `setup_shared_connection_pool` again whenever a new pool is established mid-example. Without the guard, tenant pools created during a test (via `establish_connection` inside the `ConnectionHandling` patch) would trigger the subscriber, which would deregister the pool that was just registered -- leaving it in apartment's PoolManager but orphaned from the ConnectionHandler.
+
+Three operations on first call:
+- `deregister_all_tenant_pools` -- removes apartment shards from AR's ConnectionHandler so `setup_shared_connection_pool` doesn't iterate them
+- `pool_manager.clear` -- clears apartment's internal pool cache (pools rebuild lazily on next `connection_pool` call)
+- `Current.reset` -- clears tenant context so no stale tenant leaks into fixture setup
+
+The teardown override resets the guard for the next example's setup cycle.
+
+#### 2. Railtie wiring
+
+Addition to `lib/apartment/railtie.rb`, inside the existing Railtie class:
+
+```ruby
+if Rails.env.test?
+  ActiveSupport.on_load(:active_record_fixtures) do
+    if Apartment.config&.test_fixture_cleanup
+      require 'apartment/test_fixtures'
+      prepend Apartment::TestFixtures
+    end
+  end
+end
+```
+
+**Boot order assumption**: `Apartment.configure` must run before the test framework includes `ActiveRecord::TestFixtures` (which fires the hook). This holds for standard Rails boot: initializers run before the test suite loads. If `Apartment.config` is nil at hook time, the prepend is silently skipped. Apps that defer `Apartment.configure` past test framework load would need to prepend manually.
+
+The `:active_record_fixtures` hook fires via `ActiveSupport.run_load_hooks(:active_record_fixtures, self)` inside `TestFixtures`' `included` block. `self` there is the class that included `ActiveRecord::TestFixtures` (e.g., `ActiveSupport::TestCase` for Minitest, or the RSpec example group base class via `RSpec::Rails::FixtureSupport`). The `prepend` therefore targets that class, not the `ActiveRecord::TestFixtures` module itself. Functionally equivalent: the overridden method sits above the mixed-in `setup_shared_connection_pool` in the method resolution chain.
+
+This applies to both Minitest and RSpec: `RSpec::Rails::FixtureSupport` includes `ActiveRecord::TestFixtures`, which fires the same hook.
+
+#### 3. Config attribute
+
+Addition to `lib/apartment/config.rb`:
+
+Add `:test_fixture_cleanup` to `attr_accessor` and set `@test_fixture_cleanup = true` in `initialize`. No validation needed; boolean with a safe default.
+
+### Scope boundaries
+
+This patch does NOT:
+
+- Affect non-test environments -- the `on_load` hook only fires when `Rails.env.test?` is true.
+- Change pool key format or registration strategy -- custom shard keys remain; the fix is cleanup before the fixture machinery iterates them.
+- Interfere with the `!connection.active_record` subscriber in `setup_transactional_fixtures` -- the `@apartment_fixtures_cleaned` guard ensures cleanup runs only once per setup cycle; subscriber-triggered re-entries of `setup_shared_connection_pool` pass through to `super` without cleanup.
+
+### Interaction with other gems
+
+Gems that also prepend on `:active_record_fixtures` (e.g., `activerecord-tenanted`) share the prepend chain. The last gem to prepend runs first (outermost in MRO). If Apartment prepends last, its cleanup runs before other gems' `setup_shared_connection_pool` overrides, and they see a clean handler. If another gem prepends after Apartment, their override runs first and may encounter apartment shards before cleanup. In practice this is unlikely to conflict: `activerecord-tenanted`'s override targets `transactional_tests_for_pool?` (orthogonal method), not `setup_shared_connection_pool`. If a real conflict surfaces, prepend order can be controlled by Railtie load order or by having the app explicitly re-prepend.
+
+## Testing
+
+### Unit test: `spec/unit/test_fixtures_spec.rb`
+
+Exercises the scenario directly:
+
+1. Register a tenant pool under `:reading` only (simulating `connected_to(role: :reading)` + elevator)
+2. Verify that calling `setup_shared_connection_pool` without the patch raises `ArgumentError`
+3. Verify that with the patch prepended, `setup_shared_connection_pool` succeeds
+4. Verify pools are lazily recreated after cleanup
+5. Verify the guard prevents cleanup on re-entrant calls (simulating the `!connection.active_record` subscriber path)
+6. Verify `teardown_shared_connection_pool` resets the guard for the next cycle
+7. Verify `config.test_fixture_cleanup = false` prevents the prepend
+
+### Integration consideration
+
+The gem's own integration tests use RSpec with a ConnectionHandler swap per example; fixture support is not loaded, so `setup_shared_connection_pool` doesn't fire in the gem's test suite. However, both Minitest and RSpec exercise the same `ActiveRecord::TestFixtures` code path in downstream apps. The real proof is in apps that use transactional fixtures with `before(:all)` request blocks. A targeted unit test that exercises the Rails method directly is sufficient for the gem.
+
+## Alternatives considered
+
+### A. Register shards for ALL roles when creating for one role
+
+Apartment would register a pool_config for every known role when creating a tenant pool, ensuring `setup_shared_connection_pool` always finds a `:writing` entry.
+
+**Rejected**: Creates unnecessary pools, complicates pool lifecycle (eviction, drop), and couples pool creation to the set of roles registered at that moment. A role registered later would still be missed.
+
+### B. Opt-in test helper (`include Apartment::TestHelper`)
+
+Users add the include to their test base class manually.
+
+**Rejected**: The incompatibility is invisible until it fails. Users can't reasonably predict that `setup_shared_connection_pool` iterates custom shards. `activerecord-tenanted` sets the precedent for auto-wiring this class of fix.
+
+### C. Use `:default` shard instead of custom shard keys
+
+Overwrite the `(:reading, :default)` pool entry with tenant-specific config.
+
+**Rejected**: Breaks the clean namespace separation apartment uses. Clobbers the default reading pool, complicating cleanup and PoolManager tracking. Would require reworking the existing pool key architecture.

--- a/docs/plans/apartment-v4/overview.md
+++ b/docs/plans/apartment-v4/overview.md
@@ -192,7 +192,3 @@ All phases (1-8) implemented and merged to `main` in PRs #345-374. Per-phase pla
 
 - **v4.0.0.alpha1** — released 2026-04-09 (Phases 1-8)
 - **v4.0.0.alpha2** — Shared pinned connections (#374), persistent_schemas validation (#376), convenience APIs (#372-373)
-
-## Post-Alpha Plans
-
-- [`test-fixtures-compatibility.md`](test-fixtures-compatibility.md) — Fix `ArgumentError` from Rails' `setup_shared_connection_pool` when tenant pools exist under non-writing roles. Design: [`docs/designs/v4-test-fixtures-compatibility.md`](../../designs/v4-test-fixtures-compatibility.md)

--- a/docs/plans/apartment-v4/overview.md
+++ b/docs/plans/apartment-v4/overview.md
@@ -192,3 +192,7 @@ All phases (1-8) implemented and merged to `main` in PRs #345-374. Per-phase pla
 
 - **v4.0.0.alpha1** — released 2026-04-09 (Phases 1-8)
 - **v4.0.0.alpha2** — Shared pinned connections (#374), persistent_schemas validation (#376), convenience APIs (#372-373)
+
+## Post-Alpha Plans
+
+- [`test-fixtures-compatibility.md`](test-fixtures-compatibility.md) — Fix `ArgumentError` from Rails' `setup_shared_connection_pool` when tenant pools exist under non-writing roles. Design: [`docs/designs/v4-test-fixtures-compatibility.md`](../../designs/v4-test-fixtures-compatibility.md)

--- a/docs/plans/apartment-v4/test-fixtures-compatibility.md
+++ b/docs/plans/apartment-v4/test-fixtures-compatibility.md
@@ -1,0 +1,366 @@
+# TestFixtures Compatibility Patch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `ArgumentError` from Rails' `setup_shared_connection_pool` when apartment tenant pools exist under non-writing roles.
+
+**Architecture:** Auto-wire a prepend on `ActiveRecord::TestFixtures` (via Railtie + `on_load(:active_record_fixtures)`) that deregisters apartment's tenant pools before Rails' fixture setup iterates shards. A guard ivar prevents re-entry from the `!connection.active_record` notification subscriber.
+
+**Tech Stack:** Ruby, Rails ActiveRecord TestFixtures, RSpec
+
+**Design spec:** `docs/designs/v4-test-fixtures-compatibility.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `lib/apartment/test_fixtures.rb` | `Apartment::TestFixtures` module: overrides `setup_shared_connection_pool` and `teardown_shared_connection_pool` |
+| Modify | `lib/apartment/config.rb` | Add `test_fixture_cleanup` attribute (default `true`) |
+| Modify | `lib/apartment/railtie.rb` | Wire `on_load(:active_record_fixtures)` hook in test env |
+| Create | `spec/unit/test_fixtures_spec.rb` | Unit tests for the patch |
+
+---
+
+### Task 1: Add `test_fixture_cleanup` config attribute
+
+**Files:**
+- Modify: `lib/apartment/config.rb:17` (attr_accessor line), `:28-54` (initialize), `:112-178` (validate!)
+- Test: `spec/unit/config_spec.rb` (existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `spec/unit/config_spec.rb`, inside the main describe block. Find the existing pattern for boolean config attributes (e.g., `check_pending_migrations`) and follow it.
+
+```ruby
+describe 'test_fixture_cleanup' do
+  it 'defaults to true' do
+    Apartment.configure do |config|
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+    end
+    expect(Apartment.config.test_fixture_cleanup).to be(true)
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e 'test_fixture_cleanup'`
+Expected: FAIL — `undefined method 'test_fixture_cleanup'`
+
+- [ ] **Step 3: Add the attribute**
+
+In `lib/apartment/config.rb`:
+
+1. Add `:test_fixture_cleanup` to the `attr_accessor` list on line 17 (after `:force_separate_pinned_pool`).
+
+2. Add `@test_fixture_cleanup = true` in `initialize` (after `@force_separate_pinned_pool = false`, around line 54).
+
+No validation needed — boolean with a safe default; no freeze needed.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e 'test_fixture_cleanup'`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/config.rb spec/unit/config_spec.rb
+git commit -m "Add test_fixture_cleanup config attribute (default: true)"
+```
+
+---
+
+### Task 2: Create `Apartment::TestFixtures` module
+
+**Files:**
+- Create: `lib/apartment/test_fixtures.rb`
+- Test: `spec/unit/test_fixtures_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `spec/unit/test_fixtures_spec.rb`. This test requires real ActiveRecord (same pattern as `spec/unit/patches/connection_handling_spec.rb`). It simulates the scenario: register a tenant pool under `:reading` only, then exercise `setup_shared_connection_pool`.
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# This spec requires real ActiveRecord + sqlite3 gem.
+# Run via any sqlite3 appraisal, e.g.: bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/test_fixtures_spec.rb
+# Skips gracefully when sqlite3 is not available.
+FIXTURES_AR_AVAILABLE = begin
+  require('active_record')
+  if ActiveRecord::Base.respond_to?(:establish_connection)
+    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+    require_relative('../../lib/apartment/patches/connection_handling')
+    ActiveRecord::Base.singleton_class.prepend(Apartment::Patches::ConnectionHandling)
+    true
+  else
+    warn '[test_fixtures_spec] Skipping: AR stub loaded (no establish_connection)'
+    false
+  end
+rescue LoadError => e
+  warn "[test_fixtures_spec] Skipping: #{e.message}"
+  false
+end
+
+RSpec.describe('Apartment::TestFixtures') do
+  before do
+    skip 'requires real ActiveRecord with sqlite3 gem (run via appraisal)' unless FIXTURES_AR_AVAILABLE
+    Apartment.configure do |config|
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { %w[acme] }
+      config.default_tenant = 'public'
+      config.check_pending_migrations = false
+    end
+    Apartment.adapter = mock_adapter
+  end
+
+  after do
+    Apartment.clear_config
+    Apartment::Current.reset
+  end
+
+  let(:mock_adapter) do
+    double('AbstractAdapter',
+           validated_connection_config: { 'adapter' => 'sqlite3', 'database' => ':memory:' },
+           shared_pinned_connection?: false)
+  end
+
+  # Helper: register a tenant pool under a specific role by simulating
+  # what ConnectionHandling#connection_pool does.
+  def register_tenant_pool(tenant, role)
+    pool_key = "#{tenant}:#{role}"
+    prefix = Apartment.config.shard_key_prefix
+    shard_key = :"#{prefix}_#{pool_key}"
+    config = { 'adapter' => 'sqlite3', 'database' => ':memory:' }
+    db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new('test', "#{prefix}_#{pool_key}", config)
+    ActiveRecord::Base.connection_handler.establish_connection(
+      db_config, owner_name: ActiveRecord::Base, role: role, shard: shard_key
+    )
+    Apartment.pool_manager.fetch_or_create(pool_key) do |_key|
+      ActiveRecord::Base.connection_handler.retrieve_connection_pool(
+        'ActiveRecord::Base', role: role, shard: shard_key
+      )
+    end
+  end
+
+  # Minimal fixture host: includes TestFixtures so setup_shared_connection_pool is available.
+  let(:fixture_host_class) do
+    Class.new do
+      include ActiveRecord::TestFixtures
+
+      # TestFixtures expects @saved_pool_configs to exist (initialized in setup_fixtures)
+      def initialize
+        @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+      end
+
+      # Expose private methods for testing
+      public :setup_shared_connection_pool, :teardown_shared_connection_pool
+    end
+  end
+
+  describe 'without the patch' do
+    it 'raises ArgumentError when a tenant pool exists under :reading only' do
+      register_tenant_pool('acme', :reading)
+      host = fixture_host_class.new
+      expect { host.setup_shared_connection_pool }.to raise_error(ArgumentError, /pool_config.*nil/)
+    end
+  end
+
+  describe 'with the patch' do
+    let(:patched_host_class) do
+      require_relative('../../lib/apartment/test_fixtures')
+      klass = fixture_host_class
+      klass.prepend(Apartment::TestFixtures)
+      klass
+    end
+
+    it 'does not raise when a tenant pool exists under :reading only' do
+      register_tenant_pool('acme', :reading)
+      host = patched_host_class.new
+      expect { host.setup_shared_connection_pool }.not_to raise_error
+    end
+
+    it 'clears apartment pools from the ConnectionHandler' do
+      register_tenant_pool('acme', :reading)
+      host = patched_host_class.new
+      host.setup_shared_connection_pool
+
+      shard_key = :"#{Apartment.config.shard_key_prefix}_acme:reading"
+      pool = ActiveRecord::Base.connection_handler.retrieve_connection_pool(
+        'ActiveRecord::Base', role: :reading, shard: shard_key
+      )
+      expect(pool).to be_nil
+    end
+
+    it 'clears the pool manager' do
+      register_tenant_pool('acme', :reading)
+      host = patched_host_class.new
+      host.setup_shared_connection_pool
+
+      expect(Apartment.pool_manager.stats[:total_pools]).to eq(0)
+    end
+
+    it 'does not clean up on re-entrant calls (subscriber path)' do
+      host = patched_host_class.new
+
+      # First call: cleans up
+      host.setup_shared_connection_pool
+      expect(host.instance_variable_get(:@apartment_fixtures_cleaned)).to be(true)
+
+      # Register a pool AFTER first cleanup (simulates mid-example pool creation)
+      register_tenant_pool('acme', :writing)
+      pool_count_before = Apartment.pool_manager.stats[:total_pools]
+
+      # Second call (re-entry from subscriber): should NOT clean up
+      host.setup_shared_connection_pool
+      expect(Apartment.pool_manager.stats[:total_pools]).to eq(pool_count_before)
+    end
+
+    it 'resets the guard on teardown' do
+      host = patched_host_class.new
+      host.setup_shared_connection_pool
+      expect(host.instance_variable_get(:@apartment_fixtures_cleaned)).to be(true)
+
+      host.teardown_shared_connection_pool
+      expect(host.instance_variable_get(:@apartment_fixtures_cleaned)).to be(false)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/test_fixtures_spec.rb`
+Expected: The "without the patch" test should PASS (it confirms the bug exists — `ArgumentError` is raised). The "with the patch" tests should FAIL with `LoadError` because `lib/apartment/test_fixtures.rb` doesn't exist yet.
+
+- [ ] **Step 3: Create the module**
+
+Create `lib/apartment/test_fixtures.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Apartment
+  # Prepended on the class that includes ActiveRecord::TestFixtures
+  # (e.g., ActiveSupport::TestCase or the RSpec fixture host).
+  #
+  # Rails' setup_shared_connection_pool iterates all shards registered in
+  # the ConnectionHandler and assumes every shard has a :writing pool_config.
+  # Apartment's role-specific tenant shards violate this invariant, causing
+  # ArgumentError. This module deregisters apartment pools before the fixture
+  # machinery iterates them. Pools rebuild lazily on next connection_pool call.
+  #
+  # A guard ivar (@apartment_fixtures_cleaned) prevents re-entry: the
+  # !connection.active_record notification subscriber in
+  # setup_transactional_fixtures calls setup_shared_connection_pool again
+  # when new pools appear mid-example.
+  module TestFixtures
+    private
+
+    def setup_shared_connection_pool
+      unless @apartment_fixtures_cleaned
+        @apartment_fixtures_cleaned = true
+        if Apartment.pool_manager
+          Apartment.send(:deregister_all_tenant_pools)
+          Apartment.pool_manager.clear
+          Apartment::Current.reset
+        end
+      end
+      super
+    end
+
+    def teardown_shared_connection_pool
+      @apartment_fixtures_cleaned = false
+      super
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/test_fixtures_spec.rb`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/test_fixtures.rb spec/unit/test_fixtures_spec.rb
+git commit -m "Add Apartment::TestFixtures to deregister tenant pools before fixture setup"
+```
+
+---
+
+### Task 3: Wire the Railtie hook
+
+**Files:**
+- Modify: `lib/apartment/railtie.rb:50` (before the `rake_tasks` block)
+- Test: `spec/unit/railtie_spec.rb` (existing, if railtie specs exist) or manual verification
+
+- [ ] **Step 1: Check for existing railtie specs**
+
+Run: `find spec -name '*railtie*' -type f` to see if there are existing railtie unit tests. If not, this task will be verified by the integration-level unit test in Task 2 (which manually prepends, covering the module behavior) and by downstream app testing.
+
+- [ ] **Step 2: Add the on_load hook to the Railtie**
+
+In `lib/apartment/railtie.rb`, add the following block after the `initializer 'apartment.middleware'` block and before the `rake_tasks` block (before line 51):
+
+```ruby
+    # In test environments, clean up apartment's tenant pools before Rails'
+    # fixture setup iterates shards. See docs/designs/v4-test-fixtures-compatibility.md.
+    if Rails.env.test?
+      ActiveSupport.on_load(:active_record_fixtures) do
+        if Apartment.config&.test_fixture_cleanup
+          require 'apartment/test_fixtures'
+          prepend Apartment::TestFixtures
+        end
+      end
+    end
+```
+
+- [ ] **Step 3: Verify no existing tests break**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/`
+Expected: All existing unit tests PASS. The `on_load` hook won't fire during unit tests (no fixture support loaded in the gem's RSpec suite), so this is a no-op in the test run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/apartment/railtie.rb
+git commit -m "Wire TestFixtures cleanup via Railtie on_load(:active_record_fixtures)"
+```
+
+---
+
+### Task 4: Run full test suite and verify
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run unit tests across all appraisals**
+
+Run: `bundle exec appraisal rspec spec/unit/`
+Expected: All tests PASS across all Rails versions.
+
+- [ ] **Step 2: Run rubocop on changed files**
+
+Run: `bundle exec rubocop lib/apartment/test_fixtures.rb lib/apartment/config.rb lib/apartment/railtie.rb spec/unit/test_fixtures_spec.rb`
+Expected: No offenses. Fix any that arise.
+
+- [ ] **Step 3: Run the specific test_fixtures_spec across appraisals**
+
+Run: `bundle exec appraisal rspec spec/unit/test_fixtures_spec.rb`
+Expected: PASS on all appraisals (tests skip gracefully when sqlite3 is unavailable for that appraisal).
+
+- [ ] **Step 4: Final commit if rubocop required changes**
+
+Only if step 2 produced fixes:
+```bash
+git add -A
+git commit -m "Fix rubocop offenses in test_fixtures patch"
+```

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -182,11 +182,14 @@ module Apartment
 
     # Deregister all tenant pools from AR's ConnectionHandler and clear the
     # pool manager cache. Tenant context is also reset. Pools rebuild lazily
-    # on next connection_pool call.
+    # on the next +connection_pool+ call.
     #
-    # Used by Apartment::TestFixtures to clean up before Rails' fixture setup
-    # iterates shards (setup_shared_connection_pool assumes every shard has a
-    # :writing pool_config; apartment's role-specific shards violate this).
+    # Called automatically by +Apartment::TestFixtures+ before Rails' fixture
+    # setup iterates shards. Can also be called manually in custom test harnesses
+    # that need to clear tenant state between examples.
+    #
+    # @return [void]
+    # @see Apartment::TestFixtures
     def reset_tenant_pools!
       deregister_all_tenant_pools
       @pool_manager&.clear

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -180,6 +180,19 @@ module Apartment
       warn "[Apartment] Failed to deregister AR pool for #{pool_key}: #{e.class}: #{e.message}"
     end
 
+    # Deregister all tenant pools from AR's ConnectionHandler and clear the
+    # pool manager cache. Tenant context is also reset. Pools rebuild lazily
+    # on next connection_pool call.
+    #
+    # Used by Apartment::TestFixtures to clean up before Rails' fixture setup
+    # iterates shards (setup_shared_connection_pool assumes every shard has a
+    # :writing pool_config; apartment's role-specific shards violate this).
+    def reset_tenant_pools!
+      deregister_all_tenant_pools
+      @pool_manager&.clear
+      Apartment::Current.reset
+    end
+
     private
 
     # Safely tear down old state. Stops the reaper first (so it doesn't

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -23,7 +23,7 @@ module Apartment
                   :tenant_not_found_handler, :active_record_log, :sql_query_tags,
                   :shard_key_prefix,
                   :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
-                  :force_separate_pinned_pool
+                  :force_separate_pinned_pool, :test_fixture_cleanup
 
     def initialize # rubocop:disable Metrics/AbcSize
       @tenant_strategy = nil
@@ -52,6 +52,7 @@ module Apartment
       @schema_cache_per_tenant = false
       @check_pending_migrations = true
       @force_separate_pinned_pool = false
+      @test_fixture_cleanup = true
     end
 
     def excluded_models=(list)

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -171,6 +171,11 @@ module Apartment
               "force_separate_pinned_pool must be true or false, got: #{@force_separate_pinned_pool.inspect}")
       end
 
+      unless [true, false].include?(@test_fixture_cleanup)
+        raise(ConfigurationError,
+              "test_fixture_cleanup must be true or false, got: #{@test_fixture_cleanup.inspect}")
+      end
+
       return if @shard_key_prefix.is_a?(String) && @shard_key_prefix.match?(/\A[a-z_][a-z0-9_]*\z/)
 
       raise(ConfigurationError,

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -48,6 +48,17 @@ module Apartment
       Apartment::Railtie.insert_elevator_middleware(app.middleware, elevator_class, **opts)
     end
 
+    # In test environments, clean up apartment's tenant pools before Rails'
+    # fixture setup iterates shards. See docs/designs/v4-test-fixtures-compatibility.md.
+    if Rails.env.test?
+      ActiveSupport.on_load(:active_record_fixtures) do
+        if Apartment.config&.test_fixture_cleanup
+          require 'apartment/test_fixtures'
+          prepend Apartment::TestFixtures
+        end
+      end
+    end
+
     rake_tasks do
       load File.expand_path('tasks/v4.rake', __dir__)
 

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -48,17 +48,6 @@ module Apartment
       Apartment::Railtie.insert_elevator_middleware(app.middleware, elevator_class, **opts)
     end
 
-    # In test environments, clean up apartment's tenant pools before Rails'
-    # fixture setup iterates shards. See docs/designs/v4-test-fixtures-compatibility.md.
-    if Rails.env.test?
-      ActiveSupport.on_load(:active_record_fixtures) do
-        if Apartment.config&.test_fixture_cleanup
-          require 'apartment/test_fixtures'
-          prepend Apartment::TestFixtures
-        end
-      end
-    end
-
     rake_tasks do
       load File.expand_path('tasks/v4.rake', __dir__)
 

--- a/lib/apartment/test_fixtures.rb
+++ b/lib/apartment/test_fixtures.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Apartment
+  # Prepended on the class that includes ActiveRecord::TestFixtures
+  # (e.g., ActiveSupport::TestCase or the RSpec fixture host).
+  #
+  # Rails' setup_shared_connection_pool iterates all shards registered in
+  # the ConnectionHandler and assumes every shard has a :writing pool_config.
+  # Apartment's role-specific tenant shards violate this invariant, causing
+  # ArgumentError. This module deregisters apartment pools before the fixture
+  # machinery iterates them. Pools rebuild lazily on next connection_pool call.
+  #
+  # A guard ivar (@apartment_fixtures_cleaned) prevents re-entry: the
+  # !connection.active_record notification subscriber in
+  # setup_transactional_fixtures calls setup_shared_connection_pool again
+  # when new pools appear mid-example.
+  module TestFixtures
+    private
+
+    def setup_shared_connection_pool
+      unless @apartment_fixtures_cleaned
+        @apartment_fixtures_cleaned = true
+        if Apartment.pool_manager
+          Apartment.send(:deregister_all_tenant_pools)
+          Apartment.pool_manager.clear
+          Apartment::Current.reset
+        end
+      end
+      super
+    end
+
+    def teardown_shared_connection_pool
+      @apartment_fixtures_cleaned = false
+      super
+    end
+  end
+end

--- a/lib/apartment/test_fixtures.rb
+++ b/lib/apartment/test_fixtures.rb
@@ -20,11 +20,7 @@ module Apartment
     def setup_shared_connection_pool
       unless @apartment_fixtures_cleaned
         @apartment_fixtures_cleaned = true
-        if Apartment.pool_manager
-          Apartment.send(:deregister_all_tenant_pools)
-          Apartment.pool_manager.clear
-          Apartment::Current.reset
-        end
+        Apartment.reset_tenant_pools! if Apartment.pool_manager
       end
       super
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.mysql_config).to(be_nil) }
     it { expect(config.shard_key_prefix).to(eq('apartment')) }
     it { expect(config.force_separate_pinned_pool).to(be(false)) }
+    it { expect(config.test_fixture_cleanup).to(be(true)) }
   end
 
   describe '#tenant_strategy=' do
@@ -466,6 +467,16 @@ RSpec.describe(Apartment::Config) do
     it 'accepts false' do
       config.check_pending_migrations = false
       expect(config.check_pending_migrations).to(be(false))
+    end
+  end
+
+  describe 'test_fixture_cleanup' do
+    it 'defaults to true' do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+      end
+      expect(Apartment.config.test_fixture_cleanup).to(be(true))
     end
   end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.mysql_config).to(be_nil) }
     it { expect(config.shard_key_prefix).to(eq('apartment')) }
     it { expect(config.force_separate_pinned_pool).to(be(false)) }
-    it { expect(config.test_fixture_cleanup).to(be(true)) }
   end
 
   describe '#tenant_strategy=' do
@@ -467,16 +466,6 @@ RSpec.describe(Apartment::Config) do
     it 'accepts false' do
       config.check_pending_migrations = false
       expect(config.check_pending_migrations).to(be(false))
-    end
-  end
-
-  describe 'test_fixture_cleanup' do
-    it 'defaults to true' do
-      Apartment.configure do |c|
-        c.tenant_strategy = :schema
-        c.tenants_provider = -> { [] }
-      end
-      expect(Apartment.config.test_fixture_cleanup).to(be(true))
     end
   end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.mysql_config).to(be_nil) }
     it { expect(config.shard_key_prefix).to(eq('apartment')) }
     it { expect(config.force_separate_pinned_pool).to(be(false)) }
+    it { expect(config.test_fixture_cleanup).to(be(true)) }
   end
 
   describe '#tenant_strategy=' do

--- a/spec/unit/test_fixtures_spec.rb
+++ b/spec/unit/test_fixtures_spec.rb
@@ -157,6 +157,12 @@ RSpec.describe(Apartment::TestFixtures) do
       expect(Apartment.pool_manager.stats[:total_pools]).to(eq(0))
     end
 
+    # This test approximates the !connection.active_record subscriber re-entry
+    # at the unit level. In production, establish_connection fires the notification,
+    # which calls setup_shared_connection_pool again. We simulate this by manually
+    # adding a pool after the first cleanup and verifying the guard prevents a
+    # second cleanup. A full integration test would require a running Rails app
+    # with transactional fixtures enabled.
     it 'guard prevents cleanup on re-entrant calls' do
       register_tenant_pool('acme', :reading)
       host = FixtureHost.new
@@ -165,8 +171,8 @@ RSpec.describe(Apartment::TestFixtures) do
       host.call_setup
       expect(Apartment.pool_manager.stats[:total_pools]).to(eq(0))
 
-      # Manually add a pool directly to pool_manager (bypassing AR handler)
-      # to verify the second call does NOT clear it again.
+      # Add a pool directly to pool_manager (bypassing AR handler) to verify
+      # the second call does NOT clear it again.
       pool_key = 'acme:writing'
       Apartment.pool_manager.fetch_or_create(pool_key) { Object.new }
 

--- a/spec/unit/test_fixtures_spec.rb
+++ b/spec/unit/test_fixtures_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# This spec requires real ActiveRecord + sqlite3 gem (not the stub in apartment_spec.rb).
+# Run via any sqlite3 appraisal, e.g.: bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/test_fixtures_spec.rb
+# Skips gracefully when sqlite3 is not available or when the AR stub from
+# apartment_spec.rb loaded first (randomized suite order).
+REAL_AR_AVAILABLE_FOR_FIXTURES = begin
+  require('active_record')
+  # The stub in apartment_spec.rb defines AR::Base without establish_connection.
+  # If that loaded first, real AR's require is a partial no-op. Detect this.
+  if ActiveRecord::Base.respond_to?(:establish_connection)
+    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+    require_relative('../../lib/apartment/patches/connection_handling')
+    ActiveRecord::Base.singleton_class.prepend(Apartment::Patches::ConnectionHandling)
+    true
+  else
+    warn '[test_fixtures_spec] Skipping: AR stub loaded (no establish_connection)'
+    false
+  end
+rescue LoadError => e
+  warn "[test_fixtures_spec] Skipping: #{e.message}"
+  false
+end
+
+# Ensure Apartment::TestFixtures is defined for the RSpec.describe block below.
+# The real implementation is loaded inside 'with the patch' examples.
+# When AR is unavailable, define a stub so the describe block doesn't raise NameError.
+# When AR is available but the file hasn't been created yet, also define a stub.
+unless defined?(Apartment::TestFixtures)
+  module Apartment
+    module TestFixtures; end
+  end
+end
+
+# A host class that mimics what ActiveRecord::TestFixtures-including classes look like.
+# Wraps setup_shared_connection_pool / teardown_shared_connection_pool as public methods
+# so tests can call them directly without visibility friction.
+if REAL_AR_AVAILABLE_FOR_FIXTURES
+  class FixtureHost
+    include ActiveRecord::TestFixtures if REAL_AR_AVAILABLE_FOR_FIXTURES
+
+    # ActiveRecord::TestFixtures requires this ivar to be present.
+    def initialize
+      @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+    end
+
+    def call_setup
+      setup_shared_connection_pool
+    end
+
+    def call_teardown
+      teardown_shared_connection_pool
+    end
+  end
+end
+
+RSpec.describe(Apartment::TestFixtures) do
+  before do
+    skip 'requires real ActiveRecord with sqlite3 gem (run via appraisal)' unless REAL_AR_AVAILABLE_FOR_FIXTURES
+    Apartment.configure do |config|
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { %w[acme] }
+      config.default_tenant = 'public'
+      config.check_pending_migrations = false
+    end
+    Apartment.adapter = mock_adapter
+  end
+
+  after do
+    Apartment.clear_config
+    Apartment::Current.reset
+  end
+
+  let(:mock_adapter) do
+    double('AbstractAdapter',
+           validated_connection_config: { 'adapter' => 'sqlite3', 'database' => ':memory:' },
+           shared_pinned_connection?: false)
+  end
+
+  # Registers a tenant pool under a given role — simulates what ConnectionHandling#connection_pool does.
+  def register_tenant_pool(tenant, role)
+    prefix = Apartment.config.shard_key_prefix
+    pool_key = "#{tenant}:#{role}"
+    shard_key = :"#{prefix}_#{pool_key}"
+
+    db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+      Apartment.config.rails_env_name,
+      "#{prefix}_#{pool_key}",
+      { 'adapter' => 'sqlite3', 'database' => ':memory:' }
+    )
+
+    pool = ActiveRecord::Base.connection_handler.establish_connection(
+      db_config,
+      owner_name: ActiveRecord::Base,
+      role: role,
+      shard: shard_key
+    )
+
+    Apartment.pool_manager.fetch_or_create(pool_key) { pool }
+  end
+
+  describe 'without the patch' do
+    it 'raises ArgumentError from setup_shared_connection_pool when a tenant pool exists under :reading only' do
+      # Use a fresh anonymous host class to avoid contamination from the 'with the patch'
+      # tests (prepend is irreversible on a class; FixtureHost may already be patched).
+      fresh_host_class = Class.new do
+        include ActiveRecord::TestFixtures
+
+        def initialize
+          @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+        end
+
+        def call_setup
+          setup_shared_connection_pool
+        end
+      end
+
+      register_tenant_pool('acme', :reading)
+      host = fresh_host_class.new
+      expect { host.call_setup }.to(raise_error(ArgumentError, /pool_config.*nil/i))
+    end
+  end
+
+  describe 'with the patch' do
+    before do
+      require_relative('../../lib/apartment/test_fixtures')
+      FixtureHost.prepend(described_class) unless FixtureHost <= described_class # rubocop:disable Style/YodaCondition
+    end
+
+    it 'does not raise when a tenant pool exists under :reading only' do
+      register_tenant_pool('acme', :reading)
+      host = FixtureHost.new
+      expect { host.call_setup }.not_to(raise_error)
+    end
+
+    it 'clears apartment pools from the AR ConnectionHandler' do
+      register_tenant_pool('acme', :reading)
+      host = FixtureHost.new
+      host.call_setup
+
+      prefix = Apartment.config.shard_key_prefix
+      registered = ActiveRecord::Base.connection_handler.retrieve_connection_pool(
+        'ActiveRecord::Base',
+        role: :reading,
+        shard: :"#{prefix}_acme:reading"
+      )
+      expect(registered).to(be_nil)
+    end
+
+    it 'clears the pool manager' do
+      register_tenant_pool('acme', :reading)
+      host = FixtureHost.new
+      host.call_setup
+
+      expect(Apartment.pool_manager.stats[:total_pools]).to(eq(0))
+    end
+
+    it 'guard prevents cleanup on re-entrant calls' do
+      register_tenant_pool('acme', :reading)
+      host = FixtureHost.new
+
+      # First call: guard trips, clears apartment pools, pool manager is empty
+      host.call_setup
+      expect(Apartment.pool_manager.stats[:total_pools]).to(eq(0))
+
+      # Manually add a pool directly to pool_manager (bypassing AR handler)
+      # to verify the second call does NOT clear it again.
+      pool_key = 'acme:writing'
+      Apartment.pool_manager.fetch_or_create(pool_key) { Object.new }
+
+      # Second call: guard is set, cleanup block is skipped entirely
+      host.call_setup
+
+      expect(Apartment.pool_manager.stats[:total_pools]).to(eq(1))
+    end
+
+    it 'teardown_shared_connection_pool resets the guard' do
+      host = FixtureHost.new
+      host.call_setup
+      expect(host.instance_variable_get(:@apartment_fixtures_cleaned)).to(be(true))
+
+      host.call_teardown
+      expect(host.instance_variable_get(:@apartment_fixtures_cleaned)).to(be(false))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fix `ArgumentError: pool_config for :reading role and :apartment_...:reading shard was nil` caused by Rails' `setup_shared_connection_pool` iterating apartment's role-specific tenant shards
- Auto-wire cleanup via Railtie `on_load(:active_record_fixtures)` hook, matching `activerecord-tenanted`'s precedent for fixture integration
- Guard ivar prevents re-entry from the `!connection.active_record` notification subscriber mid-example

## Problem

Rails' `ActiveRecord::TestFixtures#setup_shared_connection_pool` assumes every shard has a `:writing` pool_config. Apartment v4 registers tenant pools under role-specific custom shard keys (e.g., shard `:apartment_acme:reading` under role `:reading`). When fixture setup encounters this shard, `writing_pool_config` resolves to nil, and `set_pool_config(role, shard, nil)` raises `ArgumentError`.

Surfaces when a `before(:all)` block (or prior test) triggers the elevator under `connected_to(role: :reading)`, creating a tenant pool, and a subsequent example's fixture setup discovers and iterates it.

## Changes

| File | What |
|------|------|
| `lib/apartment/test_fixtures.rb` | New `Apartment::TestFixtures` module: overrides `setup_shared_connection_pool` to deregister apartment pools before Rails iterates them |
| `lib/apartment/railtie.rb` | `on_load(:active_record_fixtures)` hook, guarded by `Rails.env.test?` and `config.test_fixture_cleanup` |
| `lib/apartment/config.rb` | `test_fixture_cleanup` attribute (default `true`) — escape hatch to disable |
| `spec/unit/test_fixtures_spec.rb` | 6 specs: regression test, cleanup, pool manager clear, re-entry guard, teardown reset |
| `docs/designs/v4-test-fixtures-compatibility.md` | Design spec |
| `docs/plans/apartment-v4/test-fixtures-compatibility.md` | Implementation plan |

## Test plan

- [x] `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/test_fixtures_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec appraisal rails-8.0-sqlite3 rspec spec/unit/test_fixtures_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/` — 688 examples, 0 failures
- [x] `bundle exec rubocop` on all changed files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)