### PR TITLE
Extract Config#apply_defaults! so validate! stays read-only

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -34,7 +34,7 @@ loader.setup
 
 require_relative 'apartment/errors'
 
-module Apartment
+module Apartment # rubocop:disable Metrics/ModuleLength
   class << self
     attr_reader :config, :pool_manager, :pool_reaper
     attr_writer :adapter
@@ -109,6 +109,7 @@ module Apartment
 
       new_config = Config.new
       yield(new_config)
+      new_config.apply_defaults!
       new_config.validate!
       new_config.freeze!
 

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -108,13 +108,17 @@ module Apartment
       freeze
     end
 
+    # Apply derived defaults that depend on user-set values. Runs after the
+    # configure block yields and before validate!, so validate! stays read-only.
+    def apply_defaults!
+      # PostgreSQL's default schema is 'public'; avoid forcing every user to set it.
+      @default_tenant ||= 'public' if @tenant_strategy == :schema
+    end
+
     # Validate configuration completeness and consistency.
     # Raises ConfigurationError on invalid state.
     def validate! # rubocop:disable Metrics/AbcSize
       raise(ConfigurationError, 'tenant_strategy is required') unless @tenant_strategy
-
-      # PostgreSQL's default schema is 'public'; avoid forcing every user to set it.
-      @default_tenant ||= 'public' if @tenant_strategy == :schema
 
       if @default_tenant.is_a?(String) && @default_tenant.strip.empty?
         raise(ConfigurationError, 'default_tenant cannot be an empty string')

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -146,19 +146,25 @@ RSpec.describe(Apartment::Config) do
 
       it 'defaults to public for schema strategy when not set' do
         config.tenant_strategy = :schema
-        config.validate!
+        config.apply_defaults!
         expect(config.default_tenant).to(eq('public'))
       end
 
       it 'preserves explicit default_tenant for schema strategy' do
         config.tenant_strategy = :schema
         config.default_tenant = 'custom'
-        config.validate!
+        config.apply_defaults!
         expect(config.default_tenant).to(eq('custom'))
       end
 
       it 'does not default for database_name strategy' do
         config.tenant_strategy = :database_name
+        config.apply_defaults!
+        expect(config.default_tenant).to(be_nil)
+      end
+
+      it 'is not applied by validate!; validate! stays read-only' do
+        config.tenant_strategy = :schema
         config.validate!
         expect(config.default_tenant).to(be_nil)
       end


### PR DESCRIPTION
## Summary

Move the `@default_tenant = 'public'` fallback for `:schema` strategy out of `Config#validate!` and into a new `Config#apply_defaults!` step, called from `Apartment.configure` between the user block and `validate!`.

The configure pipeline is now: `yield -> apply_defaults! -> validate! -> freeze!`. `validate!` becomes a pure predicate.

Addresses @mrpasquini's [review feedback on #375](https://github.com/rails-on-services/apartment/pull/375#discussion_r3175668985) — `validate!` mutating `@default_tenant` is unexpected for a method named \`validate!\`. The setter-based alternative was considered but rejected because it depends on call ordering (user may set `default_tenant` after `tenant_strategy`); a separate defaulting phase keeps the contract clear regardless of ordering.

Thanks @mrpasquini for the careful read.

## Test plan

- [x] `bundle exec rspec spec/unit/config_spec.rb` — passes (covers new `apply_defaults!` method and asserts `validate!` no longer mutates)
- [x] `bundle exec rspec spec/unit/` — 676 examples, 0 failures, 53 pending (env-only)
- [x] `bundle exec rubocop lib/apartment.rb lib/apartment/config.rb spec/unit/config_spec.rb` — clean
- [ ] CI matrix (Ruby 3.3/3.4/4.0 x Rails 7.2/8.0/8.1/main x PG/MySQL/SQLite)