### PR TITLE
Add Tenant.with_tenants_provider + with_tenants — block-scoped tenant resolver override

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,7 +68,7 @@ Rails/SkipsModelValidations:
     - lib/apartment/pool_manager.rb
 
 Metrics/ClassLength:
-  Max: 155
+  Max: 165
   Exclude:
     - spec/**/*.rb
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,7 +68,7 @@ Rails/SkipsModelValidations:
     - lib/apartment/pool_manager.rb
 
 Metrics/ClassLength:
-  Max: 165
+  Max: 155
   Exclude:
     - spec/**/*.rb
 

--- a/docs/plans/with-tenants-provider/plan.md
+++ b/docs/plans/with-tenants-provider/plan.md
@@ -1,0 +1,111 @@
+# Plan — `Apartment::Tenant.with_tenants_provider` + `with_tenants`
+
+Tracks issue [#390](https://github.com/rails-on-services/apartment/issues/390). Adds a block-scoped override for the resolver that produces the tenant list. Single PR off `main`.
+
+## Goal
+
+Block-scoped primitive that overrides `config.tenants_provider` for the duration of a block, applied uniformly at every "what tenants do we have?" call site. Production semantics unchanged when no block is active.
+
+## Public API
+
+```ruby
+# Mechanism: swap the resolver. Accepts callable or coerce-to-Array(String|Symbol).
+Apartment::Tenant.with_tenants_provider(source) { ... }
+
+# Convenience: enumerated list (splat). Delegates to with_tenants_provider.
+Apartment::Tenant.with_tenants(*names) { ... }
+```
+
+Accepted shapes for `source`:
+
+| Input | Coerced to |
+|---|---|
+| Object responding to `:call` | kept as-is (re-evaluated on each `tenant_names` access in scope) |
+| String / Symbol | `Array(source).map(&:to_s).freeze` |
+| Array of String/Symbol | `source.map(&:to_s).freeze` |
+
+`with_tenants(*names)` is `with_tenants_provider(names, &block)` — splat avoids the `with_tenants(['a'])` vs `with_tenants('a')` ambiguity.
+
+## Scope: every call site, one resolver
+
+`Apartment.tenant_names` becomes the single resolver. The Enumerable check moves up so it applies to both the ambient `tenants_provider` and per-block overrides. Five call sites that currently call `config.tenants_provider.call` directly are rerouted:
+
+| File:line | Current | After |
+|---|---|---|
+| `lib/apartment/schema_cache.rb:18` | `Apartment.config.tenants_provider.call.map { ... }` | `Apartment.tenant_names.map { ... }` |
+| `lib/apartment/migrator.rb:66` | `tenants = Apartment.config.tenants_provider.call` | `tenants = Apartment.tenant_names` |
+| `lib/apartment/cli/seeds.rb:32` | `tenants = Apartment.config.tenants_provider.call` | `tenants = Apartment.tenant_names` |
+| `lib/apartment/cli/tenants.rb:40` | `Apartment.config.tenants_provider.call.each { say(t) }` | `Apartment.tenant_names.each { say(t) }` |
+| `lib/apartment/cli/tenants.rb:59` | `tenants = Apartment.config.tenants_provider.call` | `tenants = Apartment.tenant_names` |
+| `lib/apartment/cli/migrations.rb:82` | `tenants = Apartment.config.tenants_provider.call` | `tenants = Apartment.tenant_names` |
+
+`Tenant.fetch_tenant_list` (private helper in `lib/apartment/tenant.rb`) collapses into `Apartment.tenant_names`. `Tenant.each` becomes `Apartment.tenant_names.each { ... }` when no explicit list is passed.
+
+## Mechanism
+
+`Current.tenant_override` lives on `Apartment::Current` (`ActiveSupport::CurrentAttributes`). Fiber-safe, auto-reset per Rails request, propagates through ActiveJob — strict upgrade over the `Thread.current` sketch in the issue body.
+
+```ruby
+# lib/apartment/current.rb
+class Current < ActiveSupport::CurrentAttributes
+  attribute :tenant, :previous_tenant, :migrating, :tenant_override
+end
+```
+
+## Implementation phasing
+
+One PR, three commits, in this order:
+
+### Commit 1 — Reroute call sites through `Apartment.tenant_names`
+
+Refactor only. No behavior change. Pulls the Enumerable check up into the resolver and updates the five direct call sites + `Tenant.fetch_tenant_list`.
+
+- `lib/apartment.rb` — `tenant_names` becomes the canonical resolver. Validates `respond_to?(:each)` on the resolved value.
+- `lib/apartment/tenant.rb` — drop `fetch_tenant_list`, point `each` at `Apartment.tenant_names`.
+- Five rerouted files above.
+
+Tests that already exercise `each` and `tenant_names` should pass unchanged. Add a test that proves `tenant_names` raises on non-Enumerable returns from `tenants_provider` (currently only `Tenant.each` does this; the new resolver makes it uniform).
+
+### Commit 2 — Add `Current.tenant_override` and the public methods
+
+- `lib/apartment/current.rb` — add the `:tenant_override` attribute.
+- `lib/apartment/tenant.rb` — add `with_tenants_provider(source)` and `with_tenants(*names)` as public class methods on the `<< self` block.
+- `lib/apartment.rb` — `tenant_names` reads `Current.tenant_override` first; falls back to `@config.tenants_provider`. Same Enumerable check.
+
+### Commit 3 — Specs
+
+- `spec/unit/tenant_spec.rb` — block primitive specs.
+- `spec/unit/apartment_spec.rb` — resolver specs (override wins, callable override re-evaluates, ambient when no override).
+
+## Test plan
+
+Unit (`spec/unit/`):
+
+- `with_tenants_provider` accepts a callable; resolver invokes it on each `tenant_names` access inside the block.
+- `with_tenants_provider` coerces String → `[String]`, Symbol → `[String]`, `[String, Symbol]` → `[String, String]`, all frozen.
+- `with_tenants(*names)` delegates: `with_tenants('a', 'b')` ≡ `with_tenants_provider(['a', 'b'])`.
+- Empty array override (`with_tenants` with no args) yields zero iterations through `Tenant.each`. `[]` is distinguishable from `nil`.
+- Nesting: inner override fully replaces outer for the inner block, outer restored after inner returns.
+- Ensure-restore: raise inside the block restores `Current.tenant_override` to its previous value.
+- Override applies at every rerouted call site: `Apartment.tenant_names`, `Tenant.each`, `Migrator#run` (smoke check that it consumes the override list), `SchemaCache.dump_all` (smoke), CLI commands skipped (covered by integration if needed).
+- Non-callable, non-coercible input (e.g., `Object.new`) — raises `ArgumentError` from `with_tenants_provider`. (Or is silently coerced via `Array(...)` → `[]`? Decide in implementation; `Array()` is permissive but masks bugs. Lean toward explicit raise.)
+- Callable override that returns a non-Enumerable raises `ConfigurationError` with the same message shape as `tenants_provider`.
+- Block-not-given raises `ArgumentError`.
+- Fiber isolation: `Fiber.new { Current.tenant_override }` inside the block sees `nil` (CurrentAttributes is fiber-local).
+
+Integration: not required for this change — the override is a pure-Ruby resolver swap with no DB interaction.
+
+## Out of scope (deferred)
+
+- ActiveJob propagation tests — needs the host-app railtie test infra; tracked separately in `docs/designs/v4-railtie-test-infra.md`.
+- RSpec metadata helper (`describe MyJob, tenants: [...]`) — host-side, not gem-side.
+- Validation against ambient `tenants_provider` — explicitly rejected (issue body argues this).
+- `config.skip_missing_schemas` — explicitly rejected (silent skipping in production is a footgun).
+
+## Backward compatibility
+
+All public surface is additive. Existing `Tenant.each(tenants)` with explicit list arg continues to work; the override only kicks in when no list is passed *and* `Current.tenant_override` is set. No deprecation, no breaking change.
+
+## Estimated size
+
+~30 lines of implementation + ~150 lines of spec. Single PR, mergeable into `main`, included in next alpha cut.

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -16,7 +16,7 @@ v4 replaces the thread-local tenant switching model with pool-per-tenant archite
 
 ### Configuration
 
-`config.tenant_names` has been removed. Use `config.tenants_provider` instead; it must be a callable (proc or lambda). The convenience method `Apartment.tenant_names` still works — it delegates to `config.tenants_provider.call`.
+`config.tenant_names` has been removed. Use `config.tenants_provider` instead; it must be a callable (proc or lambda). The convenience method `Apartment.tenant_names` still works — it is now the single resolver used internally by `Tenant.each`, `Migrator`, `SchemaCache`, and the CLI commands. It honors a per-block override set via `Apartment::Tenant.with_tenants_provider` / `Apartment::Tenant.with_tenants` when one is active, and validates that the resolved value responds to `:each` (raising `ConfigurationError` otherwise — previously this check ran only in `Tenant.each`).
 
 `config.tenant_strategy` is now required. Supported values: `:schema` (PostgreSQL schema-per-tenant) and `:database_name` (separate database per tenant). Additional strategies (`:shard`, `:database_config`) are reserved for future use and will raise `AdapterNotFound` if configured today.
 

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -71,12 +71,19 @@ module Apartment # rubocop:disable Metrics/ModuleLength
       @activated == true
     end
 
-    # v3 compatibility: Apartment.tenant_names returns the current tenant list.
-    # Delegates to config.tenants_provider.call.
+    # Returns the current tenant list. Single resolver used by Tenant.each,
+    # Migrator, SchemaCache, and the CLI commands. Resolves through
+    # @config.tenants_provider; the result must respond to :each.
     def tenant_names
       raise(ConfigurationError, 'Apartment not configured. Call Apartment.configure first.') unless @config
 
-      @config.tenants_provider.call
+      result = @config.tenants_provider.call
+
+      unless result.respond_to?(:each)
+        raise(ConfigurationError,
+              "tenants_provider must return an Enumerable, got #{result.class}")
+      end
+      result
     end
 
     # v3 compatibility: Apartment.excluded_models returns the excluded models list.

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -72,16 +72,24 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     end
 
     # Returns the current tenant list. Single resolver used by Tenant.each,
-    # Migrator, SchemaCache, and the CLI commands. Resolves through
-    # @config.tenants_provider; the result must respond to :each.
+    # Migrator, SchemaCache, and the CLI commands. Honors the per-block
+    # override set by Tenant.with_tenants_provider / with_tenants when present;
+    # otherwise resolves through @config.tenants_provider.
+    #
+    # The override (or the configured provider) may itself be a callable, in
+    # which case it is invoked on every access. Whatever the source, the
+    # resolved value must respond to :each.
     def tenant_names
       raise(ConfigurationError, 'Apartment not configured. Call Apartment.configure first.') unless @config
 
-      result = @config.tenants_provider.call
+      override = Current.tenant_override
+      source = override || @config.tenants_provider
+      result = source.respond_to?(:call) ? source.call : source
 
       unless result.respond_to?(:each)
+        source_label = override ? 'tenant_override' : 'tenants_provider'
         raise(ConfigurationError,
-              "tenants_provider must return an Enumerable, got #{result.class}")
+              "#{source_label} must return an Enumerable, got #{result.class}")
       end
       result
     end

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -35,7 +35,7 @@ loader.setup
 require_relative 'apartment/errors'
 
 module Apartment # rubocop:disable Metrics/ModuleLength
-  class << self
+  class << self # rubocop:disable Metrics/ClassLength
     attr_reader :config, :pool_manager, :pool_reaper
     attr_writer :adapter
 

--- a/lib/apartment/cli/migrations.rb
+++ b/lib/apartment/cli/migrations.rb
@@ -79,7 +79,7 @@ module Apartment
       end
 
       def rollback_all
-        tenants = Apartment.config.tenants_provider.call
+        tenants = Apartment.tenant_names
         failed = []
         tenants.each do |t|
           rollback_single(t)

--- a/lib/apartment/cli/seeds.rb
+++ b/lib/apartment/cli/seeds.rb
@@ -29,7 +29,7 @@ module Apartment
       end
 
       def seed_all
-        tenants = Apartment.config.tenants_provider.call
+        tenants = Apartment.tenant_names
         failed = []
         tenants.each do |t|
           say("Seeding tenant: #{t}")

--- a/lib/apartment/cli/tenants.rb
+++ b/lib/apartment/cli/tenants.rb
@@ -37,7 +37,7 @@ module Apartment
 
       desc 'list', 'List all tenants'
       def list
-        Apartment.config.tenants_provider.call.each { |t| say(t) }
+        Apartment.tenant_names.each { |t| say(t) }
       end
 
       desc 'current', 'Show current tenant'
@@ -56,7 +56,7 @@ module Apartment
       end
 
       def create_all
-        tenants = Apartment.config.tenants_provider.call
+        tenants = Apartment.tenant_names
         failed = []
         tenants.each do |t|
           say("Creating tenant: #{t}") unless quiet?

--- a/lib/apartment/current.rb
+++ b/lib/apartment/current.rb
@@ -6,6 +6,6 @@ module Apartment
   # Fiber-safe tenant context using ActiveSupport::CurrentAttributes.
   # Replaces the v3 Thread.current[:apartment_adapter] approach.
   class Current < ActiveSupport::CurrentAttributes
-    attribute :tenant, :previous_tenant, :migrating
+    attribute :tenant, :previous_tenant, :migrating, :tenant_override
   end
 end

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -5,7 +5,7 @@ require_relative 'instrumentation'
 require_relative 'errors'
 
 module Apartment
-  class Migrator
+  class Migrator # rubocop:disable Metrics/ClassLength
     Result = Data.define(
       :tenant,
       :status,

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -63,7 +63,7 @@ module Apartment
         )
       end
 
-      tenants = Apartment.config.tenants_provider.call
+      tenants = Apartment.tenant_names
       tenant_results = if @threads.positive?
                          run_parallel(tenants)
                        else

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -5,7 +5,7 @@ require_relative 'instrumentation'
 require_relative 'errors'
 
 module Apartment
-  class Migrator # rubocop:disable Metrics/ClassLength
+  class Migrator
     Result = Data.define(
       :tenant,
       :status,

--- a/lib/apartment/schema_cache.rb
+++ b/lib/apartment/schema_cache.rb
@@ -15,7 +15,7 @@ module Apartment
     end
 
     def dump_all
-      Apartment.config.tenants_provider.call.map { |t| dump(t) }
+      Apartment.tenant_names.map { |t| dump(t) }
     end
 
     def cache_path_for(tenant)

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -75,6 +75,52 @@ module Apartment
         tenants.each { |tenant| switch(tenant) { yield(tenant) } }
       end
 
+
+      # Block-scoped override of the tenant resolver. For the duration of the
+      # block, every "what tenants do we have?" call site (Apartment.tenant_names,
+      # Tenant.each, Migrator, SchemaCache, CLI commands) reads from +source+
+      # instead of config.tenants_provider.
+      #
+      # +source+ may be a callable (re-evaluated on each access) or anything
+      # coercible to an Array of strings via Array(source).map(&:to_s). Empty
+      # arrays are honored — Tenant.each yields zero times. Nesting fully
+      # replaces the outer override; the previous value is restored on block
+      # exit (including via raise).
+      #
+      #   Apartment::Tenant.with_tenants_provider(['acme', 'widgets']) do
+      #     Apartment::Tenant.each { |t| ... }       # yields acme, widgets only
+      #   end
+      #
+      #   Apartment::Tenant.with_tenants_provider(-> { Account.recent.pluck(:id) }) do
+      #     Apartment::Tenant.each { |t| ... }
+      #   end
+      def with_tenants_provider(source)
+        raise(ArgumentError, 'Apartment::Tenant.with_tenants_provider requires a block') unless block_given?
+
+        override =
+          if source.respond_to?(:call)
+            source
+          else
+            Array(source).map(&:to_s).freeze
+          end
+
+        previous = Current.tenant_override
+        Current.tenant_override = override
+        yield
+      ensure
+        Current.tenant_override = previous
+      end
+
+      # Convenience splat over with_tenants_provider for the common case of an
+      # enumerated list of names.
+      #
+      #   Apartment::Tenant.with_tenants('acme', 'widgets') do
+      #     Apartment::Tenant.each { |t| ... }
+      #   end
+      def with_tenants(*names, &block)
+        with_tenants_provider(names, &block)
+      end
+
       # Pool stats delegated to pool_manager.
       def pool_stats
         Apartment.pool_manager&.stats || {}

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -75,7 +75,6 @@ module Apartment
         tenants.each { |tenant| switch(tenant) { yield(tenant) } }
       end
 
-
       # Block-scoped override of the tenant resolver. For the duration of the
       # block, every "what tenants do we have?" call site (Apartment.tenant_names,
       # Tenant.each, Migrator, SchemaCache, CLI commands) reads from +source+
@@ -117,8 +116,8 @@ module Apartment
       #   Apartment::Tenant.with_tenants('acme', 'widgets') do
       #     Apartment::Tenant.each { |t| ... }
       #   end
-      def with_tenants(*names, &block)
-        with_tenants_provider(names, &block)
+      def with_tenants(*names, &)
+        with_tenants_provider(names, &)
       end
 
       # Pool stats delegated to pool_manager.

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -71,7 +71,7 @@ module Apartment
       def each(tenants = nil)
         raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
 
-        tenants ||= fetch_tenant_list
+        tenants ||= Apartment.tenant_names
         tenants.each { |tenant| switch(tenant) { yield(tenant) } }
       end
 
@@ -81,17 +81,6 @@ module Apartment
       end
 
       private
-
-      def fetch_tenant_list
-        config = Apartment.config or
-          raise(ConfigurationError, 'Apartment not configured. Call Apartment.configure first.')
-        result = config.tenants_provider.call
-        unless result.respond_to?(:each)
-          raise(ConfigurationError,
-                "tenants_provider must return an Enumerable, got #{result.class}")
-        end
-        result
-      end
 
       def adapter
         Apartment.adapter or

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -80,8 +80,20 @@ module Apartment
       # Tenant.each, Migrator, SchemaCache, CLI commands) reads from +source+
       # instead of config.tenants_provider.
       #
-      # +source+ may be a callable (re-evaluated on each access) or anything
-      # coercible to an Array of strings via Array(source).map(&:to_s). Empty
+      # The override is in-process, fiber-safe, and block-local. It does NOT
+      # automatically propagate to ActiveJob workers, child threads, or other
+      # processes — pass tenant names as job arguments if cross-process scoping
+      # is required.
+      #
+      # Accepted shapes for +source+:
+      #
+      #   * A callable (responds to +:call+) — re-evaluated on every
+      #     +Apartment.tenant_names+ access inside the block. Use a frozen Array
+      #     instead if you need a stable snapshot.
+      #   * A String or Symbol — coerced to a single-element Array of strings.
+      #   * An Array of String/Symbol — coerced to an Array of strings.
+      #
+      # Anything else (+nil+, Hash, arbitrary object) raises ArgumentError. Empty
       # arrays are honored — Tenant.each yields zero times. Nesting fully
       # replaces the outer override; the previous value is restored on block
       # exit (including via raise).
@@ -96,18 +108,15 @@ module Apartment
       def with_tenants_provider(source)
         raise(ArgumentError, 'Apartment::Tenant.with_tenants_provider requires a block') unless block_given?
 
-        override =
-          if source.respond_to?(:call)
-            source
-          else
-            Array(source).map(&:to_s).freeze
-          end
+        override = coerce_tenant_override(source)
 
         previous = Current.tenant_override
         Current.tenant_override = override
-        yield
-      ensure
-        Current.tenant_override = previous
+        begin
+          yield
+        ensure
+          Current.tenant_override = previous
+        end
       end
 
       # Convenience splat over with_tenants_provider for the common case of an
@@ -126,6 +135,38 @@ module Apartment
       end
 
       private
+
+      # Validate and coerce a +with_tenants_provider+ source argument.
+      # Callables pass through. String, Symbol, and Arrays of String/Symbol
+      # become a frozen Array<String>. Everything else raises ArgumentError —
+      # silently coercing nil/Hash/random objects produces tenant names like
+      # "" or "[:k, v]" that fail far from the call site.
+      def coerce_tenant_override(source)
+        return source if source.respond_to?(:call)
+
+        names = wrap_tenant_names(source)
+        validate_tenant_name_array!(names)
+        names.map(&:to_s).freeze
+      end
+
+      def wrap_tenant_names(source)
+        case source
+        when String, Symbol then [source]
+        when Array          then source
+        else
+          raise(ArgumentError,
+                'Apartment::Tenant.with_tenants_provider expects a callable, ' \
+                "String, Symbol, or Array of String/Symbol; got #{source.class}")
+        end
+      end
+
+      def validate_tenant_name_array!(names)
+        return if names.all? { |n| n.is_a?(String) || n.is_a?(Symbol) }
+
+        raise(ArgumentError,
+              'Apartment::Tenant.with_tenants_provider Array entries must be ' \
+              'String or Symbol')
+      end
 
       def adapter
         Apartment.adapter or

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -69,6 +69,29 @@ RSpec.describe(Apartment) do
       described_class.clear_config
       expect { described_class.tenant_names }.to(raise_error(Apartment::ConfigurationError, /not configured/))
     end
+
+    it 'raises ConfigurationError when tenants_provider returns a non-Enumerable' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { 42 }
+      end
+
+      expect do
+        described_class.tenant_names
+      end.to(raise_error(Apartment::ConfigurationError, /tenants_provider must return an Enumerable/))
+    end
+
+    it 'returns the override when Current.tenant_override is set' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { %w[ambient] }
+      end
+
+      Apartment::Tenant.with_tenants_provider(%w[overridden]) do
+        expect(described_class.tenant_names).to(eq(%w[overridden]))
+      end
+      expect(described_class.tenant_names).to(eq(%w[ambient]))
+    end
   end
 
   describe '.excluded_models' do

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe(Apartment) do
   end
 
   describe '.tenant_names' do
-    it 'delegates to config.tenants_provider.call' do
+    it 'returns the result of calling config.tenants_provider' do
       tenants = %w[acme widgets]
       described_class.configure do |config|
         config.tenant_strategy = :schema

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -267,6 +267,128 @@ RSpec.describe(Apartment::Tenant) do
     end
   end
 
+  describe '.with_tenants_provider' do
+    it 'requires a block' do
+      expect { described_class.with_tenants_provider(['a']) }.to(raise_error(ArgumentError, /requires a block/))
+    end
+
+    it 'overrides the resolver for Apartment.tenant_names' do
+      described_class.with_tenants_provider(%w[acme widgets]) do
+        expect(Apartment.tenant_names).to(eq(%w[acme widgets]))
+      end
+    end
+
+    it 'overrides the resolver for Tenant.each' do
+      visited = []
+      described_class.with_tenants_provider(%w[acme widgets]) do
+        described_class.each { |t| visited << t }
+      end
+      expect(visited).to(eq(%w[acme widgets]))
+    end
+
+    it 'restores the ambient resolver after the block' do
+      described_class.with_tenants_provider(%w[acme]) {}
+      expect(Apartment.tenant_names).to(eq(%w[tenant1 tenant2]))
+    end
+
+    it 'restores the ambient resolver after an exception in the block' do
+      begin
+        described_class.with_tenants_provider(%w[acme]) { raise('boom') }
+      rescue RuntimeError
+        nil
+      end
+      expect(Apartment.tenant_names).to(eq(%w[tenant1 tenant2]))
+    end
+
+    it 'coerces a String to a single-element Array of strings' do
+      described_class.with_tenants_provider('acme') do
+        expect(Apartment.tenant_names).to(eq(%w[acme]))
+      end
+    end
+
+    it 'coerces a Symbol to a single-element Array of strings' do
+      described_class.with_tenants_provider(:acme) do
+        expect(Apartment.tenant_names).to(eq(%w[acme]))
+      end
+    end
+
+    it 'coerces an Array of mixed Strings and Symbols to strings' do
+      described_class.with_tenants_provider([:acme, 'widgets']) do
+        expect(Apartment.tenant_names).to(eq(%w[acme widgets]))
+      end
+    end
+
+    it 'freezes the coerced override Array' do
+      described_class.with_tenants_provider(%w[acme widgets]) do
+        expect(Apartment::Current.tenant_override).to(be_frozen)
+      end
+    end
+
+    it 'honors an empty Array (Tenant.each yields zero times)' do
+      visited = []
+      described_class.with_tenants_provider([]) do
+        described_class.each { |t| visited << t }
+      end
+      expect(visited).to(eq([]))
+    end
+
+    it 'accepts a callable and re-evaluates it on every tenant_names access' do
+      calls = 0
+      callable = lambda do
+        calls += 1
+        ["tenant_#{calls}"]
+      end
+
+      described_class.with_tenants_provider(callable) do
+        expect(Apartment.tenant_names).to(eq(%w[tenant_1]))
+        expect(Apartment.tenant_names).to(eq(%w[tenant_2]))
+      end
+      expect(calls).to(eq(2))
+    end
+
+    it 'raises ConfigurationError when a callable override returns a non-Enumerable' do
+      callable = -> { 42 }
+      described_class.with_tenants_provider(callable) do
+        expect do
+          Apartment.tenant_names
+        end.to(raise_error(Apartment::ConfigurationError, /tenant_override must return an Enumerable/))
+      end
+    end
+
+    it 'fully replaces an outer override when nested' do
+      seen_inside = nil
+      described_class.with_tenants_provider(%w[outer1 outer2]) do
+        described_class.with_tenants_provider(%w[inner]) do
+          seen_inside = Apartment.tenant_names
+        end
+        expect(Apartment.tenant_names).to(eq(%w[outer1 outer2]))
+      end
+      expect(seen_inside).to(eq(%w[inner]))
+    end
+  end
+
+  describe '.with_tenants' do
+    it 'delegates to with_tenants_provider with the splat as the source' do
+      visited = []
+      described_class.with_tenants('acme', 'widgets') do
+        described_class.each { |t| visited << t }
+      end
+      expect(visited).to(eq(%w[acme widgets]))
+    end
+
+    it 'with no arguments yields zero iterations through Tenant.each' do
+      visited = []
+      described_class.with_tenants do
+        described_class.each { |t| visited << t }
+      end
+      expect(visited).to(eq([]))
+    end
+
+    it 'requires a block' do
+      expect { described_class.with_tenants('acme') }.to(raise_error(ArgumentError, /requires a block/))
+    end
+  end
+
   describe '.create' do
     it 'delegates to adapter' do
       expect(mock_adapter).to(receive(:create).with('new_tenant'))

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -365,6 +365,48 @@ RSpec.describe(Apartment::Tenant) do
       end
       expect(seen_inside).to(eq(%w[inner]))
     end
+
+    it 'does not clear an outer override when the inner call raises ArgumentError' do
+      described_class.with_tenants_provider(%w[outer]) do
+        expect do
+          described_class.with_tenants_provider(%w[inner]) # no block
+        end.to(raise_error(ArgumentError, /requires a block/))
+        expect(Apartment::Current.tenant_override).to(eq(%w[outer]))
+      end
+    end
+
+    it 'does not clear an outer override when coercion raises ArgumentError' do
+      described_class.with_tenants_provider(%w[outer]) do
+        expect do
+          described_class.with_tenants_provider(nil) { :unreachable }
+        end.to(raise_error(ArgumentError, /callable, String, Symbol/))
+        expect(Apartment::Current.tenant_override).to(eq(%w[outer]))
+      end
+    end
+
+    it 'raises ArgumentError for nil' do
+      expect do
+        described_class.with_tenants_provider(nil) { :unreachable }
+      end.to(raise_error(ArgumentError, /callable, String, Symbol/))
+    end
+
+    it 'raises ArgumentError for a Hash' do
+      expect do
+        described_class.with_tenants_provider({ acme: 1 }) { :unreachable }
+      end.to(raise_error(ArgumentError, /callable, String, Symbol/))
+    end
+
+    it 'raises ArgumentError for an arbitrary object' do
+      expect do
+        described_class.with_tenants_provider(Object.new) { :unreachable }
+      end.to(raise_error(ArgumentError, /callable, String, Symbol/))
+    end
+
+    it 'raises ArgumentError for an Array containing a non-String/Symbol entry' do
+      expect do
+        described_class.with_tenants_provider(['acme', 42]) { :unreachable }
+      end.to(raise_error(ArgumentError, /Array entries must be String or Symbol/))
+    end
   end
 
   describe '.with_tenants' do


### PR DESCRIPTION
Closes #390.

## Summary

Adds a block-scoped primitive that overrides `config.tenants_provider` for the duration of a block, applied uniformly at every "what tenants do we have?" call site. Production semantics unchanged when no block is active.

```ruby
# Mechanism: swap the resolver. Accepts callable, String, Symbol, or Array of String/Symbol.
Apartment::Tenant.with_tenants_provider(-> { Account.recent.pluck(:subdomain) }) do
  Apartment::Tenant.each { |t| ... }
end

# Convenience splat for the common enumerated-list case.
Apartment::Tenant.with_tenants('acme', 'widgets') do
  Apartment::Tenant.each { |t| ... }
end
```

## How it works

- `Apartment::Current` gains a `:tenant_override` attribute (`ActiveSupport::CurrentAttributes` — fiber-safe, in-process, block-local).
- `Apartment.tenant_names` becomes the single resolver. It reads `Current.tenant_override` first; falls back to `@config.tenants_provider`. Both paths run through one Enumerable check.
- Six call sites that previously called `config.tenants_provider.call` directly (`Tenant.each` via `fetch_tenant_list`, `Migrator`, `SchemaCache`, three CLI commands) now go through `Apartment.tenant_names`. The private `Tenant.fetch_tenant_list` helper collapses into the resolver.
- **Coercion** (validated up front): callables pass through unchanged (re-evaluated on each access); String/Symbol → single-element `Array<String>`; `Array<String|Symbol>` → frozen `Array<String>`. Anything else (`nil`, `Hash`, arbitrary object, Array with non-String/Symbol entries) raises `ArgumentError` at the call site.
- Nesting fully replaces the outer override; the previous value is restored on block exit (including via raise). The state capture is paired with assignment so an early raise (no block, invalid source) does not wipe an outer override.
- Empty arrays are honored — `with_tenants` with no args yields zero iterations through `Tenant.each`.

## Concurrency / scope

The override is **in-process and block-local**. It does NOT automatically propagate to ActiveJob workers, child threads, or other processes. If cross-process scoping is required, pass tenant names as job arguments (or wire a `before_perform` hook).

`Migrator#run` resolves `Apartment.tenant_names` once on the parent thread before parallel fan-out, so worker threads consume a local Array — no cross-thread `Current.tenant_override` propagation needed.

## Why a block primitive (vs. a `skip_missing_schemas` global)

Discussed in detail on the issue. Silent-skip in production turns a broken provider or unprovisioned tenant into wrong-tenant or no-op work. The block primitive is opt-in and explicit — the caller has already enumerated the names.

## Why the pair `with_tenants_provider` + `with_tenants`

Symmetry with `config.tenants_provider`: `with_tenants_provider` is the mechanism (accepts callable or coerce-to-Array), `with_tenants(*names)` is the convenience splat for the common test-case shape. Splat (rather than a single Array arg) avoids the `with_tenants(['a'])` vs `with_tenants('a')` ambiguity.

## Behavior change called out

`Apartment.tenant_names` previously returned `config.tenants_provider.call` raw, with no Enumerable validation. It now validates the result responds to `:each` (raising `ConfigurationError` otherwise — previously this check ran only inside `Tenant.each` via the now-removed `fetch_tenant_list` helper). Documented in `docs/upgrading-to-v4.md`.

## Commit shape

1. **a69c7af** Route tenant-list resolution through `Apartment.tenant_names` — pure refactor. Pulls the Enumerable check up; reroutes the five direct call sites; drops `Tenant.fetch_tenant_list`.
2. **09524cf** Add `Tenant.with_tenants_provider` and `Tenant.with_tenants` — adds `Current.tenant_override`, the public methods, and the override-aware branch in the resolver.
3. **b4984f7** Spec the new resolver, override, and block primitives — 18 unit specs covering coercion, callable, nesting, raise/restore, empty array, non-Enumerable errors.
4. **6197ac3** Address review feedback (multi-agent: Cursor, Codex, internal reviewer):
   - **P1** — Fix outer-override leak when `with_tenants_provider` is called without a block (or with an invalid source) from inside an outer override. Hoist state capture into a `begin/ensure` paired with the assignment.
   - **P2** — Tighten coercion: explicit `ArgumentError` on `nil`, `Hash`, arbitrary objects, or Arrays containing non-String/Symbol entries. Plan had called for this; implementation had drifted permissive.
   - **P3** — Drop misleading "propagates through ActiveJob" claim from docstrings.
   - **P4** — Update `docs/upgrading-to-v4.md` to describe the new resolver semantics.
   - **P5** — Rename stale `"delegates to config.tenants_provider.call"` spec.
   - **P6** — Restore `Migrator`'s per-class `Metrics/ClassLength` disable, revert global ceiling bump, add per-singleton disable on the apartment.rb façade.

   Adds 6 regression specs (no-block-from-inside-outer-override, coercion-failure-from-inside-outer-override, nil, Hash, arbitrary object, Array-with-non-String/Symbol).

## Test plan

- [x] `bundle exec rspec spec/unit/` — 700 examples, 0 failures, 53 pending
- [x] `bundle exec rubocop` — 134 files, 0 offenses
- [ ] CI green across Ruby 3.3/3.4/4.0 × Rails 7.2/8.0/8.1/main matrix

## Out of scope (deferred)

- ActiveJob propagation tests — needs the host-app railtie test infra (tracked in `docs/designs/v4-railtie-test-infra.md`). The override does NOT auto-propagate by design; cross-process scoping is the host's responsibility.
- RSpec metadata helper (`describe MyJob, tenants: [...]`) — host-side, not gem-side.
- Validation against ambient `tenants_provider` — explicitly rejected (would defeat the test-suite use case where specs create their own schemas).

## Backward compatibility

All public surface is additive. `Tenant.each(tenants)` with explicit list arg continues to work; the override only applies when no list is passed *and* `Current.tenant_override` is set. The only semantic change is the new Enumerable check on `Apartment.tenant_names` (called out above and in the upgrade doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)