### PR TITLE
Add Serena/repomix/code-graph dev tooling docs

### DIFF
--- a/.claude/rules/tool-layer-apartment.md
+++ b/.claude/rules/tool-layer-apartment.md
@@ -1,0 +1,43 @@
+# Tool Layer Selection (apartment)
+
+When working in this codebase, the three tools below sit at different layers of the same code question; they don't compete.
+
+## Layer table
+
+| Tool | Role | Optimizes | Failure it fixes |
+|---|---|---|---|
+| **Serena** | Scalpel: symbol resolution (LSP) | Token-cheap, surgical lookups and edits | Wrong rename, missed references |
+| **code-graph-mcp** | Map: structural relationships (call/dep graph) | Token-cheap, returns graph nodes | Unknown blast radius |
+| **Repomix** | Print job: bulk packaging | Loads code so the model reads end-to-end | Token thrash, fragmented reasoning |
+
+Serena and code-graph are *retrieval* (specific questions, precise answers). Repomix is *packaging* (code loaded so the model reads rather than queries). Repomix doesn't replace the others; it feeds them.
+
+## Apartment-specific triggers
+
+- "What calls `Apartment::Tenant.switch!`?" → Serena `find_referencing_symbols`
+- "If I rename `Apartment::Adapters::AbstractAdapter#switch`, what breaks downstream?" → code-graph `impact_analysis`
+- "Pack `lib/apartment/adapters/` and tell me where the abstraction leaks PostgreSQL specifics" → Repomix
+- "What's the call chain from `Apartment::Tenant.create` to the DB schema creation?" → code-graph `get_call_graph`
+- "Find dead methods in the elevators namespace" → code-graph `find_dead_code`
+- "What's the body of `Apartment::Reloader#call`?" → Serena `find_symbol` with `include_body=true`
+- "Review `lib/apartment/active_record/` for invariants we depend on" → Repomix
+- "Find similar implementations of `connection_switch!`" → code-graph `find_similar_code`
+
+## When NOT to use Repomix
+
+- Single-symbol questions (Serena beats a directory dump in one call)
+- Impact analysis (code-graph shows dependency structure; Repomix shows source)
+- Iterative refactor with edits between queries (Serena and code-graph stay fresh; Repomix needs a repack)
+- Scope larger than the context budget (the full gem at once is fine; a downstream Rails app's view of apartment usage is not)
+
+## Typical week allocation (rough)
+
+For a gem-development week:
+
+- **~50% Serena** — most questions are symbol-level (the gem is small)
+- **~25% code-graph-mcp** — impact analysis when changing public APIs
+- **~15% Repomix** — invariants review, doc generation, upstream-PR-prep packaging
+- **~5% rspec / minitest output** — iterative test-driven changes (not an MCP tool, but it dominates the loop)
+- **~5% GitHub MCP plugin** — upstream PR archaeology, fork-vs-upstream diff investigations
+
+This is a fork of `rails-on-services/apartment`; when investigating "why did we diverge from upstream here?", reach for the GitHub MCP plugin to inspect upstream PRs and our fork's history side by side.

--- a/.claude/rules/tool-layer-apartment.md
+++ b/.claude/rules/tool-layer-apartment.md
@@ -38,6 +38,6 @@ For a gem-development week:
 - **~25% code-graph-mcp** — impact analysis when changing public APIs
 - **~15% Repomix** — invariants review, doc generation, upstream-PR-prep packaging
 - **~5% rspec / minitest output** — iterative test-driven changes (not an MCP tool, but it dominates the loop)
-- **~5% GitHub MCP plugin** — upstream PR archaeology, fork-vs-upstream diff investigations
+- **~5% GitHub MCP plugin** — git history archaeology when "why did this evolve?" matters
 
-This is a fork of `rails-on-services/apartment`; when investigating "why did we diverge from upstream here?", reach for the GitHub MCP plugin to inspect upstream PRs and our fork's history side by side.
+When investigating how a method or class evolved (regression, design choice, deprecation), reach for the GitHub MCP plugin to inspect this repo's PRs and merge history.

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ spec/dummy/db/*.sqlite3
 # Firecrawl working data
 .firecrawl/
 coverage/
+# code-graph-mcp index (generated, per-machine)
+.code-graph/
+# Repomix packed output (generated, can be 10MB+)
+repomix-output.*

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -31,6 +31,7 @@ languages:
 - yaml
 - bash
 - markdown
+- json
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,157 @@
+# the name by which the project can be referenced within Serena
+project_name: "apartment"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- ruby
+- yaml
+- bash
+- markdown
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending: "lf"
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/docs/ai-tools-setup.md
+++ b/docs/ai-tools-setup.md
@@ -1,8 +1,6 @@
 # AI Tools Setup Guide
 
-Plugins, skills, and MCP servers for AI-assisted development with the CampusESP fork of the Apartment Ruby gem.
-
-For the full canonical setup (used by the main www Rails app), see [`www/docs/ai-tools-setup.md`](https://github.com/CampusESP/www/blob/develop/docs/ai-tools-setup.md). This file mirrors that structure with apartment-specific notes.
+Plugins, skills, and MCP servers for AI-assisted development with the Apartment Ruby gem.
 
 ## Plugin > Skill > MCP
 
@@ -34,7 +32,7 @@ For Cursor: `.cursor/mcp.json` mirrors `.mcp.json` for team-shared servers.
 
 ## Code Intelligence (Cross-Project)
 
-Three personal dev tools that work across all CampusESP repos. Configure at user scope (Claude Code plugins, global `~/.cursor/mcp.json`) — not in this project's MCP configs.
+Three personal dev tools that work across multiple projects. Configure at user scope (Claude Code plugins, global `~/.cursor/mcp.json`) — not in this project's MCP configs.
 
 ### Serena (semantic code search & symbolic edits)
 
@@ -43,8 +41,8 @@ LSP-backed symbolic tools for the AI: `find_symbol`, `replace_symbol_body`, `fin
 **Install:**
 
 ```bash
-uvx --from git+https://github.com/oraios/serena serena --help  # smoke test
-serena setup claude-code                                       # registers MCP server
+uv tool install -p 3.13 serena-agent@latest --prerelease=allow
+serena setup claude-code  # registers Serena as an MCP server with Claude Code
 ```
 
 **Cursor** (`~/.cursor/mcp.json`):
@@ -130,7 +128,6 @@ Personal dev tools at `~/.cursor/mcp.json`:
 - **`serena`** — `serena start-mcp-server --context=ide --project-from-cwd`
 - **`repomix`** — `npx -y repomix@latest --mcp`
 - **`code-graph`** — `npx -y @sdsrs/code-graph`
-- Database servers as configured for `www`
 
 ## Verification
 

--- a/docs/ai-tools-setup.md
+++ b/docs/ai-tools-setup.md
@@ -58,6 +58,14 @@ serena setup claude-code  # registers Serena as an MCP server with Claude Code
 
 **Project files (`.serena/`)** — when populated, commit `.serena/.gitignore`, `.serena/project.yml`, and `.serena/memories/` (verify `project.yml` has no absolute paths). Serena's bundled `.serena/.gitignore` keeps `cache/` and `project.local.yml` out of git.
 
+#### Cross-project queries
+
+Single-project contexts (`claude-code`, `ide`) lock the active project. To query *other* registered Serena projects from within this one (e.g., a downstream Rails app that consumes this gem, or a sibling library):
+
+1. The `query-projects` mode is set as a `base_mode` in `~/.serena/serena_config.yml` (one-time, machine-wide). It exposes `query_project` and `list_queryable_projects`.
+2. The Serena project-server daemon spawns LSPs for queried projects on demand. Run it as a launchd agent on macOS — see `~/Library/LaunchAgents/com.oraios.serena-project-server.plist`. For Ruby projects to install ruby-lsp into a writable gem dir, the plist's `PATH` must include `~/.rbenv/shims` (or your equivalent Ruby version manager's shims), plus `RBENV_ROOT` and `HOME`.
+3. Symbolic queries via `query_project` work against any registered project. Text-class tools (`find_file`, `search_for_pattern`, etc.) stay excluded by the active context — for cross-project text search, shell out: `grep -rn 'pattern' /absolute/path/to/other/repo/`.
+
 ### code-graph-mcp (call graph, impact analysis)
 
 Tracks the codebase as a graph; supports `impact_analysis` before signature changes, `get_call_graph`, `find_dead_code`, `find_similar_code`, `dependency_graph`, `semantic_code_search`.

--- a/docs/ai-tools-setup.md
+++ b/docs/ai-tools-setup.md
@@ -1,0 +1,146 @@
+# AI Tools Setup Guide
+
+Plugins, skills, and MCP servers for AI-assisted development with the CampusESP fork of the Apartment Ruby gem.
+
+For the full canonical setup (used by the main www Rails app), see [`www/docs/ai-tools-setup.md`](https://github.com/CampusESP/www/blob/develop/docs/ai-tools-setup.md). This file mirrors that structure with apartment-specific notes.
+
+## Plugin > Skill > MCP
+
+When a capability is available through multiple mechanisms, prefer: **Plugin** (auto-updating) > **Skill** (`.claude/skills/`) > **MCP server** (`.mcp.json`).
+
+### Capabilities Covered by Plugins
+
+These have official plugins; do not add MCP servers for them:
+
+| Capability | Claude Code Plugin | Cursor Plugin |
+|---|---|---|
+| Library docs | `context7@claude-plugins-official` | [upstash](https://cursor.com/marketplace/upstash) |
+| Web scraping/search | `firecrawl@claude-plugins-official` | [firecrawl](https://cursor.com/marketplace/firecrawl) |
+| Error tracking | `sentry@claude-plugins-official` | [sentry](https://cursor.com/marketplace/sentry) |
+| Code review | `code-review@claude-plugins-official` | — |
+| Git commits | `commit-commands@claude-plugins-official` | — |
+| PR review | `pr-review-toolkit@claude-plugins-official` | — |
+| GitHub | `github@claude-plugins-official` | — |
+| Workflows | `superpowers@claude-plugins-official` | — |
+| Ruby LSP | `ruby-lsp@claude-plugins-official` | — |
+| Repomix (codebase pack/MCP) | `repomix-mcp@repomix` + `repomix-commands@repomix` + `repomix-explorer@repomix` (user scope) | — (use MCP server) |
+| code-graph (call/dep graph) | `code-graph-mcp@code-graph-mcp` (user scope) | — (use MCP server) |
+
+## Project MCP Servers
+
+This repo's `.mcp.json` carries team-shared MCP servers (currently `rails-mcp-server` if present). Per-developer opt-in via `.claude/settings.local.json` `enabledMcpjsonServers`.
+
+For Cursor: `.cursor/mcp.json` mirrors `.mcp.json` for team-shared servers.
+
+## Code Intelligence (Cross-Project)
+
+Three personal dev tools that work across all CampusESP repos. Configure at user scope (Claude Code plugins, global `~/.cursor/mcp.json`) — not in this project's MCP configs.
+
+### Serena (semantic code search & symbolic edits)
+
+LSP-backed symbolic tools for the AI: `find_symbol`, `replace_symbol_body`, `find_referencing_symbols`, `get_symbols_overview`. Prefer over Read/Grep/Edit when working on Ruby code.
+
+**Install:**
+
+```bash
+uvx --from git+https://github.com/oraios/serena serena --help  # smoke test
+serena setup claude-code                                       # registers MCP server
+```
+
+**Cursor** (`~/.cursor/mcp.json`):
+
+```json
+"serena": {
+  "command": "serena",
+  "args": ["start-mcp-server", "--context=ide", "--project-from-cwd"]
+}
+```
+
+`--context=ide` is the right context for Cursor; `--context=claude-code` is for Claude Code.
+
+**Project files (`.serena/`)** — when populated, commit `.serena/.gitignore`, `.serena/project.yml`, and `.serena/memories/` (verify `project.yml` has no absolute paths). Serena's bundled `.serena/.gitignore` keeps `cache/` and `project.local.yml` out of git.
+
+### code-graph-mcp (call graph, impact analysis)
+
+Tracks the codebase as a graph; supports `impact_analysis` before signature changes, `get_call_graph`, `find_dead_code`, `find_similar_code`, `dependency_graph`, `semantic_code_search`.
+
+**Claude Code:**
+
+```
+/plugin marketplace add sdsrss/code-graph-mcp
+/plugin install code-graph-mcp
+/reload-plugins
+```
+
+**Cursor** (`~/.cursor/mcp.json`):
+
+```json
+"code-graph": {
+  "command": "npx",
+  "args": ["-y", "@sdsrs/code-graph"]
+}
+```
+
+The plugin/MCP creates a `.code-graph/` index — gitignored.
+
+### Repomix (bulk codebase packing)
+
+Packs the codebase (or a remote repo) into a single XML/markdown blob.
+
+**Claude Code:**
+
+```
+/plugin marketplace add yamadashy/repomix
+/plugin install repomix-mcp@repomix
+/plugin install repomix-commands@repomix
+/plugin install repomix-explorer@repomix
+```
+
+**Cursor** (`~/.cursor/mcp.json`):
+
+```json
+"repomix": {
+  "command": "npx",
+  "args": ["-y", "repomix@latest", "--mcp"]
+}
+```
+
+Output (`repomix-output.*`) is gitignored.
+
+### Choosing between Serena, code-graph-mcp, and Repomix
+
+The decision rule and apartment-specific triggers live in [`.claude/rules/tool-layer-apartment.md`](../.claude/rules/tool-layer-apartment.md), auto-loaded into AI sessions in this repo. Short version: Serena for symbols, code-graph for blast radius, Repomix for bounded holistic reads.
+
+## Cursor Setup
+
+### Plugins (Preferred)
+
+- **[Upstash (Context7)](https://cursor.com/marketplace/upstash)** — Library documentation lookup
+- **[Firecrawl](https://cursor.com/marketplace/firecrawl)** — Web scraping and search
+- **[Sentry](https://cursor.com/marketplace/sentry)** — Error tracking and debugging
+
+### Project MCP Servers
+
+`.cursor/mcp.json` carries team-shared MCP servers (matches `.mcp.json`).
+
+### Global MCP Servers
+
+Personal dev tools at `~/.cursor/mcp.json`:
+
+- **`serena`** — `serena start-mcp-server --context=ide --project-from-cwd`
+- **`repomix`** — `npx -y repomix@latest --mcp`
+- **`code-graph`** — `npx -y @sdsrs/code-graph`
+- Database servers as configured for `www`
+
+## Verification
+
+```bash
+claude mcp list           # Claude Code MCP servers
+ls .claude/rules/         # auto-loaded rules
+```
+
+In Claude Code:
+```
+> Use serena to find_symbol Apartment::Tenant
+> Use code-graph to get_call_graph for Apartment::Adapters::PostgresqlSchemaAdapter
+```


### PR DESCRIPTION
## Summary

Adds AI dev-tooling documentation and project-scoped tool-selection rules.

## Related Trello Card

N/A — internal dev-tooling chore.

## Product Changes

N/A — internal dev-tooling change with no user-visible behavior.

### Product Impact

Dev team only. Documents the Serena, Repomix, and code-graph-mcp setup for AI-assisted work in this fork. Particularly useful when investigating apartment-side bugs surfaced by the main app, since the AI sessions in this repo will now know which tool to reach for.

## Technical Changes

- `docs/ai-tools-setup.md` (new): plugin/skill/MCP hierarchy, capabilities table, Cursor and Claude Code install paths for Serena/Repomix/code-graph, project MCP server notes.
- `.claude/rules/tool-layer-apartment.md` (new): auto-loaded project-rules file with the three-tool layer model (Serena scalpel / code-graph map / Repomix print job), 8 apartment-specific triggers, and rough week allocation. Notes that this is a fork — when investigating "why did we diverge from upstream here?", reach for the GitHub MCP plugin.
- `.gitignore`: ignore `.code-graph/` and `repomix-output.*` if not already present.

## Testing Guidance

### QA (UI/UX)

N/A — UI-only change.

### Technical QA

N/A — no runtime code, no Ruby changes, no test changes.

Verification:

\`\`\`bash
ls .claude/rules/tool-layer-apartment.md  # rules file present
cat docs/ai-tools-setup.md | head -20      # doc readable
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)