### PR TITLE
Register worktrees with Serena and give each a unique project name

### DIFF
--- a/bin/dev/remove-worktree
+++ b/bin/dev/remove-worktree
@@ -174,6 +174,17 @@ else
     fi
 fi
 
+# --- Serena registry cleanup ---
+# Strips this worktree's path from ~/.serena/serena_config.yml. Setup-worktree
+# also prunes stale entries on the next run as a safety net, but doing it here
+# keeps the daemon healthy until then (stale entries crash samefile checks).
+SERENA_CONFIG="$HOME/.serena/serena_config.yml"
+if [ -f "$SERENA_CONFIG" ] && grep -qxF -- "- $ABS_PATH" "$SERENA_CONFIG"; then
+    grep -vxF -- "- $ABS_PATH" "$SERENA_CONFIG" > "${SERENA_CONFIG}.tmp" \
+        && mv "${SERENA_CONFIG}.tmp" "$SERENA_CONFIG"
+    log_info "Serena: deregistered $ABS_PATH"
+fi
+
 # ---------------------------------------------------------------------------
 # Optionally delete the local branch
 # ---------------------------------------------------------------------------

--- a/bin/dev/setup-worktree
+++ b/bin/dev/setup-worktree
@@ -82,19 +82,26 @@ SERENA_PROJECT_NAME="${REPO_BASENAME}-${WORKTREE_NAME}"
 if [ -f "$SERENA_CONFIG" ]; then
     # Prune entries whose paths no longer exist (defense in depth — handles
     # worktrees removed via `git worktree remove` instead of bin/dev/remove-worktree).
-    # `projects:` is the final top-level block; everything after it is `- /path`.
+    # We enter "projects" mode on the `projects:` key and exit on the next
+    # top-level YAML key, so we never path-test `- ` items belonging to a
+    # sibling list Serena might add in a future config layout.
     PRUNED=0
     TMP_CFG="${SERENA_CONFIG}.tmp.$$"
+    trap 'rm -f "$TMP_CFG"' EXIT INT TERM
     in_projects=0
     while IFS= read -r line; do
         if [[ "$line" == "projects:" ]]; then
             in_projects=1
+            printf '%s\n' "$line" >> "$TMP_CFG"
+        elif [[ $in_projects -eq 1 && "$line" =~ ^[A-Za-z] ]]; then
+            in_projects=0
             printf '%s\n' "$line" >> "$TMP_CFG"
         elif [[ $in_projects -eq 1 && "$line" =~ ^-\ (.+)$ ]]; then
             stale_path="${BASH_REMATCH[1]}"
             if [ -d "$stale_path" ]; then
                 printf '%s\n' "$line" >> "$TMP_CFG"
             else
+                log_info "Serena: pruning stale registration $stale_path"
                 PRUNED=$((PRUNED + 1))
             fi
         else
@@ -102,9 +109,12 @@ if [ -f "$SERENA_CONFIG" ]; then
         fi
     done < "$SERENA_CONFIG"
     mv "$TMP_CFG" "$SERENA_CONFIG"
-    [ $PRUNED -gt 0 ] && log_info "Serena: pruned $PRUNED stale path(s) from $SERENA_CONFIG"
+    trap - EXIT INT TERM
+    if [ $PRUNED -gt 0 ]; then
+        log_info "Serena: pruned $PRUNED stale path(s) from $SERENA_CONFIG"
+    fi
 
-    # Idempotent append (whole-line match avoids substring collisions).
+    # Idempotent append.
     if grep -qxF -- "- $ABS_WORKTREE_PATH" "$SERENA_CONFIG"; then
         log_info "Serena: already registered ($ABS_WORKTREE_PATH)"
     else

--- a/bin/dev/setup-worktree
+++ b/bin/dev/setup-worktree
@@ -47,6 +47,8 @@ fi
 
 # Resolve main repo from git worktree list (works even when invoked from a worktree)
 MAIN_REPO_PATH=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
+REPO_BASENAME=$(basename "$MAIN_REPO_PATH")
+WORKTREE_NAME=$(basename "$WORKTREE_PATH")
 
 if [ ! -d "$WORKTREE_PATH" ]; then
     log_error "Worktree path '$WORKTREE_PATH' does not exist"
@@ -59,6 +61,73 @@ log_info "Worktree: $WORKTREE_PATH"
 log_info "Main repo: $MAIN_REPO_PATH"
 
 cd "$WORKTREE_PATH" || { log_error "Failed to cd into $WORKTREE_PATH"; exit 1; }
+ABS_WORKTREE_PATH=$(pwd)
+
+# ---------------------------------------------------------------------------
+# Serena registration
+# ---------------------------------------------------------------------------
+# Two failure modes this prevents:
+#   1. Stale entries in ~/.serena/serena_config.yml that point at deleted
+#      worktrees crash the project-server daemon during samefile checks.
+#   2. Multiple worktrees sharing the same `project_name` (because
+#      .serena/project.yml is tracked) cause `query_project` to raise
+#      ValueError: Multiple projects found with name 'X'.
+# Fix: append this worktree's absolute path (idempotent), prune stale paths,
+# and override project_name locally via the gitignored project.local.yml.
+section "Registering with Serena"
+
+SERENA_CONFIG="$HOME/.serena/serena_config.yml"
+SERENA_PROJECT_NAME="${REPO_BASENAME}-${WORKTREE_NAME}"
+
+if [ -f "$SERENA_CONFIG" ]; then
+    # Prune entries whose paths no longer exist (defense in depth — handles
+    # worktrees removed via `git worktree remove` instead of bin/dev/remove-worktree).
+    # `projects:` is the final top-level block; everything after it is `- /path`.
+    PRUNED=0
+    TMP_CFG="${SERENA_CONFIG}.tmp.$$"
+    in_projects=0
+    while IFS= read -r line; do
+        if [[ "$line" == "projects:" ]]; then
+            in_projects=1
+            printf '%s\n' "$line" >> "$TMP_CFG"
+        elif [[ $in_projects -eq 1 && "$line" =~ ^-\ (.+)$ ]]; then
+            stale_path="${BASH_REMATCH[1]}"
+            if [ -d "$stale_path" ]; then
+                printf '%s\n' "$line" >> "$TMP_CFG"
+            else
+                PRUNED=$((PRUNED + 1))
+            fi
+        else
+            printf '%s\n' "$line" >> "$TMP_CFG"
+        fi
+    done < "$SERENA_CONFIG"
+    mv "$TMP_CFG" "$SERENA_CONFIG"
+    [ $PRUNED -gt 0 ] && log_info "Serena: pruned $PRUNED stale path(s) from $SERENA_CONFIG"
+
+    # Idempotent append (whole-line match avoids substring collisions).
+    if grep -qxF -- "- $ABS_WORKTREE_PATH" "$SERENA_CONFIG"; then
+        log_info "Serena: already registered ($ABS_WORKTREE_PATH)"
+    else
+        printf -- '- %s\n' "$ABS_WORKTREE_PATH" >> "$SERENA_CONFIG"
+        log_info "Serena: registered $ABS_WORKTREE_PATH"
+    fi
+else
+    log_warn "Serena config not found ($SERENA_CONFIG); skipping registration"
+fi
+
+# Override project_name in the gitignored project.local.yml so this worktree
+# carries a unique identity (e.g. apartment-v4-foundation) without dirtying
+# the tracked project.yml. Serena merges *.local.yml over project.yml.
+# Create .serena/ if absent — the daemon will auto-create project.yml on first
+# activation, but we want the project_name override in place beforehand.
+mkdir -p .serena
+LOCAL_YML=".serena/project.local.yml"
+if [ -f "$LOCAL_YML" ] && grep -q '^project_name:' "$LOCAL_YML"; then
+    sed -i '' "s|^project_name:.*|project_name: \"$SERENA_PROJECT_NAME\"|" "$LOCAL_YML"
+else
+    printf 'project_name: "%s"\n' "$SERENA_PROJECT_NAME" >> "$LOCAL_YML"
+fi
+log_info "Serena: project_name = $SERENA_PROJECT_NAME (in $LOCAL_YML)"
 
 # Copy files/directories using ditto (macOS-native, APFS copy-on-write)
 copy_if_exists() {
@@ -87,8 +156,6 @@ PEACOCK_COLOR=""
 REGISTRY="${WORKTREE_COLOR_REGISTRY:-$HOME/.config/campusesp/color-registry.json}"
 
 if [ "$SKIP_PEACOCK" = false ]; then
-    WORKTREE_NAME=$(basename "$WORKTREE_PATH")
-
     # Gracefully degrade if jq or registry are missing
     if ! command -v jq &>/dev/null; then
         log_warn "jq not found — skipping Peacock color assignment (brew install jq)"


### PR DESCRIPTION
## Summary

Patches `bin/dev/setup-worktree` and `bin/dev/remove-worktree` to keep this repo's worktrees in sync with Serena's project registry at `~/.serena/serena_config.yml`.

## Why

Two failure modes can crash Serena's `query_project` the first time a worktree is created in this repo:

1. **Stale registry entries.** `~/.serena/serena_config.yml`'s `projects:` list grows when Serena activates against a path. When a worktree is later removed, the entry stays. The project-server daemon `os.path.samefile()`-checks every entry on each call and raises `FileNotFoundError` before reaching the target project — every subsequent call 500s.

2. **`project_name` collisions.** `.serena/project.yml` is tracked, so every worktree inherits `project_name: "apartment"`. Name-based lookup raises `ValueError: Multiple projects found with name 'apartment'`.

## Changes

**`bin/dev/setup-worktree`:**
- Prune entries from `~/.serena/serena_config.yml` whose paths no longer exist (catches worktrees removed via plain `git worktree remove`)
- Idempotently append the new worktree's absolute path
- Write `project_name: "apartment-<worktree-name>"` to `.serena/project.local.yml` (already in `.serena/.gitignore`); Serena merges `*.local.yml` over `project.yml`

**`bin/dev/remove-worktree`:**
- Strip the worktree's path from `~/.serena/serena_config.yml` after `git worktree remove`

## Risk

| Concern | Mitigation |
|---|---|
| Prune block over-deletes | Whole-line YAML matching (`grep -qxF`); only paths whose `[ -d ]` check fails are dropped; tested under `/bin/bash` against fixture |
| Race on shared config file | Rewrites via temp + `mv` (atomic on same filesystem); single-user dev tooling, not concurrent |
| Non-macOS users | `sed -i ''` is BSD-style, consistent with existing scripts marked "macOS-only" |
| Side effects on main repo's `.serena/project.yml` | None — main repo only carries `project_name: "apartment"`; worktrees override via gitignored `project.local.yml` |

## Verification

- `bash -n` passes on both scripts
- Prune block tested against fixture: drops only stale paths, preserves existing ones

## Test plan

- [ ] Create a worktree: `bin/dev/setup-worktree ../apartment-worktrees/test`
- [ ] Verify `~/.serena/serena_config.yml` lists the worktree path
- [ ] Verify `../apartment-worktrees/test/.serena/project.local.yml` contains `project_name: "apartment-test"`
- [ ] Remove: `bin/dev/remove-worktree test --delete-branch --confirm`
- [ ] Verify the path is gone from `~/.serena/serena_config.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)