### PR TITLE
Add Dependabot security-only config and OSV-Scanner workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot config — security updates only.
+#
+# `open-pull-requests-limit: 0` disables version updates without affecting
+# security updates: per GitHub docs, security updates are not subject to that
+# limit and fire whenever a Dependabot Security Advisory matches a dependency
+# in the lockfile.
+#
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "security"
+      - "dependencies"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    labels:
+      - "security"
+      - "ci"
+    commit-message:
+      prefix: "security(ci)"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -21,12 +21,14 @@ on:
     paths:
       - "Gemfile"
       - "Gemfile.lock"
+      - "gemfiles/**"
       - "*.gemspec"
       - ".github/workflows/**"
       - ".github/dependabot.yml"
   push:
     branches: [main]
   schedule:
+    # Mondays 09:30 UTC.
     - cron: "30 9 * * 1"
   workflow_dispatch:
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,56 @@
+name: Security Scan
+
+# Two-layer dependency vulnerability scanning:
+#
+# 1. PR-time scan via OSV-Scanner reusable workflow: diffs base vs head, fails
+#    the workflow on newly introduced vulns. OSV cross-references GHSA, NVD,
+#    GSD, RustSec, and ecosystem-specific advisory DBs (RubyGems included).
+#
+# 2. Weekly scheduled scan via OSV-Scanner: catches existing-but-newly-disclosed
+#    vulns without waiting for a PR. Failed runs are visible in the Actions
+#    tab; findings are in the run log; admins receive email on failure.
+#
+# Pairs with .github/dependabot.yml (security-only Dependabot PRs) for the
+# CVE fast-path.
+#
+# Security note: this workflow does NOT execute any user-controlled input
+# in run: blocks. All steps use reusable workflows with typed inputs.
+
+on:
+  pull_request:
+    paths:
+      - "Gemfile"
+      - "Gemfile.lock"
+      - "*.gemspec"
+      - ".github/workflows/**"
+      - ".github/dependabot.yml"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 9 * * 1"
+  workflow_dispatch:
+
+# Top-level permissions. The reusable OSV-Scanner workflows declare
+# `security-events: write` in their own permissions block; GitHub validates
+# the caller against that declaration at workflow-parse time, BEFORE
+# checking whether the workflow actually needs the permission. So even
+# though we set `upload-sarif: false` (because Code Scanning needs GHAS
+# and we're not on it), the caller must still grant `security-events: write`
+# or the workflow won't validate.
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  osv-scan-pr:
+    if: github.event_name == 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5
+    with:
+      upload-sarif: false
+
+  osv-scan-scheduled:
+    if: github.event_name != 'pull_request'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      upload-sarif: false


### PR DESCRIPTION
## Summary

Two-part dependency security stack for this gem:

- `.github/dependabot.yml` — security updates only (`bundler` + `github-actions`), no weekly version PRs
- `.github/workflows/security-scan.yml` — OSV-Scanner reusable workflow at PR-time and on a weekly schedule

## Why

Two complementary layers, low maintenance:

1. **CVE fast-path** — Dependabot opens a PR within hours of a GitHub Security Advisory matching a dependency in `Gemfile.lock`. `open-pull-requests-limit: 0` disables the noisy weekly *version* update PRs while leaving security updates active (security updates are exempt from that limit per [GitHub docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates)).
2. **Existing-vuln scan** — OSV-Scanner cross-references GHSA, NVD, GSD, RustSec, and ecosystem-specific advisory DBs (RubyGems included). The PR-time job blocks merges that introduce a new vuln; the scheduled job (Mondays 09:30 UTC) surfaces vulns that were disclosed against unchanged dependencies.

## Risk

| Concern | Mitigation |
|---|---|
| Caller-side permission validation rejects the workflow | Top-level `permissions:` grants `security-events: write` even though `upload-sarif: false` — required because GitHub validates caller perms against the called reusable workflow's *declared* perms at parse time, regardless of input flags |
| `upload-sarif: false` reduces visibility | Code Scanning / SARIF upload requires GitHub Advanced Security, which this repo doesn't have. Failed runs still appear in the Actions tab and email admins. The PR-time job blocks merges on new vulns either way |
| Workflow injection in `run:` blocks | None — this workflow has no `run:` blocks; only typed inputs to reusable workflows |
| Dependabot noise | `open-pull-requests-limit: 0` zeros version-update PRs; only security advisories trigger |
| OSV-Scanner false positives on dev-only dependencies | Acceptable in scope for this gem — surfaces them, lets reviewer decide. Can be tuned via `scan-args` later if it becomes a problem |

## Verification

- `ruby -ryaml -e 'YAML.load_file(...)'` parses both files without error
- `actionlint` not available locally; relying on GitHub's parse-time validation on first push
- OSV-Scanner reusable workflow inputs verified against `google/osv-scanner-action` v2.3.5

## Test plan

- [ ] Workflow appears in the Actions tab after merge
- [ ] First scheduled run (next Monday 09:30 UTC) completes; surfaces any existing vulns
- [ ] PR that touches `Gemfile.lock` triggers `osv-scan-pr`
- [ ] Dependabot opens a security PR if/when a matching advisory is published
- [ ] No version-update PRs from Dependabot (would indicate `open-pull-requests-limit: 0` isn't working as documented)

## Notes

- Action-pin bumps were out of scope for this PR — the gem's existing workflows pin `actions/checkout@v4`, `ruby/setup-ruby@v1`, and `rubygems/release-gem@v1`, none of which are on the bump list. Dependabot-github-actions will keep them current going forward via the security-only path
- No `.dependency-constraints.yml` — the gemspec's version constraints already act as a watch list for this repo
- No SARIF upload, no `actions/dependency-review-action` — both require GHAS

🤖 Generated with [Claude Code](https://claude.com/claude-code)