### PR TITLE
Default-tenant guardrails (closes #393)

### DIFF
--- a/docs/plans/default-tenant-guardrails/plan.md
+++ b/docs/plans/default-tenant-guardrails/plan.md
@@ -1,61 +1,81 @@
 # Plan — Default-tenant guardrails (explicit base-schema semantics)
 
-Tracks issue [#393](https://github.com/rails-on-services/apartment/issues/393). Adds guardrails around `Apartment.config.default_tenant` so apps can opt out of the implicit-public model that produces order-dependent test flake and "I created a record but `each` doesn't see it" surprise. Single PR off `main`.
+Tracks issue [#393](https://github.com/rails-on-services/apartment/issues/393). Adds opt-in guardrails around `Apartment.config.default_tenant` so apps can elect explicit base-schema semantics without the v4 default changing for everyone. Single PR off `main`.
 
 ## Goal
 
-Close the asymmetry where `Tenant.current` falls back to `default_tenant` (read-side implicit) while `Tenant.each` excludes it (write-side excluded). The fix is two cheap predicates plus one configurable guard — not a rename, not a strict-mode rewrite, not a deprecation cycle.
+Close the asymmetry where `Tenant.current` falls back to `default_tenant` (read-side implicit) while `Tenant.each` excludes it (write-side excluded). The fix is two cheap predicates plus one **opt-in** configurable guard — not a rename, not a strict-mode rewrite, not a default behavior change.
 
 ## Non-goals
 
 - Renaming `default_tenant` to `base_schema`. The existing name spans `:schema` (PG) and `:database` (MySQL); `base_schema` is PG-specific and worse.
 - Changing `Tenant.current`'s fallback semantics. Logging, query tags, and Sentry breadcrumbs depend on a String return; returning `nil` would regress those.
-- An iterable-default flag (`base_schema_iterable`). Cleanup helpers stop needing default sweeps once the guards land; defer until a real use case appears.
+- An iterable-default flag (`base_schema_iterable`). Cleanup helpers stop needing default sweeps once apps adopt the guards; defer until a real use case appears.
 - Excluded-models behavior. `excluded_models` is already shimmed into `pinned_models` at `Tenant.init` time and is orthogonal to this work.
+- **A `Tenant.in_default_tenant { ... }` block API.** Deferred. Only justified if `default_tenant_switch_allowed = false` becomes the default (it doesn't, see below). Under the permissive default, `switch(default_tenant) { ... }` already works for the same use case.
+- **Cross-pool transaction visibility in tests.** Documented as a constraint of pool-per-tenant; not solved at the API level. Apps mixing transactional fixtures with cross-pool reads must use deletion strategies.
+
+## What changed after the downstream consumer briefing
+
+A v4 alpha consumer surfaced six asks. Panel review (Codex + Cursor) narrowed the upstream-appropriate scope:
+
+| Ask | Verdict | Where |
+|---|---|---|
+| `Tenant.switched?` | In | Commit 1 |
+| `Tenant.assert_inside_tenant!` | In | Commit 1 |
+| `assert_inside_tenant!(message:)` kwarg | In | Commit 2 |
+| `default_tenant_switch_allowed` flag | In, **default true everywhere** | Commit 2 |
+| `Tenant.in_default_tenant { ... }` block API | Deferred | — |
+| `switch!` stance clarification | In, doc-only | Commit 3 |
+| Cross-pool transaction visibility | Doc constraint, no API | Commit 3 |
+| `clean_excluded_models!` helper | Doc recipe, no helper | Commit 3 |
+| `tenant_names` memoization | Rejected (violates callable contract) | — |
+| `Tenant.create` + PG 17 `\restrict` | Separate issue, requires non-CampusESP reproducer | Follow-up |
+
+The strict-mode default flip was the biggest change. The consumer's actual flake came from wrapping in `switch('test-tenant')`, not `switch('public')` — so a `:schema`-strict default wouldn't have prevented their bug. Breaking v3 semantics by default needs a broader failure mode than one app's test discipline. Strict mode stays opt-in.
 
 ## Public API
 
 ```ruby
 # Predicate: was a tenant explicitly entered?
+# Reads Current.tenant directly (NOT Tenant.current); ignores the
+# default_tenant fallback.
 Apartment::Tenant.switched?            # => true | false
 
-# Test-time assertion: raise when no explicit tenant is active
+# Test-time assertion: raise when no explicit tenant is active.
+# Optional message: kwarg for richer failure context.
 Apartment::Tenant.assert_inside_tenant!
+Apartment::Tenant.assert_inside_tenant!(message: 'this spec must declare a tenant')
 
-# Config: guard explicit switches into the default tenant
+# Config: opt-in guard on switch(default_tenant) { ... }
 Apartment.configure do |config|
   config.default_tenant_switch_allowed = false  # raises on switch(default_tenant)
 end
 ```
 
-`Tenant.reset` continues to use `switch!` (no block, no guard) — it remains the legitimate path back to the default tenant under the strict default.
+`Tenant.reset` and `Tenant.switch!` continue to work without the guard — they remain the path back to the default tenant under strict mode. `switch(default_tenant) { ... }` is the only call shape the guard intercepts.
 
-## Strategy-keyed defaults
+## Defaults
 
-The pathology the issue describes is a PostgreSQL-`:schema` artifact: the `public` schema is simultaneously AR's default and Apartment's shared store. MySQL `:database` and PG `:database_name` don't have that overlap. Defaults reflect that:
+`default_tenant_switch_allowed` defaults to **`true` for all strategies**. Existing v4 alpha apps see no behavior change. Strict mode is opt-in:
 
-| Strategy | `default_tenant` default | `default_tenant_switch_allowed` default |
-|---|---|---|
-| `:schema` (PostgreSQL) | `'public'` | `false` |
-| `:database` (MySQL) | `nil` | `true` (no-op when default is nil) |
-| `:database_name` (PostgreSQL) | `nil` | `true` (no-op when default is nil) |
+```ruby
+# Recommended for new PG :schema apps that want strict tenant discipline:
+config.default_tenant_switch_allowed = false
+```
 
-When `default_tenant` is `nil`, the guard is inert — no real `switch(name)` argument matches `nil`. MySQL apps that explicitly set a `default_tenant` opt into the strict default if they also set `default_tenant_switch_allowed = false`; otherwise they get permissive behavior.
+When `default_tenant` is `nil` (current default for `:database` strategies), the guard is inert — no real `switch(name)` argument matches `nil`. So setting `default_tenant_switch_allowed = false` on MySQL is a safe no-op until the app also sets a `default_tenant`.
 
 ## Implementation surface
 
 ### `lib/apartment/config.rb`
-
-Add the attribute, defaults, validation:
 
 ```ruby
 attr_accessor :default_tenant_switch_allowed
 # initialize:
 @default_tenant_switch_allowed = nil
 # apply_defaults!:
-if @default_tenant_switch_allowed.nil?
-  @default_tenant_switch_allowed = (@tenant_strategy != :schema)
-end
+@default_tenant_switch_allowed = true if @default_tenant_switch_allowed.nil?
 # validate!:
 unless [true, false].include?(@default_tenant_switch_allowed)
   raise(ConfigurationError,
@@ -65,51 +85,52 @@ end
 
 ### `lib/apartment/tenant.rb`
 
-Three additions:
+Two changes (commit 1 already added `switched?` and `assert_inside_tenant!`):
 
 ```ruby
-# Guard inside switch (block form only — switch! stays unguarded so reset works)
+# Guard inside switch (block form only — switch! and reset stay unguarded)
 def switch(tenant, &block)
   raise(ArgumentError, 'Apartment::Tenant.switch requires a block') unless block
 
   cfg = Apartment.config
-  if cfg && !cfg.default_tenant_switch_allowed && tenant.to_s == cfg.default_tenant.to_s
+  if cfg && !cfg.default_tenant_switch_allowed &&
+     cfg.default_tenant && tenant.to_s == cfg.default_tenant.to_s
     raise(Apartment::ApartmentError,
           "switch(#{cfg.default_tenant.inspect}) is disabled by default_tenant_switch_allowed = false. " \
-          'Use Apartment::Tenant.reset for explicit re-entry into the default tenant.')
+          'Use Apartment::Tenant.reset for explicit re-entry into the default tenant, ' \
+          'or Apartment::Tenant.switch!(name) for non-block scopes.')
   end
 
-  # ... existing body ...
+  # ... existing body unchanged ...
 end
 
-def switched?
-  !Current.tenant.nil?
-end
-
-def assert_inside_tenant!
+# Update assert_inside_tenant! to accept an optional message
+def assert_inside_tenant!(message: nil)
   return if switched?
 
   raise(Apartment::ApartmentError,
+        message ||
         'Expected an explicit tenant context, but Apartment::Current.tenant is nil. ' \
-        'Wrap the call in Apartment::Tenant.switch(tenant) { ... } or call Apartment::Tenant.switch!(tenant).')
+        'Wrap the call in Apartment::Tenant.switch(tenant) { ... } or call ' \
+        'Apartment::Tenant.switch!(tenant).')
 end
 ```
 
-`switched?` reads `Current.tenant` directly — *not* `Tenant.current`. That's the semantic distinction: "did someone explicitly enter a tenant" is different from "what tenant is effectively active right now."
-
-`reset` is unchanged — it calls `switch!`, which never enters the guarded path.
+`reset` and `switch!` are unchanged — neither enters the guarded path.
 
 ### `lib/apartment/errors.rb`
 
-No new error class; reuses `Apartment::ApartmentError`. The message is the discriminator.
+No new error class; reuses `Apartment::ApartmentError`.
 
 ### Generator template
 
-`lib/generators/apartment/install/templates/apartment.rb` gets a commented line:
+`lib/generators/apartment/install/templates/apartment.rb`:
 
 ```ruby
-# Strict default for PostgreSQL :schema strategy. Set to true to allow
-# Apartment::Tenant.switch(default_tenant) { ... }; reset is always allowed.
+# Strict tenant discipline. When false, Apartment::Tenant.switch(default_tenant) { ... }
+# raises — forces apps to use Tenant.reset or Tenant.switch! for explicit
+# re-entry into the default tenant. Recommended for new PostgreSQL :schema
+# apps. Defaults to true for backward compatibility.
 # config.default_tenant_switch_allowed = false
 ```
 
@@ -117,94 +138,91 @@ No new error class; reuses `Apartment::ApartmentError`. The message is the discr
 
 One PR, three commits, in this order:
 
-### Commit 1 — Predicates and assertion (no behavior change)
+### Commit 1 — Predicates and assertion *(done — 3cfcd0d)*
 
-- `lib/apartment/tenant.rb` — add `switched?` and `assert_inside_tenant!`. Pure additions; no existing call sites change.
-- Specs in `spec/unit/tenant_spec.rb`.
+- `lib/apartment/tenant.rb` — `switched?` and `assert_inside_tenant!` added.
+- `spec/unit/tenant_spec.rb` — 9 specs covering both predicates.
 
-Ships first because it's risk-free and lets test suites adopt `assert_inside_tenant!` immediately, even before commit 2 lands.
+### Commit 2 — Config flag + switch guard + message kwarg
 
-### Commit 2 — Config flag + switch guard
-
-- `lib/apartment/config.rb` — attribute, defaults keyed on strategy, validation.
-- `lib/apartment/tenant.rb` — guard inside `switch` block form. `switch!` stays unguarded.
+- `lib/apartment/config.rb` — `default_tenant_switch_allowed` attribute, default `true`, validation.
+- `lib/apartment/tenant.rb` — guard inside `switch` block form; `assert_inside_tenant!` gains `message:` kwarg.
 - Generator template comment.
 - Specs:
-  - `spec/unit/config_spec.rb` — strategy-keyed defaults, validation.
-  - `spec/unit/tenant_spec.rb` — guard raises under strict; permits when allowed; `reset` always works; `switch!(default_tenant)` always works.
+  - `spec/unit/config_spec.rb` — default true regardless of strategy; explicit override; validation.
+  - `spec/unit/tenant_spec.rb` — guard raises when strict; permits when allowed; `reset` always works; `switch!(default_tenant)` always works; guard inert when `default_tenant` is nil; `assert_inside_tenant!(message:)` uses custom message.
 
 ### Commit 3 — Documentation
 
-- `docs/architecture.md` — short section on the default-tenant contract: AR base pool, holds pinned tables, in PG search path, never iterated by `each`.
-- `lib/apartment/CLAUDE.md` — note on the new predicates and the strategy-keyed default.
-- `CHANGELOG.md` — single entry describing the breaking default for `:schema` apps and the migration path (`config.default_tenant_switch_allowed = true` to keep v3 behavior).
+- `docs/architecture.md` — section on the default-tenant contract: AR base pool, holds pinned tables, in PG search path, never iterated by `each`.
+- `docs/testing.md` (new file) — three sections:
+  1. **Strict tenant discipline** — `default_tenant_switch_allowed = false` + `assert_inside_tenant!` recipe.
+  2. **`switch` vs `switch!` vs `reset`** — when each is right; explicit "switch! is not deprecated, use it for non-block scopes like `before(:context)`".
+  3. **Cross-pool transaction visibility constraint** — pool-per-tenant means writes in one pool's transaction aren't visible to another pool's connection. For specs that need cross-pool reads, use deletion strategies (DatabaseCleaner `:deletion` or `:truncation`) rather than transactional fixtures. Document an example pattern; do not provide an API.
+  4. **Cleaning shared (default) tenant data between specs** — recipe for iterating `Apartment.pinned_models` and `DELETE`-ing in tests; do not provide a helper method.
+- `lib/apartment/CLAUDE.md` — note the new predicates, config flag default, and link to `docs/testing.md`.
+- `CHANGELOG.md` — single entry: new opt-in guard, no breaking change.
 
 ## Test plan
 
 ### Unit
 
-- `Tenant.switched?` returns false when `Current.tenant` is nil; true after `switch!('a')`; false after `reset`; true inside a `switch(...) { }` block; false outside.
-- `Tenant.assert_inside_tenant!` raises with a helpful message when `Current.tenant` is nil; no-ops when switched.
-- Strategy-keyed defaults: `:schema` → `default_tenant_switch_allowed == false`; `:database` → `true`; explicit override (either direction) wins over strategy default.
+- `Tenant.switched?` (commit 1, done): false when nil; true after `switch!`; true after `reset` (reset is explicit entry); true inside `switch(...) { }`; false outside.
+- `Tenant.assert_inside_tenant!`: raises when nil with default message; no-ops when switched; honors `message:` kwarg.
+- `Config.default_tenant_switch_allowed`: defaults to `true` for all strategies; honors explicit override (true/false); validation rejects non-boolean.
 - Guard:
-  - `switch('public') { }` raises under `:schema` defaults.
-  - `switch('public') { }` permitted when `default_tenant_switch_allowed = true`.
+  - `switch('public') { }` permitted under default (`= true`).
+  - `switch('public') { }` raises when `default_tenant_switch_allowed = false` and `default_tenant = 'public'`.
   - `switch!('public')` permitted regardless.
-  - `Tenant.reset` permitted regardless (proves `reset` uses `switch!`).
-  - Guard is inert when `default_tenant` is nil (MySQL with no override).
+  - `Tenant.reset` permitted regardless (uses `switch!`).
+  - Guard inert when `default_tenant` is nil even with `= false`.
   - Guard does not trigger for non-default tenants.
-- Validation: non-boolean `default_tenant_switch_allowed` raises `ConfigurationError`.
 
 ### Integration
 
-No new integration specs required. Existing `spec/integration/v4/` suites should pass unchanged because:
-- `Tenant.reset` is unguarded, and the suites use it (or `switch!`) for setup/teardown.
-- No test calls `switch('public') { }` directly today (verified via grep before merging).
-
-If the grep turns up such call sites in fixtures or shared examples, those become migration touchpoints in the same PR.
-
-### Manual
-
-- `bin/dev/test-strict-default` smoke: configure `default_tenant_switch_allowed = false`, attempt `switch('public') { }` — confirms the error message points at `reset`.
+No new integration specs required. Grep verified zero `switch('public')` or `switch(default_tenant)` call sites in `lib/` or `spec/` (run on `main` before commit 1). Existing suites pass unchanged at default settings.
 
 ## Migration notes (for the CHANGELOG)
 
-For PG `:schema` apps upgrading to v4 with this change:
+No migration needed. The default behavior is unchanged. Apps wanting strict discipline:
 
 ```ruby
-# Restore v3 / pre-#393 behavior:
 Apartment.configure do |config|
-  config.default_tenant_switch_allowed = true
+  config.default_tenant_switch_allowed = false
 end
 ```
 
-For test suites adopting the strict default, a one-liner in the suite's `rails_helper.rb`:
+For test suites adopting strict mode:
 
 ```ruby
 RSpec.configure do |c|
-  c.before(:each, type: :tenant_scoped) { Apartment::Tenant.assert_inside_tenant! }
+  c.before(:each) { Apartment::Tenant.assert_inside_tenant! }
 end
 ```
 
-(or unconditionally in suites where every example must run inside a real tenant).
+(or scoped via metadata where appropriate).
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| Existing PG apps that do `switch('public') { … }` for shared work break on upgrade | CHANGELOG migration note + strategy-keyed default makes the change loud, not silent. The error message points at `reset`. |
-| Confusion between `Tenant.switched?` (raw) and `Tenant.current` (effective with fallback) | Document both in `docs/architecture.md`; `switched?` body is one line so the semantics stay legible. |
-| `assert_inside_tenant!` over-fires in app code that legitimately runs in default | It's opt-in. No automatic wiring. Apps choose where to call it. |
-| MySQL apps with custom `default_tenant` get permissive default unexpectedly | Documented in the generator template + CHANGELOG. Setting `default_tenant_switch_allowed = false` is one line. |
+| Strict-mode error message confuses callers | Message points at `reset` and `switch!` as the alternatives. |
+| `Current.tenant` vs `Tenant.current` keeps confusing readers | `docs/architecture.md` documents the distinction; `switched?` body is one line so semantics stay legible. |
+| Apps adopt strict mode and discover `before(:context)` doesn't fit a block | `docs/testing.md` documents `switch!` as the recommended pattern for non-block scopes. |
+| Cross-pool tx visibility footgun keeps surfacing | `docs/testing.md` documents the constraint plainly; no API change. |
 
-## Open questions
+## Follow-up issues to file
 
-- Should `Tenant.assert_inside_tenant!` accept an optional message argument for richer test failures? Defer; add when a caller asks.
-- Should we surface a Rails generator (`bin/rails g apartment:strict_tenancy`) that wires the RSpec hook? Defer; one-line copy-paste is cheap.
+These came out of the consumer briefing but don't belong in this PR:
+
+1. **`Tenant.create` reliability on Rails 7.1+ / PG 17 with `structure.sql`.** Needs a non-CampusESP reproducer before any API change. File as a bug with their `with_ddl_connection` workaround attached as context.
+2. **Optional `apartment-rspec` companion gem.** If multiple apps surface needs around `clean_pinned_models!`, a `before(:tenant_scoped)` hook helper, etc. — defer until a second app asks.
+
+Both are explicit follow-ups; this PR ships the smallest-coherent slice.
 
 ## Status
 
-- [ ] Commit 1 — predicates and assertion
-- [ ] Commit 2 — config flag and switch guard
-- [ ] Commit 3 — documentation and CHANGELOG
+- [x] Commit 1 — predicates and assertion
+- [ ] Commit 2 — config flag, switch guard, message kwarg
+- [ ] Commit 3 — documentation (architecture, testing, CHANGELOG)
 - [ ] Open PR off `main`

--- a/docs/plans/default-tenant-guardrails/plan.md
+++ b/docs/plans/default-tenant-guardrails/plan.md
@@ -21,7 +21,7 @@ A v4 alpha consumer surfaced six asks. Panel review (Codex + Cursor) narrowed th
 
 | Ask | Verdict | Where |
 |---|---|---|
-| `Tenant.switched?` | In | Commit 1 |
+| `Tenant.inside_tenant?` | In | Commit 1 |
 | `Tenant.assert_inside_tenant!` | In | Commit 1 |
 | `assert_inside_tenant!(message:)` kwarg | In | Commit 2 |
 | `default_tenant_switch_allowed` flag | In, **default true everywhere** | Commit 2 |
@@ -40,7 +40,7 @@ The strict-mode default flip was the biggest change. The consumer's actual flake
 # Predicate: was a tenant explicitly entered?
 # Reads Current.tenant directly (NOT Tenant.current); ignores the
 # default_tenant fallback.
-Apartment::Tenant.switched?            # => true | false
+Apartment::Tenant.inside_tenant?            # => true | false
 
 # Test-time assertion: raise when no explicit tenant is active.
 # Optional message: kwarg for richer failure context.
@@ -85,7 +85,7 @@ end
 
 ### `lib/apartment/tenant.rb`
 
-Two changes (commit 1 already added `switched?` and `assert_inside_tenant!`):
+Two changes (commit 1 already added `inside_tenant?` and `assert_inside_tenant!`):
 
 ```ruby
 # Guard inside switch (block form only — switch! and reset stay unguarded)
@@ -106,7 +106,7 @@ end
 
 # Update assert_inside_tenant! to accept an optional message
 def assert_inside_tenant!(message: nil)
-  return if switched?
+  return if inside_tenant?
 
   raise(Apartment::ApartmentError,
         message ||
@@ -140,7 +140,7 @@ One PR, three commits, in this order:
 
 ### Commit 1 — Predicates and assertion *(done — 3cfcd0d)*
 
-- `lib/apartment/tenant.rb` — `switched?` and `assert_inside_tenant!` added.
+- `lib/apartment/tenant.rb` — `inside_tenant?` and `assert_inside_tenant!` added.
 - `spec/unit/tenant_spec.rb` — 9 specs covering both predicates.
 
 ### Commit 2 — Config flag + switch guard + message kwarg
@@ -167,7 +167,7 @@ One PR, three commits, in this order:
 
 ### Unit
 
-- `Tenant.switched?` (commit 1, done): false when nil; true after `switch!`; true after `reset` (reset is explicit entry); true inside `switch(...) { }`; false outside.
+- `Tenant.inside_tenant?` (commit 1, done): false when nil; true after `switch!`; true after `reset` (reset is explicit entry); true inside `switch(...) { }`; false outside.
 - `Tenant.assert_inside_tenant!`: raises when nil with default message; no-ops when switched; honors `message:` kwarg.
 - `Config.default_tenant_switch_allowed`: defaults to `true` for all strategies; honors explicit override (true/false); validation rejects non-boolean.
 - Guard:
@@ -207,7 +207,7 @@ end
 | Risk | Mitigation |
 |---|---|
 | Strict-mode error message confuses callers | Message points at `reset` and `switch!` as the alternatives. |
-| `Current.tenant` vs `Tenant.current` keeps confusing readers | `docs/architecture.md` documents the distinction; `switched?` body is one line so semantics stay legible. |
+| `Current.tenant` vs `Tenant.current` keeps confusing readers | `docs/architecture.md` documents the distinction; `inside_tenant?` body is one line so semantics stay legible. |
 | Apps adopt strict mode and discover `before(:context)` doesn't fit a block | `docs/testing.md` documents `switch!` as the recommended pattern for non-block scopes. |
 | Cross-pool tx visibility footgun keeps surfacing | `docs/testing.md` documents the constraint plainly; no API change. |
 

--- a/docs/plans/default-tenant-guardrails/plan.md
+++ b/docs/plans/default-tenant-guardrails/plan.md
@@ -1,0 +1,210 @@
+# Plan — Default-tenant guardrails (explicit base-schema semantics)
+
+Tracks issue [#393](https://github.com/rails-on-services/apartment/issues/393). Adds guardrails around `Apartment.config.default_tenant` so apps can opt out of the implicit-public model that produces order-dependent test flake and "I created a record but `each` doesn't see it" surprise. Single PR off `main`.
+
+## Goal
+
+Close the asymmetry where `Tenant.current` falls back to `default_tenant` (read-side implicit) while `Tenant.each` excludes it (write-side excluded). The fix is two cheap predicates plus one configurable guard — not a rename, not a strict-mode rewrite, not a deprecation cycle.
+
+## Non-goals
+
+- Renaming `default_tenant` to `base_schema`. The existing name spans `:schema` (PG) and `:database` (MySQL); `base_schema` is PG-specific and worse.
+- Changing `Tenant.current`'s fallback semantics. Logging, query tags, and Sentry breadcrumbs depend on a String return; returning `nil` would regress those.
+- An iterable-default flag (`base_schema_iterable`). Cleanup helpers stop needing default sweeps once the guards land; defer until a real use case appears.
+- Excluded-models behavior. `excluded_models` is already shimmed into `pinned_models` at `Tenant.init` time and is orthogonal to this work.
+
+## Public API
+
+```ruby
+# Predicate: was a tenant explicitly entered?
+Apartment::Tenant.switched?            # => true | false
+
+# Test-time assertion: raise when no explicit tenant is active
+Apartment::Tenant.assert_inside_tenant!
+
+# Config: guard explicit switches into the default tenant
+Apartment.configure do |config|
+  config.default_tenant_switch_allowed = false  # raises on switch(default_tenant)
+end
+```
+
+`Tenant.reset` continues to use `switch!` (no block, no guard) — it remains the legitimate path back to the default tenant under the strict default.
+
+## Strategy-keyed defaults
+
+The pathology the issue describes is a PostgreSQL-`:schema` artifact: the `public` schema is simultaneously AR's default and Apartment's shared store. MySQL `:database` and PG `:database_name` don't have that overlap. Defaults reflect that:
+
+| Strategy | `default_tenant` default | `default_tenant_switch_allowed` default |
+|---|---|---|
+| `:schema` (PostgreSQL) | `'public'` | `false` |
+| `:database` (MySQL) | `nil` | `true` (no-op when default is nil) |
+| `:database_name` (PostgreSQL) | `nil` | `true` (no-op when default is nil) |
+
+When `default_tenant` is `nil`, the guard is inert — no real `switch(name)` argument matches `nil`. MySQL apps that explicitly set a `default_tenant` opt into the strict default if they also set `default_tenant_switch_allowed = false`; otherwise they get permissive behavior.
+
+## Implementation surface
+
+### `lib/apartment/config.rb`
+
+Add the attribute, defaults, validation:
+
+```ruby
+attr_accessor :default_tenant_switch_allowed
+# initialize:
+@default_tenant_switch_allowed = nil
+# apply_defaults!:
+if @default_tenant_switch_allowed.nil?
+  @default_tenant_switch_allowed = (@tenant_strategy != :schema)
+end
+# validate!:
+unless [true, false].include?(@default_tenant_switch_allowed)
+  raise(ConfigurationError,
+        "default_tenant_switch_allowed must be true or false, got: #{@default_tenant_switch_allowed.inspect}")
+end
+```
+
+### `lib/apartment/tenant.rb`
+
+Three additions:
+
+```ruby
+# Guard inside switch (block form only — switch! stays unguarded so reset works)
+def switch(tenant, &block)
+  raise(ArgumentError, 'Apartment::Tenant.switch requires a block') unless block
+
+  cfg = Apartment.config
+  if cfg && !cfg.default_tenant_switch_allowed && tenant.to_s == cfg.default_tenant.to_s
+    raise(Apartment::ApartmentError,
+          "switch(#{cfg.default_tenant.inspect}) is disabled by default_tenant_switch_allowed = false. " \
+          'Use Apartment::Tenant.reset for explicit re-entry into the default tenant.')
+  end
+
+  # ... existing body ...
+end
+
+def switched?
+  !Current.tenant.nil?
+end
+
+def assert_inside_tenant!
+  return if switched?
+
+  raise(Apartment::ApartmentError,
+        'Expected an explicit tenant context, but Apartment::Current.tenant is nil. ' \
+        'Wrap the call in Apartment::Tenant.switch(tenant) { ... } or call Apartment::Tenant.switch!(tenant).')
+end
+```
+
+`switched?` reads `Current.tenant` directly — *not* `Tenant.current`. That's the semantic distinction: "did someone explicitly enter a tenant" is different from "what tenant is effectively active right now."
+
+`reset` is unchanged — it calls `switch!`, which never enters the guarded path.
+
+### `lib/apartment/errors.rb`
+
+No new error class; reuses `Apartment::ApartmentError`. The message is the discriminator.
+
+### Generator template
+
+`lib/generators/apartment/install/templates/apartment.rb` gets a commented line:
+
+```ruby
+# Strict default for PostgreSQL :schema strategy. Set to true to allow
+# Apartment::Tenant.switch(default_tenant) { ... }; reset is always allowed.
+# config.default_tenant_switch_allowed = false
+```
+
+## Implementation phasing
+
+One PR, three commits, in this order:
+
+### Commit 1 — Predicates and assertion (no behavior change)
+
+- `lib/apartment/tenant.rb` — add `switched?` and `assert_inside_tenant!`. Pure additions; no existing call sites change.
+- Specs in `spec/unit/tenant_spec.rb`.
+
+Ships first because it's risk-free and lets test suites adopt `assert_inside_tenant!` immediately, even before commit 2 lands.
+
+### Commit 2 — Config flag + switch guard
+
+- `lib/apartment/config.rb` — attribute, defaults keyed on strategy, validation.
+- `lib/apartment/tenant.rb` — guard inside `switch` block form. `switch!` stays unguarded.
+- Generator template comment.
+- Specs:
+  - `spec/unit/config_spec.rb` — strategy-keyed defaults, validation.
+  - `spec/unit/tenant_spec.rb` — guard raises under strict; permits when allowed; `reset` always works; `switch!(default_tenant)` always works.
+
+### Commit 3 — Documentation
+
+- `docs/architecture.md` — short section on the default-tenant contract: AR base pool, holds pinned tables, in PG search path, never iterated by `each`.
+- `lib/apartment/CLAUDE.md` — note on the new predicates and the strategy-keyed default.
+- `CHANGELOG.md` — single entry describing the breaking default for `:schema` apps and the migration path (`config.default_tenant_switch_allowed = true` to keep v3 behavior).
+
+## Test plan
+
+### Unit
+
+- `Tenant.switched?` returns false when `Current.tenant` is nil; true after `switch!('a')`; false after `reset`; true inside a `switch(...) { }` block; false outside.
+- `Tenant.assert_inside_tenant!` raises with a helpful message when `Current.tenant` is nil; no-ops when switched.
+- Strategy-keyed defaults: `:schema` → `default_tenant_switch_allowed == false`; `:database` → `true`; explicit override (either direction) wins over strategy default.
+- Guard:
+  - `switch('public') { }` raises under `:schema` defaults.
+  - `switch('public') { }` permitted when `default_tenant_switch_allowed = true`.
+  - `switch!('public')` permitted regardless.
+  - `Tenant.reset` permitted regardless (proves `reset` uses `switch!`).
+  - Guard is inert when `default_tenant` is nil (MySQL with no override).
+  - Guard does not trigger for non-default tenants.
+- Validation: non-boolean `default_tenant_switch_allowed` raises `ConfigurationError`.
+
+### Integration
+
+No new integration specs required. Existing `spec/integration/v4/` suites should pass unchanged because:
+- `Tenant.reset` is unguarded, and the suites use it (or `switch!`) for setup/teardown.
+- No test calls `switch('public') { }` directly today (verified via grep before merging).
+
+If the grep turns up such call sites in fixtures or shared examples, those become migration touchpoints in the same PR.
+
+### Manual
+
+- `bin/dev/test-strict-default` smoke: configure `default_tenant_switch_allowed = false`, attempt `switch('public') { }` — confirms the error message points at `reset`.
+
+## Migration notes (for the CHANGELOG)
+
+For PG `:schema` apps upgrading to v4 with this change:
+
+```ruby
+# Restore v3 / pre-#393 behavior:
+Apartment.configure do |config|
+  config.default_tenant_switch_allowed = true
+end
+```
+
+For test suites adopting the strict default, a one-liner in the suite's `rails_helper.rb`:
+
+```ruby
+RSpec.configure do |c|
+  c.before(:each, type: :tenant_scoped) { Apartment::Tenant.assert_inside_tenant! }
+end
+```
+
+(or unconditionally in suites where every example must run inside a real tenant).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Existing PG apps that do `switch('public') { … }` for shared work break on upgrade | CHANGELOG migration note + strategy-keyed default makes the change loud, not silent. The error message points at `reset`. |
+| Confusion between `Tenant.switched?` (raw) and `Tenant.current` (effective with fallback) | Document both in `docs/architecture.md`; `switched?` body is one line so the semantics stay legible. |
+| `assert_inside_tenant!` over-fires in app code that legitimately runs in default | It's opt-in. No automatic wiring. Apps choose where to call it. |
+| MySQL apps with custom `default_tenant` get permissive default unexpectedly | Documented in the generator template + CHANGELOG. Setting `default_tenant_switch_allowed = false` is one line. |
+
+## Open questions
+
+- Should `Tenant.assert_inside_tenant!` accept an optional message argument for richer test failures? Defer; add when a caller asks.
+- Should we surface a Rails generator (`bin/rails g apartment:strict_tenancy`) that wires the RSpec hook? Defer; one-line copy-paste is cheap.
+
+## Status
+
+- [ ] Commit 1 — predicates and assertion
+- [ ] Commit 2 — config flag and switch guard
+- [ ] Commit 3 — documentation and CHANGELOG
+- [ ] Open PR off `main`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ end
 
 Raises `Apartment::ApartmentError` when no tenant has been explicitly entered (i.e. `Apartment::Current.tenant` is `nil`).
 
-The simplest way to keep `switched?` true across every example is **suite-level**: call `Tenant.switch!` once after suite bootstrap (see [Recommended baseline](#recommended-baseline-for-new-v4-apps)). Per-example `around { switch(name) { example.run } }` works too, but is only necessary when specs need different tenants via metadata; otherwise prefer the suite-level form to avoid lifecycle interactions with frameworks like test-prof's `let_it_be` / `before_all` (see footnote in the baseline section).
+The simplest way to keep `inside_tenant?` true across every example is **suite-level**: call `Tenant.switch!` once after suite bootstrap (see [Recommended baseline](#recommended-baseline-for-new-v4-apps)). Per-example `around { switch(name) { example.run } }` works too, but is only necessary when specs need different tenants via metadata; otherwise prefer the suite-level form to avoid lifecycle interactions with frameworks like test-prof's `let_it_be` / `before_all` (see footnote in the baseline section).
 
 For richer failure messages, pass `message:`:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,16 +28,9 @@ RSpec.configure do |config|
 end
 ```
 
-Raises `Apartment::ApartmentError` when no tenant has been explicitly entered (i.e. `Apartment::Current.tenant` is `nil`). Pair with an `around` hook that wraps each example in a `switch`:
+Raises `Apartment::ApartmentError` when no tenant has been explicitly entered (i.e. `Apartment::Current.tenant` is `nil`).
 
-```ruby
-RSpec.configure do |config|
-  config.around do |example|
-    tenant = example.metadata.fetch(:tenant, 'test_tenant')
-    Apartment::Tenant.switch(tenant) { example.run }
-  end
-end
-```
+The simplest way to keep `switched?` true across every example is **suite-level**: call `Tenant.switch!` once after suite bootstrap (see [Recommended baseline](#recommended-baseline-for-new-v4-apps)). Per-example `around { switch(name) { example.run } }` works too, but is only necessary when specs need different tenants via metadata; otherwise prefer the suite-level form to avoid lifecycle interactions with frameworks like test-prof's `let_it_be` / `before_all` (see footnote in the baseline section).
 
 For richer failure messages, pass `message:`:
 
@@ -142,14 +135,32 @@ Apartment.configure do |config|
   config.default_tenant_switch_allowed = false
 end
 
-# spec/rails_helper.rb
-RSpec.configure do |c|
-  c.around do |example|
-    Apartment::Tenant.switch('test_tenant') { example.run }
-  end
+# spec/rails_helper.rb (after the suite bootstraps tenants)
+Apartment::Tenant.switch!('test_tenant')
 
+RSpec.configure do |c|
   c.before(:each) { Apartment::Tenant.assert_inside_tenant! }
 end
 ```
 
-This keeps the default schema for shared/pinned data (`Apartment::Model` + `pin_tenant`), forces every spec into an explicit tenant, and makes the "I forgot to switch" bug fail loudly at the first read of pinned data.
+This keeps the default schema for shared/pinned data (`Apartment::Model` + `pin_tenant`), enters an explicit tenant once at suite bootstrap so every example inherits it, and makes the "I forgot to switch" bug fail loudly at the first read of pinned data.
+
+For suites that need **different tenants per example**, layer an `around` hook on top — driven by metadata so the default stays suite-level:
+
+```ruby
+RSpec.configure do |c|
+  c.around do |example|
+    tenants = Array(example.metadata[:tenants])
+    next example.run if tenants.empty?
+
+    Apartment::Tenant.with_tenants(*tenants) { example.run }
+  end
+end
+
+# Per-spec opt-in:
+RSpec.describe MyJob, tenants: %w[acme widgets] do
+  # ...
+end
+```
+
+> **Footnote on test-prof.** If your suite uses test-prof's `let_it_be` / `before_all`, prefer the suite-level `switch!` shown above over per-example `around { switch(...) { example.run } }`. `let_it_be` commits its setup data inside its own transaction; wrapping examples in an `around switch` can interact with the savepoint hierarchy in a way that DatabaseCleaner's rollback can't unwind cleanly when an example raises — producing a transaction-poisoning cascade where every subsequent example fails with `PG::InFailedSqlTransaction`. Suite-level `switch!` avoids this because there's no per-example switching wrapping `let_it_be` setup.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,155 @@
+# Testing with Apartment v4
+
+This guide covers patterns for using Apartment in test suites: tenant discipline, the `switch` / `switch!` / `reset` distinction, cross-pool transaction visibility, and cleaning shared (default) tenant data between specs.
+
+## Strict tenant discipline
+
+Apartment's default behavior is permissive: `Apartment::Tenant.current` falls back to `default_tenant` when no tenant has been explicitly entered, and `Apartment::Tenant.switch(default_tenant) { ... }` works silently. This is convenient for app code but produces a class of test-suite bugs where ambient writes land in the default schema and tests don't notice.
+
+Two opt-in tools tighten this up:
+
+### `default_tenant_switch_allowed`
+
+```ruby
+Apartment.configure do |config|
+  config.default_tenant_switch_allowed = false
+end
+```
+
+When set to `false`, the block form `Apartment::Tenant.switch(default_tenant) { ... }` raises. `Apartment::Tenant.reset` and `Apartment::Tenant.switch!(default_tenant)` remain available — they're the documented "I genuinely intend to enter the default tenant" paths and bypass the guard.
+
+The flag defaults to `true` for all strategies. New PostgreSQL `:schema` apps that want strict semantics from day one should opt in.
+
+### `Tenant.assert_inside_tenant!`
+
+```ruby
+RSpec.configure do |config|
+  config.before(:each) { Apartment::Tenant.assert_inside_tenant! }
+end
+```
+
+Raises `Apartment::ApartmentError` when no tenant has been explicitly entered (i.e. `Apartment::Current.tenant` is `nil`). Pair with an `around` hook that wraps each example in a `switch`:
+
+```ruby
+RSpec.configure do |config|
+  config.around do |example|
+    tenant = example.metadata.fetch(:tenant, 'test_tenant')
+    Apartment::Tenant.switch(tenant) { example.run }
+  end
+end
+```
+
+For richer failure messages, pass `message:`:
+
+```ruby
+Apartment::Tenant.assert_inside_tenant!(message: 'cross_tenant: true required for this spec')
+```
+
+`assert_inside_tenant!` reads `Current.tenant` directly, not `Tenant.current` — so it doesn't see the default-tenant fallback. That's the point: it answers "did this spec explicitly enter a tenant?", not "what tenant is effectively active?".
+
+## `switch`, `switch!`, and `reset`
+
+Three primitives, three scopes:
+
+| Method | Form | Use case |
+|---|---|---|
+| `Tenant.switch(name) { ... }` | Block | Default; guaranteed cleanup via `ensure`. Use everywhere a block is natural. |
+| `Tenant.switch!(name)` | No block | When the scope is structural (an `around` hook can't reach in), e.g. `before(:context)`, suite bootstrap. The caller is responsible for restoring tenant state. |
+| `Tenant.reset` | No block | Returns to `default_tenant`. Bypasses `default_tenant_switch_allowed` — the documented path back to the default tenant. |
+
+`switch!` is **not** deprecated in v4. It's correct for non-block scopes. The README's "prefer block-based switching" guidance applies when a block is natural; structural test hooks are exempt.
+
+## Cross-pool transaction visibility
+
+v4 uses pool-per-tenant connection routing. Each tenant gets its own connection pool, and a transaction held on one pool's connection is invisible to another pool's connection — even within the same test example.
+
+This composes poorly with transactional fixture strategies (DatabaseCleaner `:transaction`, Rails' `use_transactional_fixtures`):
+
+```ruby
+let!(:integration) { create(:integration, instance_id: Instance.find_by(name: 'parents').id) }
+
+it 'queues a job for each tenant' do
+  expect { worker.perform }.to change { SomeJob.jobs.size }.by(1)
+  # actually changes by 0 — the integration was committed to pool A's
+  # transaction; the iterator runs in pool B and can't see uncommitted rows.
+end
+```
+
+This is a structural property of pool-per-tenant, not a bug. Resolve it at the test-strategy layer:
+
+- For specs that must do **cross-pool reads of writes from the same example**, switch off transactional fixtures and use a deletion strategy (`DatabaseCleaner.strategy = :deletion` or `:truncation`).
+- For specs that **don't need cross-pool reads**, transactional fixtures are fine — keep them as the default for performance.
+
+A common pattern is metadata-driven cleanup mode:
+
+```ruby
+RSpec.shared_context 'cross-tenant', cross_tenant: true do
+  before do
+    DatabaseCleaner.strategy = :deletion
+    DatabaseCleaner.start
+  end
+
+  after { DatabaseCleaner.clean }
+end
+
+RSpec.configure do |c|
+  c.include_context 'cross-tenant', cross_tenant: true
+end
+
+# Per-spec opt-in:
+RSpec.describe MyJob, cross_tenant: true do
+  # ...
+end
+```
+
+Apartment intentionally does not provide a "shared connection across all pools in test mode" option. That would diverge test behavior from production pool semantics in a way that hides real bugs.
+
+## Cleaning shared (default) tenant data between specs
+
+Pinned models (declared with `Apartment::Model` + `pin_tenant`, or registered via the deprecated `excluded_models` shim) write to the default tenant's schema regardless of `Current.tenant`. With pool-per-tenant, those writes commit through whichever pool the model resolves to and may leak across examples if cleanup happens only in tenant pools.
+
+A simple cleanup helper iterates pinned models and issues targeted deletes:
+
+```ruby
+# spec/support/clean_pinned_models.rb
+module CleanPinnedModels
+  def clean_pinned_models!
+    Apartment.pinned_models.each do |klass|
+      next unless klass.respond_to?(:delete_all)
+      klass.delete_all
+    rescue ActiveRecord::StatementInvalid
+      # Table may not exist yet during early bootstrap; ignore.
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include CleanPinnedModels
+  config.after(:each, :cleans_pinned) { clean_pinned_models! }
+end
+```
+
+Apartment doesn't ship this helper because the right cleanup shape depends on the suite (transactional vs deletion strategy, fixture caching via test-prof, parallel CI shards). Copy the recipe and adapt.
+
+## Recommended baseline for new v4 apps
+
+```ruby
+# config/initializers/apartment.rb
+Apartment.configure do |config|
+  config.tenant_strategy = :schema
+  config.tenants_provider = -> { Tenant.pluck(:name) }
+  config.default_tenant = 'public'
+  config.default_tenant_switch_allowed = false
+end
+
+# spec/rails_helper.rb
+RSpec.configure do |c|
+  c.around do |example|
+    Apartment::Tenant.switch('test_tenant') { example.run }
+  end
+
+  c.before(:each) { Apartment::Tenant.assert_inside_tenant! }
+end
+```
+
+This keeps the default schema for shared/pinned data (`Apartment::Model` + `pin_tenant`), forces every spec into an explicit tenant, and makes the "I forgot to switch" bug fail loudly at the first read of pinned data.

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -72,7 +72,7 @@ Two new predicates and a config flag landed in 4.0.0.alpha3 to support strict te
 
 ```ruby
 # Predicate: was a tenant explicitly entered?
-Apartment::Tenant.switched?            # reads Current.tenant directly, ignores default fallback
+Apartment::Tenant.inside_tenant?            # reads Current.tenant directly, ignores default fallback
 
 # Test-time assertion: raise when no explicit tenant is active
 Apartment::Tenant.assert_inside_tenant!

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -62,9 +62,31 @@ Apartment::Tenant.switch(tenant) do
 end
 ```
 
-`switch!` still exists for console/REPL use but is discouraged in application code.
+`switch!` still exists for console/REPL use but is discouraged in application code. `switch!` is **not deprecated** — it remains the correct primitive for non-block scopes (suite bootstrap, `before(:context)` hooks, structural test setup where an `around` can't reach in). The "prefer blocks" guidance applies when a block is natural.
 
 `Apartment::Tenant.current` is unchanged between v3 and v4.
+
+### New v4 predicates and guard (optional)
+
+Two new predicates and a config flag landed in 4.0.0.alpha3 to support strict tenant discipline. All are opt-in; defaults preserve existing behavior.
+
+```ruby
+# Predicate: was a tenant explicitly entered?
+Apartment::Tenant.switched?            # reads Current.tenant directly, ignores default fallback
+
+# Test-time assertion: raise when no explicit tenant is active
+Apartment::Tenant.assert_inside_tenant!
+Apartment::Tenant.assert_inside_tenant!(message: 'spec must declare a tenant')
+
+# Config: opt-in guard on switch(default_tenant) { ... }
+Apartment.configure do |config|
+  config.default_tenant_switch_allowed = false  # raises on switch(default_tenant) block form
+end
+```
+
+`Tenant.reset` and `Tenant.switch!` bypass the guard by design — they are the documented paths back to the default tenant under strict mode. Defaults to `true` (permissive) for all strategies; opt in to `false` for new PostgreSQL `:schema` apps that want strict semantics from day one.
+
+See [Testing with Apartment v4](./testing.md) for recipe-level guidance on strict discipline, cross-pool transaction visibility, and pinned-model cleanup.
 
 ### Models
 

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -42,6 +42,11 @@ lib/apartment/
 
 `switch(tenant) { ... }` sets `Current.tenant` via ensure block. Delegates lifecycle ops (`create`, `drop`, `migrate`, `seed`) to `Apartment.adapter`. No thread-local state — uses `CurrentAttributes` for fiber safety.
 
+**Predicates and strict-mode guard (4.0.0.alpha3)**:
+- `switched?` reads `Current.tenant` directly (NOT `Tenant.current`), so it ignores the `default_tenant` fallback. Use when "is there an explicit tenant context?" matters more than "what tenant is effectively active?".
+- `assert_inside_tenant!(message: nil)` raises `ApartmentError` when `Current.tenant` is `nil`. Test-time discipline; `message:` kwarg supports richer failure context.
+- `switch(name) { ... }` calls `guard_default_tenant_switch!`, which raises when `Apartment.config.default_tenant_switch_allowed` is `false` AND `name == default_tenant`. `switch!` and `reset` are exempt by design — they remain the unguarded paths back to the default tenant. The flag defaults to `true` (permissive) for all strategies; new PG `:schema` apps wanting strict semantics opt in. See `docs/testing.md`.
+
 ### config.rb — Configuration
 
 `Apartment.configure { |c| ... }` builds config, validates, freezes. Prepare-then-swap pattern: failed configure preserves previous working config. Frozen after validation — tests must reconfigure, not stub.

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -43,7 +43,7 @@ lib/apartment/
 `switch(tenant) { ... }` sets `Current.tenant` via ensure block. Delegates lifecycle ops (`create`, `drop`, `migrate`, `seed`) to `Apartment.adapter`. No thread-local state — uses `CurrentAttributes` for fiber safety.
 
 **Predicates and strict-mode guard (4.0.0.alpha3)**:
-- `switched?` reads `Current.tenant` directly (NOT `Tenant.current`), so it ignores the `default_tenant` fallback. Use when "is there an explicit tenant context?" matters more than "what tenant is effectively active?".
+- `inside_tenant?` reads `Current.tenant` directly (NOT `Tenant.current`), so it ignores the `default_tenant` fallback. Use when "is there an explicit tenant context?" matters more than "what tenant is effectively active?".
 - `assert_inside_tenant!(message: nil)` raises `ApartmentError` when `Current.tenant` is `nil`. Test-time discipline; `message:` kwarg supports richer failure context.
 - `switch(name) { ... }` calls `guard_default_tenant_switch!`, which raises when `Apartment.config.default_tenant_switch_allowed` is `false` AND `name == default_tenant`. `switch!` and `reset` are exempt by design — they remain the unguarded paths back to the default tenant. The flag defaults to `true` (permissive) for all strategies; new PG `:schema` apps wanting strict semantics opt in. See `docs/testing.md`.
 

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -15,6 +15,7 @@ module Apartment
                 :environmentify_strategy, :excluded_models
 
     attr_accessor :tenants_provider, :default_tenant,
+                  :default_tenant_switch_allowed,
                   :tenant_pool_size, :pool_idle_timeout, :max_total_connections,
                   :seed_after_create, :seed_data_file,
                   :schema_load_strategy, :schema_file,
@@ -29,6 +30,7 @@ module Apartment
       @tenant_strategy = nil
       @tenants_provider = nil
       @default_tenant = nil
+      @default_tenant_switch_allowed = true
       @excluded_models = []
       @tenant_pool_size = 5
       @pool_idle_timeout = 300
@@ -122,6 +124,12 @@ module Apartment
 
       if @default_tenant.is_a?(String) && @default_tenant.strip.empty?
         raise(ConfigurationError, 'default_tenant cannot be an empty string')
+      end
+
+      unless [true, false].include?(@default_tenant_switch_allowed)
+        raise(ConfigurationError,
+              'default_tenant_switch_allowed must be true or false, got: ' \
+              "#{@default_tenant_switch_allowed.inspect}")
       end
 
       unless @tenants_provider.respond_to?(:call)

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -41,6 +41,27 @@ module Apartment
         switch!(Apartment.config&.default_tenant)
       end
 
+      # Predicate: was a tenant explicitly entered?
+      # Reads Current.tenant directly (not Tenant.current) so it does NOT
+      # consider the default_tenant fallback. Use this when "is there an
+      # explicit tenant context right now?" matters more than "what tenant
+      # is effectively active?" — typically test setup and assertion code.
+      def switched?
+        !Current.tenant.nil?
+      end
+
+      # Raise if no tenant has been explicitly entered. Test-time guard for
+      # suites that want to fail loudly when ambient writes would land in
+      # the default tenant. No-op when a tenant is active.
+      def assert_inside_tenant!
+        return if switched?
+
+        raise(Apartment::ApartmentError,
+              'Expected an explicit tenant context, but Apartment::Current.tenant is nil. ' \
+              'Wrap the call in Apartment::Tenant.switch(tenant) { ... } or call ' \
+              'Apartment::Tenant.switch!(tenant).')
+      end
+
       # Initialize: resolve excluded_models shim, then process pinned models.
       def init
         resolve_excluded_models_shim

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -48,6 +48,10 @@ module Apartment
       # consider the default_tenant fallback. Use this when "is there an
       # explicit tenant context right now?" matters more than "what tenant
       # is effectively active?" — typically test setup and assertion code.
+      #
+      # Note: after Tenant.reset, switched? returns true. reset enters the
+      # default tenant via switch!, which is an explicit entry. To check
+      # "no tenant ever entered," combine with Current.previous_tenant.nil?.
       def switched?
         !Current.tenant.nil?
       end
@@ -168,11 +172,6 @@ module Apartment
 
       private
 
-      # Validate and coerce a +with_tenants_provider+ source argument.
-      # Callables pass through. String, Symbol, and Arrays of String/Symbol
-      # become a frozen Array<String>. Everything else raises ArgumentError —
-      # silently coercing nil/Hash/random objects produces tenant names like
-      # "" or "[:k, v]" that fail far from the call site.
       # Raise when default_tenant_switch_allowed is false and the caller is
       # block-switching into the default tenant. switch! and reset are exempt:
       # neither enters this guard, so they remain the legitimate paths into
@@ -185,11 +184,16 @@ module Apartment
 
         raise(Apartment::ApartmentError,
               "switch(#{cfg.default_tenant.inspect}) is disabled by " \
-              'default_tenant_switch_allowed = false. Use Apartment::Tenant.reset for ' \
-              'explicit re-entry into the default tenant, or Apartment::Tenant.switch!(name) ' \
-              'for non-block scopes.')
+              'default_tenant_switch_allowed = false. Inside a block scope, call ' \
+              'Apartment::Tenant.reset to re-enter the default tenant. For non-block ' \
+              'scopes (suite bootstrap, before(:context)), use Apartment::Tenant.switch!(name).')
       end
 
+      # Validate and coerce a +with_tenants_provider+ source argument.
+      # Callables pass through. String, Symbol, and Arrays of String/Symbol
+      # become a frozen Array<String>. Everything else raises ArgumentError —
+      # silently coercing nil/Hash/random objects produces tenant names like
+      # "" or "[:k, v]" that fail far from the call site.
       def coerce_tenant_override(source)
         return source if source.respond_to?(:call)
 

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -12,6 +12,8 @@ module Apartment
       def switch(tenant, &block)
         raise(ArgumentError, 'Apartment::Tenant.switch requires a block') unless block
 
+        guard_default_tenant_switch!(tenant)
+
         previous = Current.tenant
         Current.tenant = tenant
         Current.previous_tenant = previous
@@ -53,10 +55,11 @@ module Apartment
       # Raise if no tenant has been explicitly entered. Test-time guard for
       # suites that want to fail loudly when ambient writes would land in
       # the default tenant. No-op when a tenant is active.
-      def assert_inside_tenant!
+      def assert_inside_tenant!(message: nil)
         return if switched?
 
         raise(Apartment::ApartmentError,
+              message ||
               'Expected an explicit tenant context, but Apartment::Current.tenant is nil. ' \
               'Wrap the call in Apartment::Tenant.switch(tenant) { ... } or call ' \
               'Apartment::Tenant.switch!(tenant).')
@@ -170,6 +173,23 @@ module Apartment
       # become a frozen Array<String>. Everything else raises ArgumentError —
       # silently coercing nil/Hash/random objects produces tenant names like
       # "" or "[:k, v]" that fail far from the call site.
+      # Raise when default_tenant_switch_allowed is false and the caller is
+      # block-switching into the default tenant. switch! and reset are exempt:
+      # neither enters this guard, so they remain the legitimate paths into
+      # the default tenant under strict mode.
+      def guard_default_tenant_switch!(tenant)
+        cfg = Apartment.config
+        return if cfg.nil? || cfg.default_tenant_switch_allowed
+        return if cfg.default_tenant.nil?
+        return unless tenant.to_s == cfg.default_tenant.to_s
+
+        raise(Apartment::ApartmentError,
+              "switch(#{cfg.default_tenant.inspect}) is disabled by " \
+              'default_tenant_switch_allowed = false. Use Apartment::Tenant.reset for ' \
+              'explicit re-entry into the default tenant, or Apartment::Tenant.switch!(name) ' \
+              'for non-block scopes.')
+      end
+
       def coerce_tenant_override(source)
         return source if source.respond_to?(:call)
 

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -49,10 +49,10 @@ module Apartment
       # explicit tenant context right now?" matters more than "what tenant
       # is effectively active?" — typically test setup and assertion code.
       #
-      # Note: after Tenant.reset, switched? returns true. reset enters the
+      # Note: after Tenant.reset, inside_tenant? returns true. reset enters the
       # default tenant via switch!, which is an explicit entry. To check
       # "no tenant ever entered," combine with Current.previous_tenant.nil?.
-      def switched?
+      def inside_tenant?
         !Current.tenant.nil?
       end
 
@@ -60,7 +60,7 @@ module Apartment
       # suites that want to fail loudly when ambient writes would land in
       # the default tenant. No-op when a tenant is active.
       def assert_inside_tenant!(message: nil)
-        return if switched?
+        return if inside_tenant?
 
         raise(Apartment::ApartmentError,
               message ||

--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -17,6 +17,13 @@ Apartment.configure do |config|
   # The default tenant (used on boot and between requests).
   # config.default_tenant = 'public'
 
+  # Strict tenant discipline. When false, Apartment::Tenant.switch(default_tenant)
+  # raises — apps must use Tenant.reset (block-less) or Tenant.switch!(name) for
+  # explicit re-entry into the default tenant. Catches accidental block-form
+  # switches into the shared schema. Defaults to true for backward compatibility;
+  # recommended for new PostgreSQL :schema apps that want strict semantics.
+  # config.default_tenant_switch_allowed = false
+
   # Models that live in the shared/default schema (not per-tenant).
   # The recommended approach is to declare this in the model itself:
   #

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -26,6 +26,40 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.shard_key_prefix).to(eq('apartment')) }
     it { expect(config.force_separate_pinned_pool).to(be(false)) }
     it { expect(config.test_fixture_cleanup).to(be(true)) }
+    it { expect(config.default_tenant_switch_allowed).to(be(true)) }
+  end
+
+  describe '#default_tenant_switch_allowed validation' do
+    before do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+    end
+
+    it 'accepts true' do
+      config.default_tenant_switch_allowed = true
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'accepts false' do
+      config.default_tenant_switch_allowed = false
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'rejects non-boolean values' do
+      config.default_tenant_switch_allowed = 'yes'
+      expect { config.validate! }.to(raise_error(
+                                       Apartment::ConfigurationError,
+                                       /default_tenant_switch_allowed must be true or false/
+                                     ))
+    end
+
+    it 'rejects nil' do
+      config.default_tenant_switch_allowed = nil
+      expect { config.validate! }.to(raise_error(
+                                       Apartment::ConfigurationError,
+                                       /default_tenant_switch_allowed must be true or false/
+                                     ))
+    end
   end
 
   describe '#tenant_strategy=' do

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -110,39 +110,39 @@ RSpec.describe(Apartment::Tenant) do
     end
   end
 
-  describe '.switched?' do
+  describe '.inside_tenant?' do
     it 'returns false when Current.tenant is nil' do
       Apartment::Current.tenant = nil
-      expect(described_class.switched?).to(be(false))
+      expect(described_class.inside_tenant?).to(be(false))
     end
 
     it 'returns true after switch!' do
       described_class.switch!('tenant1')
-      expect(described_class.switched?).to(be(true))
+      expect(described_class.inside_tenant?).to(be(true))
     end
 
     it 'returns true after reset (reset is an explicit entry into default_tenant)' do
       described_class.switch!('tenant1')
       described_class.reset
       # reset switches to default_tenant ('public') via switch!, which sets
-      # Current.tenant. switched? reports true — reset is an explicit entry
+      # Current.tenant. inside_tenant? reports true — reset is an explicit entry
       # into the default tenant, distinct from "no tenant ever entered".
-      expect(described_class.switched?).to(be(true))
+      expect(described_class.inside_tenant?).to(be(true))
     end
 
     it 'returns false outside a switch block, true inside' do
       Apartment::Current.tenant = nil
-      expect(described_class.switched?).to(be(false))
+      expect(described_class.inside_tenant?).to(be(false))
       described_class.switch('tenant1') do
-        expect(described_class.switched?).to(be(true))
+        expect(described_class.inside_tenant?).to(be(true))
       end
-      expect(described_class.switched?).to(be(false))
+      expect(described_class.inside_tenant?).to(be(false))
     end
 
     it 'distinguishes from .current when nothing has been entered' do
       Apartment::Current.tenant = nil
       expect(described_class.current).to(eq('public'))
-      expect(described_class.switched?).to(be(false))
+      expect(described_class.inside_tenant?).to(be(false))
     end
   end
 

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -200,11 +200,6 @@ RSpec.describe(Apartment::Tenant) do
                           /switch\("public"\) is disabled.*default_tenant_switch_allowed/m))
       end
 
-      it 'error message points at reset and switch!' do
-        expect { described_class.switch('public') { :ok } }
-          .to(raise_error(/Apartment::Tenant\.reset.*Apartment::Tenant\.switch!/m))
-      end
-
       it 'permits switch into a non-default tenant' do
         expect { described_class.switch('tenant1') { :ok } }.not_to(raise_error)
       end
@@ -225,6 +220,28 @@ RSpec.describe(Apartment::Tenant) do
         end
         # default_tenant is nil; no tenant name can match, so guard never fires.
         expect { described_class.switch('t1') { :ok } }.not_to(raise_error)
+      end
+
+      it 'raises on Symbol tenant matching String default_tenant' do
+        # default_tenant = 'public' (String) from the surrounding configure
+        expect { described_class.switch(:public) { :ok } }
+          .to(raise_error(Apartment::ApartmentError, /switch\("public"\) is disabled/))
+      end
+
+      it 'raises on String tenant matching Symbol default_tenant' do
+        Apartment.configure do |c|
+          c.tenant_strategy = :schema
+          c.tenants_provider = -> { %w[tenant1] }
+          c.default_tenant = :public
+          c.default_tenant_switch_allowed = false
+        end
+        expect { described_class.switch('public') { :ok } }
+          .to(raise_error(Apartment::ApartmentError, /is disabled/))
+      end
+
+      it 'error message points at reset for block scope and switch! for non-block' do
+        expect { described_class.switch('public') { :ok } }
+          .to(raise_error(/Inside a block scope, call Apartment::Tenant\.reset.*non-block scopes.*Apartment::Tenant\.switch!/m))
       end
     end
   end

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -110,6 +110,67 @@ RSpec.describe(Apartment::Tenant) do
     end
   end
 
+  describe '.switched?' do
+    it 'returns false when Current.tenant is nil' do
+      Apartment::Current.tenant = nil
+      expect(described_class.switched?).to(be(false))
+    end
+
+    it 'returns true after switch!' do
+      described_class.switch!('tenant1')
+      expect(described_class.switched?).to(be(true))
+    end
+
+    it 'returns true after reset (reset is an explicit entry into default_tenant)' do
+      described_class.switch!('tenant1')
+      described_class.reset
+      # reset switches to default_tenant ('public') via switch!, which sets
+      # Current.tenant. switched? reports true — reset is an explicit entry
+      # into the default tenant, distinct from "no tenant ever entered".
+      expect(described_class.switched?).to(be(true))
+    end
+
+    it 'returns false outside a switch block, true inside' do
+      Apartment::Current.tenant = nil
+      expect(described_class.switched?).to(be(false))
+      described_class.switch('tenant1') do
+        expect(described_class.switched?).to(be(true))
+      end
+      expect(described_class.switched?).to(be(false))
+    end
+
+    it 'distinguishes from .current when nothing has been entered' do
+      Apartment::Current.tenant = nil
+      expect(described_class.current).to(eq('public'))
+      expect(described_class.switched?).to(be(false))
+    end
+  end
+
+  describe '.assert_inside_tenant!' do
+    it 'raises when Current.tenant is nil' do
+      Apartment::Current.tenant = nil
+      expect { described_class.assert_inside_tenant! }
+        .to(raise_error(Apartment::ApartmentError, /no explicit tenant context|Current.tenant is nil/))
+    end
+
+    it 'no-ops when a tenant has been entered' do
+      described_class.switch!('tenant1')
+      expect { described_class.assert_inside_tenant! }.not_to(raise_error)
+    end
+
+    it 'no-ops inside a switch block' do
+      described_class.switch('tenant1') do
+        expect { described_class.assert_inside_tenant! }.not_to(raise_error)
+      end
+    end
+
+    it 'message points the caller at switch / switch!' do
+      Apartment::Current.tenant = nil
+      expect { described_class.assert_inside_tenant! }
+        .to(raise_error(/Apartment::Tenant\.switch/))
+    end
+  end
+
   describe '.init' do
     it 'delegates to adapter.process_pinned_models' do
       expect(mock_adapter).to(receive(:process_pinned_models))

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -169,6 +169,64 @@ RSpec.describe(Apartment::Tenant) do
       expect { described_class.assert_inside_tenant! }
         .to(raise_error(/Apartment::Tenant\.switch/))
     end
+
+    it 'honors a custom message: kwarg' do
+      Apartment::Current.tenant = nil
+      expect { described_class.assert_inside_tenant!(message: 'cross_tenant: true required') }
+        .to(raise_error(Apartment::ApartmentError, 'cross_tenant: true required'))
+    end
+  end
+
+  describe '.switch default_tenant guard' do
+    context 'when default_tenant_switch_allowed is true (default)' do
+      it 'permits switch into the default tenant' do
+        expect { described_class.switch('public') { :ok } }.not_to(raise_error)
+      end
+    end
+
+    context 'when default_tenant_switch_allowed is false' do
+      before do
+        Apartment.configure do |c|
+          c.tenant_strategy = :schema
+          c.tenants_provider = -> { %w[tenant1 tenant2] }
+          c.default_tenant = 'public'
+          c.default_tenant_switch_allowed = false
+        end
+      end
+
+      it 'raises on switch(default_tenant) block form' do
+        expect { described_class.switch('public') { :ok } }
+          .to(raise_error(Apartment::ApartmentError,
+                          /switch\("public"\) is disabled.*default_tenant_switch_allowed/m))
+      end
+
+      it 'error message points at reset and switch!' do
+        expect { described_class.switch('public') { :ok } }
+          .to(raise_error(/Apartment::Tenant\.reset.*Apartment::Tenant\.switch!/m))
+      end
+
+      it 'permits switch into a non-default tenant' do
+        expect { described_class.switch('tenant1') { :ok } }.not_to(raise_error)
+      end
+
+      it 'permits switch!(default_tenant) (non-block bypass)' do
+        expect { described_class.switch!('public') }.not_to(raise_error)
+      end
+
+      it 'permits Tenant.reset' do
+        expect { described_class.reset }.not_to(raise_error)
+      end
+
+      it 'is inert when default_tenant is nil' do
+        Apartment.configure do |c|
+          c.tenant_strategy = :database_name
+          c.tenants_provider = -> { %w[t1] }
+          c.default_tenant_switch_allowed = false
+        end
+        # default_tenant is nil; no tenant name can match, so guard never fires.
+        expect { described_class.switch('t1') { :ok } }.not_to(raise_error)
+      end
+    end
   end
 
   describe '.init' do


### PR DESCRIPTION
## Summary

- Adds `Tenant.switched?` and `Tenant.assert_inside_tenant!(message:)` predicates that read `Current.tenant` directly, ignoring the `default_tenant` fallback.
- Adds opt-in `config.default_tenant_switch_allowed` (default `true` for all strategies) that, when set to `false`, raises on `Tenant.switch(default_tenant) { ... }`. `Tenant.reset` and `Tenant.switch!` are exempt by design.
- Documents strict tenant discipline, the `switch` / `switch!` / `reset` distinction, the cross-pool transaction visibility constraint, and a pinned-model cleanup recipe in a new `docs/testing.md`.

Closes #393.

## Background

Issue #393 surfaced an asymmetry: `Tenant.current` falls back to `default_tenant` (read-side implicit) while `Tenant.each` excludes it (write-side excluded). A record created without an explicit switch lands in `default_tenant`; later iteration doesn't see it.

The original proposal suggested three flags (`base_schema`, `base_schema_iterable`, `base_schema_switch_allowed`). After v4 surface analysis this PR ships the smallest coherent slice:

- The first two flags are already implemented in v4 under the better name `default_tenant` (which spans `:schema` and `:database` strategies, unlike `base_schema`).
- Only the third flag is genuinely new behavior, and only the *opt-in* direction. Default stays permissive — strict-by-default for `:schema` was considered and rejected because the strict default doesn't prevent the more common bug class (around-hook switching into a non-default tenant), and breaking v3 semantics by default needs broader v4 alpha feedback than is available today.
- Two cheap predicates (`switched?`, `assert_inside_tenant!`) close the read-side gap that the implicit fallback creates, without touching `Tenant.current`'s String return (which logging, query tags, and Sentry breadcrumbs depend on).

Plan and rationale: `docs/plans/default-tenant-guardrails/plan.md`.

## What's NOT in this PR (and why)

Considered during scoping; documented as upstream docs (where appropriate) or deferred:

- `Tenant.in_default_tenant { ... }` block API — only justified if strict were the default. It isn't, so deferred.
- "Single shared connection across pools" test-mode option — would diverge test from production pool semantics in a way that hides real bugs. Documented as a constraint instead.
- `clean_pinned_models!` helper — recipe in `docs/testing.md`; no helper in core (the right shape depends on suite specifics — transactional vs deletion strategy, fixture caching, parallel CI shards).
- `tenant_names` memoization — would violate documented callable-each-time semantics of `with_tenants_provider`.

## Backward compatibility

Default behavior unchanged. `default_tenant_switch_allowed` defaults to `true` for all strategies, so existing v4 alpha apps see no change. Strict mode is opt-in; new PG `:schema` apps that want strict semantics set the flag to `false`.

## Test plan

- [x] `Tenant.switched?` — false when `Current.tenant` is `nil`; true after `switch!`; true after `reset` (reset is explicit entry); true inside `switch(...) { }`; false outside; distinguishable from `Tenant.current` fallback.
- [x] `Tenant.assert_inside_tenant!` — raises with default message when nil; no-ops when switched; honors `message:` kwarg.
- [x] Guard — raises on `switch('public') { }` when strict; permits when allowed; permits `switch!('public')` regardless; permits `Tenant.reset` regardless; inert when `default_tenant` is `nil`; does not trigger for non-default tenants.
- [x] Config — defaults to `true` for all strategies; honors explicit override; validation rejects non-boolean.
- [x] Full unit suite (722 examples, 0 failures, 53 pending).
- [x] Rubocop clean on all changed files.
- [x] Pre-PR grep verified zero `switch(default_tenant)` call sites in `lib/` or `spec/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)