### PR TITLE
Add .cursor/mcp.json for rails-mcp-server

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "rails-mcp-server": {
+      "command": "rails-mcp-server",
+      "args": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Check in `.cursor/mcp.json` so Cursor users get `rails-mcp-server` wired up out of the box

## Test plan
- [ ] Open the repo in Cursor and confirm the MCP server is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)