### PR TITLE
bin/dev/remove-worktree: harden branch detection + path resolution

### DIFF
--- a/bin/dev/remove-worktree
+++ b/bin/dev/remove-worktree
@@ -78,7 +78,15 @@ if [ ! -d "$WORKTREE_PATH" ]; then
     fi
 fi
 
-ABS_PATH=$(cd "$WORKTREE_PATH" 2>/dev/null && pwd || echo "$WORKTREE_PATH")
+# Resolve to an absolute path. The cd-and-pwd dance fails silently if the
+# directory is missing or unreadable, leaving $ABS_PATH set to the (possibly
+# relative) input. Downstream cleanup blocks compare $ABS_PATH against entries
+# in the Serena registry (absolute paths only); a relative fallback misses the
+# match and leaves the entry stale. Hard-error instead.
+if ! ABS_PATH=$(cd "$WORKTREE_PATH" 2>/dev/null && pwd); then
+    log_error "Could not resolve $WORKTREE_PATH to an absolute path"
+    exit 1
+fi
 WORKTREE_NAME=$(basename "$ABS_PATH")
 
 header "Remove worktree: $WORKTREE_NAME"
@@ -86,6 +94,10 @@ header "Remove worktree: $WORKTREE_NAME"
 # ---------------------------------------------------------------------------
 # Detect branch (using line-based parsing to handle paths with spaces)
 # ---------------------------------------------------------------------------
+# Try the porcelain parser first (also tells us this is a real registered
+# worktree), then fall back to symbolic-ref directly. The fallback handles
+# worktrees whose porcelain entry is malformed or already detached — without
+# it the script silently skipped --delete-branch and looked like a no-op.
 BRANCH=""
 IS_GIT_WORKTREE=false
 if git worktree list --porcelain | grep -q "^worktree ${ABS_PATH}$"; then
@@ -95,8 +107,11 @@ if git worktree list --porcelain | grep -q "^worktree ${ABS_PATH}$"; then
         found && /^branch / { sub("^branch refs/heads/", ""); print; exit }
         found && /^worktree / { exit }
     ')
-    [ -n "$BRANCH" ] && log_info "Branch: $BRANCH"
 fi
+if [ -z "$BRANCH" ]; then
+    BRANCH=$(git -C "$ABS_PATH" symbolic-ref --short -q HEAD 2>/dev/null || true)
+fi
+[ -n "$BRANCH" ] && log_info "Branch: $BRANCH"
 
 # ---------------------------------------------------------------------------
 # Check for uncommitted changes


### PR DESCRIPTION
## Summary

Two robustness fixes for `bin/dev/remove-worktree`. Both were observed in practice in a sister CampusESP repo (data-analysis) where `bin/remove-worktree pending-post-notification-gap` ran to "completion" but silently skipped Serena deregistration and branch deletion. The www and cloud-form-code scripts have already been brought in line; this PR brings apartment to parity.

### 1. Branch detection now has a fallback

The porcelain awk parser was the only branch-detection path:

```bash
if git worktree list --porcelain | grep -q "^worktree ${ABS_PATH}$"; then
    IS_GIT_WORKTREE=true
    BRANCH=$(git worktree list --porcelain | awk ...)
fi
```

When the worktree's porcelain entry is malformed or missing (partial state from a previous failed removal, weird detached-HEAD encoding), `$BRANCH` stays empty and `--delete-branch` is silently a no-op. Now we fall back to `git -C "$ABS_PATH" symbolic-ref --short -q HEAD`, which works regardless of porcelain state.

### 2. Path resolution is now a hard error

Previously:

```bash
ABS_PATH=$(cd "$WORKTREE_PATH" 2>/dev/null && pwd || echo "$WORKTREE_PATH")
```

When `cd` fails, `$ABS_PATH` silently becomes the (possibly relative) input string. Downstream cleanup blocks compare `$ABS_PATH` against absolute paths in `~/.serena/serena_config.yml`, so a relative fallback misses the match and leaves the entry stale — the exact incident that prompted this. Hard-error instead; a relative path here is never correct.

## Companion PRs (already merged)

- CampusESP/data-analysis — `bin/remove-worktree`
- CampusESP/www — `bin/dev/remove-worktree`
- cloud-form-code already had this shape from the start (was the inspiration for the symbolic-ref fallback in the others)

Apartment was the only outstanding repo because PR #384 had already merged when the bug was discovered.

## Test plan

- [ ] Reviewer: `bin/dev/remove-worktree <path-that-doesnt-exist> --delete-branch --confirm` should hard-error on path resolution instead of proceeding silently.
- [ ] Reviewer: create a worktree, manually corrupt its `.git` ref, then run `bin/dev/remove-worktree <name> --delete-branch --confirm`. Branch should still be detected via the symbolic-ref fallback and deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)