### PR TITLE
Add .gemini/settings.json to mirror existing MCP config

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "rails-mcp-server": {
+      "type": "stdio",
+      "command": "rails-mcp-server",
+      "args": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.gemini/settings.json` so contributors using Gemini CLI get the same `rails-mcp-server` tooling that's already configured for Claude Code (`.mcp.json`) and Cursor (`.cursor/mcp.json`).
- Contents are byte-equivalent to `.mcp.json`; no new dependencies, no secrets.

## Why

Gemini CLI loads MCP servers from `<repo>/.gemini/settings.json` (per [gemini-cli docs](https://geminicli.com/docs/cli/settings)). Without this file, Gemini-CLI users get only their global MCP servers, missing the rails-mcp-server that other agents already see in this repo.

## Test plan

- [ ] `gemini mcp list` from the repo root shows `rails-mcp-server`
- [ ] Existing `.mcp.json` and `.cursor/mcp.json` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)