### PR TITLE
Fix silent tenant switch on Rails 8.1 schema_search_path memoization (#396)

### DIFF
--- a/lib/apartment/adapters/jdbc_postgresql_adapter.rb
+++ b/lib/apartment/adapters/jdbc_postgresql_adapter.rb
@@ -41,7 +41,7 @@ module Apartment
         raise(ActiveRecord::StatementInvalid, "Could not find schema #{tenant}") unless schema_exists?(tenant)
 
         @current = tenant.is_a?(Array) ? tenant.map(&:to_s) : tenant.to_s
-        Apartment.connection.schema_search_path = full_search_path
+        set_schema_search_path(full_search_path)
       rescue ActiveRecord::StatementInvalid, ActiveRecord::JDBCError
         raise(TenantNotFound, "One of the following schema(s) is invalid: #{full_search_path}")
       end

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -41,12 +41,12 @@ module Apartment
       #
       def reset
         @current = default_tenant
-        Apartment.connection.schema_search_path = full_search_path
+        set_schema_search_path(full_search_path)
       end
 
       def init
         super
-        Apartment.connection.schema_search_path = full_search_path
+        set_schema_search_path(full_search_path)
       end
 
       def current
@@ -76,12 +76,25 @@ module Apartment
         raise(ActiveRecord::StatementInvalid, "Could not find schema #{tenant}") unless schema_exists?(tenant)
 
         @current = tenant.is_a?(Array) ? tenant.map(&:to_s) : tenant.to_s
-        Apartment.connection.schema_search_path = full_search_path
+        set_schema_search_path(full_search_path)
       rescue *rescuable_exceptions => e
         raise_schema_connect_to_new(tenant, e)
       end
 
       private
+
+      # Force a fresh +SET search_path+ even when ActiveRecord's
+      # +@schema_search_path+ cache still matches +value+. Rails 8.1 added a
+      # memoization early-return to PostgreSQLAdapter#schema_search_path= (see
+      # rails/rails#54698), which makes the assignment a no-op when the ivar
+      # is unchanged. After a transactional ROLLBACK or a connection reconnect
+      # the ivar can hold a stale value while the actual session search_path
+      # has reverted, so we must invalidate the ivar before reassigning.
+      # This is a cache-invalidating wrapper, not a plain writer.
+      def set_schema_search_path(value) # rubocop:disable Naming/AccessorMethodName
+        Apartment.connection.instance_variable_set(:@schema_search_path, nil)
+        Apartment.connection.schema_search_path = value
+      end
 
       def tenant_exists?(tenant)
         return true unless Apartment.tenant_presence_check

--- a/lib/apartment/adapters/postgresql_adapter.rb
+++ b/lib/apartment/adapters/postgresql_adapter.rb
@@ -91,6 +91,15 @@ module Apartment
       # the ivar can hold a stale value while the actual session search_path
       # has reverted, so we must invalidate the ivar before reassigning.
       # This is a cache-invalidating wrapper, not a plain writer.
+      #
+      # Maintenance note: this couples us to Rails' private
+      # +@schema_search_path+ ivar. Watch rails/rails#54698 for an upstream
+      # fix or a public invalidation API -- once one ships, this workaround
+      # should be dropped in favor of the public path. If a future Rails
+      # release renames or removes the ivar, this helper degrades silently
+      # back to the memoization no-op; the regression specs under
+      # +describe '#switch!'+ and +describe '#reset'+ in
+      # +spec/examples/schema_adapter_examples.rb+ are the canary.
       def set_schema_search_path(value) # rubocop:disable Naming/AccessorMethodName
         Apartment.connection.instance_variable_set(:@schema_search_path, nil)
         Apartment.connection.schema_search_path = value

--- a/spec/examples/schema_adapter_examples.rb
+++ b/spec/examples/schema_adapter_examples.rb
@@ -228,6 +228,33 @@ shared_examples_for 'a schema based apartment adapter' do
         end
       end
     end
+
+    # Regression for https://github.com/rails-on-services/apartment/issues/396.
+    # Apartment::Tenant.reset and AbstractAdapter#connect_to_new's
+    # connection-exception rescue both call adapter.reset directly, bypassing
+    # the :switch callback chain. PG#reset reassigns schema_search_path and
+    # would hit the same memoization no-op as switch! if the ivar held a
+    # stale value matching the default-tenant search path.
+    context 'when the PostgreSQL session search_path has drifted from the AR cache' do
+      it 'still issues SET search_path on reset' do
+        session_path = -> { connection.execute('SHOW search_path').first['search_path'] }
+
+        # Land on the default tenant so the AR ivar caches its search path.
+        subject.switch!(schema1)
+        subject.reset
+        expect(session_path.call).to(include(public_schema))
+
+        # Drift the session away from the cached default-tenant value.
+        connection.execute(%(SET search_path TO "#{schema1}"))
+        expect(session_path.call).to(include(schema1.to_s))
+
+        # Without cache invalidation, schema_search_path= would early-return
+        # here because the ivar already holds the default-tenant value.
+        subject.reset
+
+        expect(session_path.call).to(include(public_schema))
+      end
+    end
   end
 
   describe '#switch!' do
@@ -303,6 +330,30 @@ shared_examples_for 'a schema based apartment adapter' do
 
       it 'prioritizes the switched schema to front of schema_search_path' do
         expect(connection.schema_search_path).to(start_with(%("#{schema1}")))
+      end
+    end
+
+    # Regression for https://github.com/rails-on-services/apartment/issues/396.
+    # Rails 8.1's PostgreSQLAdapter#schema_search_path= memoizes the last
+    # assigned value and returns early on identical re-assignment. When the
+    # PostgreSQL session's search_path has been changed out from under the
+    # ivar (transactional ROLLBACK, reconnect, pooled-connection reuse),
+    # the next switch! to the same tenant would silently skip the SET and
+    # leave queries pointing at the wrong schema.
+    context 'when the PostgreSQL session search_path has drifted from the AR cache' do
+      it 'still issues SET search_path on switch!' do
+        session_path = -> { connection.execute('SHOW search_path').first['search_path'] }
+
+        subject.switch!(schema1)
+
+        # Force divergence: change the session directly, leaving the AR
+        # ivar pointing at schema1.
+        connection.execute(%(SET search_path TO "#{public_schema}"))
+        expect(session_path.call).to(include(public_schema))
+
+        subject.switch!(schema1)
+
+        expect(session_path.call).to(include(schema1.to_s))
       end
     end
   end


### PR DESCRIPTION
## Summary

- Fixes #396. Rails 8.1's `PostgreSQLAdapter#schema_search_path=` memoizes the last assigned value and returns early on identical re-assignment (rails/rails#54698). When the ActiveRecord `@schema_search_path` ivar and the PG session's actual `search_path` diverge — transactional ROLLBACK in tests, connection reconnect, pooled-connection reuse — the next `switch!` silently skips `SET search_path` and queries hit the wrong schema.
- Adds a private `set_schema_search_path` helper on `PostgresqlSchemaAdapter` that nils the ivar immediately before reassigning, and routes every in-class assignment through it (`#reset`, `#init`, `#connect_to_new`). `JDBCPostgresqlSchemaAdapter#connect_to_new` inherits the helper.
- Follows the maintainer's guidance in https://github.com/rails-on-services/apartment/issues/396#issuecomment-4427065424.

## Test plan

- [x] `DATABASE_ENGINE=postgresql bundle exec rspec spec/adapters/postgresql_adapter_spec.rb` passes locally on Rails 8.1.3 (163 examples, including the two new regression contexts under `#switch!` and `#reset`, exercised in `schema.rb`, SQL-dump, and `pg_exclude_clone_tables` modes).
- [x] `DATABASE_ENGINE=postgresql bundle exec rspec spec/integration` passes (9 examples).
- [x] `DATABASE_ENGINE=postgresql bundle exec rspec` passes for the full suite (327 examples).
- [x] `bundle exec rubocop` reports no new offenses on the modified files.
- [ ] CI on Rails 8.1 matrix goes green.
