### PR TITLE
Fixture-lifecycle safety for lazily-created tenant pools

### DIFF
--- a/lib/apartment/pool_manager.rb
+++ b/lib/apartment/pool_manager.rb
@@ -23,9 +23,9 @@ module Apartment
       pool
     end
 
-    # Read a pool without updating its idle timestamp. Used by PoolReaper
-    # to inspect a candidate (e.g. its pinned state) before deciding to
-    # evict — +get+ would reset the very idleness the reaper is measuring.
+    # Read a pool without updating its idle timestamp. PoolReaper uses this
+    # to inspect an eviction candidate; +get+ would reset the very idleness
+    # the reaper is measuring.
     def peek(tenant_key)
       @pools[tenant_key]
     end

--- a/lib/apartment/pool_manager.rb
+++ b/lib/apartment/pool_manager.rb
@@ -23,6 +23,13 @@ module Apartment
       pool
     end
 
+    # Read a pool without updating its idle timestamp. Used by PoolReaper
+    # to inspect a candidate (e.g. its pinned state) before deciding to
+    # evict — +get+ would reset the very idleness the reaper is measuring.
+    def peek(tenant_key)
+      @pools[tenant_key]
+    end
+
     # Delete pool first, then timestamp. This ordering prevents a concurrent
     # #get from orphaning a timestamp (get checks @pools, skips touch if absent).
     def remove(tenant_key)

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -131,7 +131,9 @@ module Apartment
     # strands the fixture transaction; teardown then errors or marks the DB
     # dirty. AR exposes no public predicate, so we read the ivar it sets.
     # Best-effort: callers check-then-remove, so a pool can be pinned in
-    # that sub-millisecond window — the cost is a flaky test, not corruption.
+    # that sub-millisecond window. Evicting one then orphans its fixture
+    # transaction — a test-isolation failure (dirty fixture state, rows
+    # leaking between examples), not production data corruption.
     def pool_pinned?(pool)
       return false unless pool&.instance_variable_defined?(:@pinned_connection)
 

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -127,19 +127,11 @@ module Apartment
     end
 
     # True when Rails' transactional-fixture machinery has pinned the pool
-    # to a single connection for the duration of a test
-    # (ConnectionPool#pin_connection!). Evicting a pinned pool strands the
-    # fixture transaction — teardown's unpin_connection! then raises or
-    # marks the database dirty. ActiveRecord exposes no public predicate
-    # for this, so we read the @pinned_connection ivar it sets; the name
-    # has been stable since pin_connection! landed in Rails 7.1.
-    # True when Rails' transactional-fixture machinery has pinned the pool
-    # to a single connection for the duration of a test
-    # (ConnectionPool#pin_connection!). Evicting a pinned pool strands the
-    # fixture transaction — teardown's unpin_connection! then raises or
-    # marks the database dirty. ActiveRecord exposes no public predicate
-    # for this, so we read the @pinned_connection ivar it sets; the name
-    # has been stable since pin_connection! landed in Rails 7.1.
+    # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting a pinned pool
+    # strands the fixture transaction; teardown then errors or marks the DB
+    # dirty. AR exposes no public predicate, so we read the ivar it sets.
+    # Best-effort: callers check-then-remove, so a pool can be pinned in
+    # that sub-millisecond window — the cost is a flaky test, not corruption.
     def pool_pinned?(pool)
       return false unless pool&.instance_variable_defined?(:@pinned_connection)
 

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -81,6 +81,7 @@ module Apartment
       count = 0
       @pool_manager.idle_tenants(timeout: @idle_timeout).each do |tenant|
         next if default_tenant_pool?(tenant)
+        next if pool_pinned?(@pool_manager.peek(tenant))
 
         pool = @pool_manager.remove(tenant)
         deregister_from_ar_handler(tenant)
@@ -102,6 +103,7 @@ module Apartment
       candidates.each do |tenant|
         break if evicted >= excess
         next if default_tenant_pool?(tenant)
+        next if pool_pinned?(@pool_manager.peek(tenant))
 
         pool = @pool_manager.remove(tenant)
         deregister_from_ar_handler(tenant)
@@ -122,6 +124,26 @@ module Apartment
       return false unless @default_tenant
 
       pool_key == @default_tenant || pool_key.start_with?("#{@default_tenant}:")
+    end
+
+    # True when Rails' transactional-fixture machinery has pinned the pool
+    # to a single connection for the duration of a test
+    # (ConnectionPool#pin_connection!). Evicting a pinned pool strands the
+    # fixture transaction — teardown's unpin_connection! then raises or
+    # marks the database dirty. ActiveRecord exposes no public predicate
+    # for this, so we read the @pinned_connection ivar it sets; the name
+    # has been stable since pin_connection! landed in Rails 7.1.
+    # True when Rails' transactional-fixture machinery has pinned the pool
+    # to a single connection for the duration of a test
+    # (ConnectionPool#pin_connection!). Evicting a pinned pool strands the
+    # fixture transaction — teardown's unpin_connection! then raises or
+    # marks the database dirty. ActiveRecord exposes no public predicate
+    # for this, so we read the @pinned_connection ivar it sets; the name
+    # has been stable since pin_connection! landed in Rails 7.1.
+    def pool_pinned?(pool)
+      return false unless pool&.instance_variable_defined?(:@pinned_connection)
+
+      !pool.instance_variable_get(:@pinned_connection).nil?
     end
   end
 end

--- a/spec/integration/v4/fixture_pin_visibility_spec.rb
+++ b/spec/integration/v4/fixture_pin_visibility_spec.rb
@@ -41,8 +41,10 @@ RSpec.describe('v4 transactional-fixture visibility for lazy tenant pools', :int
         @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
       end
 
-      # `ActiveRecord::TestFixtures#run_in_transaction?` expects a
-      # Minitest-style host; supply the minimum it calls.
+      # run_in_transaction? = use_transactional_tests && !uses_transaction?(name).
+      # uses_transaction? is Rails' per-example opt-OUT list — `false` keeps
+      # transactional fixtures (and the pinning subscriber) ON. Flipping it to
+      # `true` would silently disable pinning and rot the examples below.
       def self.uses_transaction?(_name) = false
       def name = 'fixture_pin_visibility_reproduction'
 

--- a/spec/integration/v4/fixture_pin_visibility_spec.rb
+++ b/spec/integration/v4/fixture_pin_visibility_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+require 'apartment/test_fixtures'
+
+# Regression guard for transactional-fixture visibility of lazily-created
+# tenant pools.
+#
+# Apartment creates tenant pools lazily, on first access. In a host
+# application's test suite running with transactional fixtures, that first
+# access can happen *after* Rails' `setup_transactional_fixtures` has
+# already snapshotted and pinned the :writing pools — so a lazy tenant
+# pool is pinned late, by the `!connection.active_record` subscriber
+# rather than the initial snapshot. The concern: a write made inside the
+# example could miss the fixture transaction and be invisible to a later
+# read on the same tenant.
+#
+# These specs reproduce that lazy-creation timing faithfully — real Rails
+# `setup_fixtures` / `teardown_fixtures`, `Apartment::TestFixtures`
+# prepended as the Railtie wires it, the first in-example write triggering
+# lazy pool creation — and confirm the write IS visible to a later read on
+# the same tenant. The subscriber pins the lazy pool in time;
+# transactional visibility holds across `with_tenants`, `each`, and nested
+# `switch`.
+#
+# Kept as a regression guard: if a future change to the pool or pin
+# lifecycle breaks lazy-pool visibility, these go red.
+#
+# :schema strategy is PG-only.
+RSpec.describe('v4 transactional-fixture visibility for lazy tenant pools', :integration, # rubocop:disable RSpec/MultipleMemoizedHelpers
+               skip: (V4_INTEGRATION_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires PostgreSQL')) do
+  include V4IntegrationHelper
+
+  # Drives the real Rails transactional-fixture lifecycle (the same
+  # `setup_fixtures` / `teardown_fixtures` machinery rspec-rails invokes
+  # around every example when `use_transactional_tests` is true).
+  # `Apartment::TestFixtures` is prepended exactly as the v4 Railtie wires
+  # it in a host application.
+  if V4_INTEGRATION_AVAILABLE
+    class FixtureLifecycleHost
+      include ActiveRecord::TestFixtures
+      prepend Apartment::TestFixtures
+
+      def initialize
+        @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+      end
+
+      # `ActiveRecord::TestFixtures#run_in_transaction?` expects a
+      # Minitest-style host; supply the minimum it calls.
+      def self.uses_transaction?(_name) = false
+      def name = 'fixture_pin_visibility_reproduction'
+
+      # Mirrors the rspec-rails example wrapper: setup -> body -> teardown.
+      def run_example
+        setup_fixtures
+        yield
+      ensure
+        teardown_fixtures
+      end
+    end
+  end
+
+  let(:tmp_dir)      { Dir.mktmpdir('apartment_fixture_pin') }
+  let(:rand_suffix)  { SecureRandom.hex(4) }
+  let(:tenants)      { ["acme_#{rand_suffix}", "globex_#{rand_suffix}"] }
+  let(:write_tenant) { tenants.first }
+  let(:table_name)   { "widgets_#{rand_suffix}" }
+  let(:widget_class) do
+    klass = Class.new(ActiveRecord::Base)
+    klass.table_name = table_name
+    stub_const('Widget', klass)
+    klass
+  end
+
+  before do
+    V4IntegrationHelper.ensure_test_database!
+    config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+    ActiveRecord::Base.connection.execute('CREATE SCHEMA IF NOT EXISTS extensions')
+
+    Apartment.configure do |c|
+      c.tenant_strategy   = :schema
+      c.tenants_provider  = -> { tenants }
+      c.default_tenant    = 'public'
+      c.check_pending_migrations = false
+      c.configure_postgres { |pg| pg.persistent_schemas = ['extensions'] }
+    end
+    Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+    Apartment.activate!
+
+    tenants.each do |name|
+      Apartment.adapter.create(name)
+      Apartment::Tenant.switch(name) do
+        V4IntegrationHelper.create_test_table!(table_name)
+      end
+    end
+
+    # Precondition: creating the tables above lazily registered tenant
+    # pools. Clear them so the fixture lifecycle starts from the same
+    # state a real suite does — tenant schemas exist, tenant pools do not.
+    # `setup_transactional_fixtures` will then pin only `primary`, and the
+    # first in-example write is what re-creates the tenant pool.
+    Apartment.reset_tenant_pools!
+  end
+
+  after do
+    ActiveRecord::Base.connection.execute('DROP SCHEMA IF EXISTS extensions CASCADE')
+  ensure
+    V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter)
+    Apartment.clear_config
+    Apartment::Current.reset
+  end
+
+  it 'sees rows written inside the example when a later pass re-enters the tenant' do
+    widget_class
+    counts = {}
+
+    FixtureLifecycleHost.new.run_example do
+      # Local `around { Apartment::Tenant.switch(write_tenant) }` wrapping a
+      # `before(:each)` that writes: the first write lazily (re-)creates
+      # `apartment_<write_tenant>:writing` mid-example.
+      Apartment::Tenant.switch(write_tenant) do
+        5.times { Widget.create! }
+
+        # Example body: a job iterating every tenant and counting rows.
+        Apartment::Tenant.each do |tenant|
+          counts[tenant] = Widget.count
+        end
+      end
+    end
+
+    expect(counts[write_tenant]).to(eq(5))
+  end
+
+  # A `with_tenants` override wrapping the local switch — the shape of a
+  # global tenant-scoping hook layered under a per-example
+  # `around { switch }`.
+  it 'sees in-example writes when a with_tenants override wraps the local switch' do
+    widget_class
+    counts = {}
+
+    FixtureLifecycleHost.new.run_example do
+      Apartment::Tenant.with_tenants(*tenants) do
+        Apartment::Tenant.switch(write_tenant) do
+          5.times { Widget.create! }
+
+          Apartment::Tenant.each do |tenant|
+            counts[tenant] = Widget.count
+          end
+        end
+      end
+    end
+
+    expect(counts[write_tenant]).to(eq(5))
+  end
+
+  # The job iterates via `each` with no enclosing switch — `each` itself is
+  # the only thing entering the write tenant, and it does so *after* the
+  # `before(:each)` write already created+pinned the pool.
+  it 'sees in-example writes when each re-enters the tenant from a with_tenants override' do
+    widget_class
+    counts = {}
+
+    FixtureLifecycleHost.new.run_example do
+      # `before(:each)` equivalent: write under a bare switch, then let it close.
+      Apartment::Tenant.switch(write_tenant) { 5.times { Widget.create! } }
+
+      # Example body: job iterates via the override list, no outer switch.
+      Apartment::Tenant.with_tenants(*tenants) do
+        Apartment::Tenant.each do |tenant|
+          counts[tenant] = Widget.count
+        end
+      end
+    end
+
+    expect(counts[write_tenant]).to(eq(5))
+  end
+end

--- a/spec/integration/v4/fixture_pin_visibility_spec.rb
+++ b/spec/integration/v4/fixture_pin_visibility_spec.rb
@@ -7,25 +7,20 @@ require 'apartment/test_fixtures'
 # Regression guard for transactional-fixture visibility of lazily-created
 # tenant pools.
 #
-# Apartment creates tenant pools lazily, on first access. In a host
-# application's test suite running with transactional fixtures, that first
-# access can happen *after* Rails' `setup_transactional_fixtures` has
-# already snapshotted and pinned the :writing pools — so a lazy tenant
-# pool is pinned late, by the `!connection.active_record` subscriber
-# rather than the initial snapshot. The concern: a write made inside the
-# example could miss the fixture transaction and be invisible to a later
-# read on the same tenant.
+# Apartment creates tenant pools lazily, on first access. Under a host
+# application's transactional fixtures, that first access can land *after*
+# Rails' `setup_transactional_fixtures` has snapshotted and pinned the
+# :writing pools — so a lazy tenant pool is pinned late, by the
+# `!connection.active_record` subscriber rather than the initial snapshot.
+# The concern: a write made inside the example could miss the fixture
+# transaction and be invisible to a later read on the same tenant.
 #
-# These specs reproduce that lazy-creation timing faithfully — real Rails
-# `setup_fixtures` / `teardown_fixtures`, `Apartment::TestFixtures`
-# prepended as the Railtie wires it, the first in-example write triggering
-# lazy pool creation — and confirm the write IS visible to a later read on
-# the same tenant. The subscriber pins the lazy pool in time;
-# transactional visibility holds across `with_tenants`, `each`, and nested
-# `switch`.
-#
-# Kept as a regression guard: if a future change to the pool or pin
-# lifecycle breaks lazy-pool visibility, these go red.
+# These specs drive the real Rails fixture lifecycle (`setup_fixtures` /
+# `teardown_fixtures`, `Apartment::TestFixtures` prepended as the Railtie
+# wires it) and confirm the subscriber pins the lazy pool in time:
+# visibility holds across `with_tenants`, `each`, and nested `switch`. The
+# last example also confirms PoolReaper can detect the pin — guarding the
+# private-ivar read against a future ActiveRecord rename.
 #
 # :schema strategy is PG-only.
 RSpec.describe('v4 transactional-fixture visibility for lazy tenant pools', :integration, # rubocop:disable RSpec/MultipleMemoizedHelpers
@@ -174,5 +169,26 @@ RSpec.describe('v4 transactional-fixture visibility for lazy tenant pools', :int
     end
 
     expect(counts[write_tenant]).to(eq(5))
+  end
+
+  # Triangulates PoolReaper#pool_pinned? against a real, freshly-pinned
+  # ConnectionPool on whatever Rails version CI runs. The unit tests use a
+  # bare-Object fake, so only this catches an ActiveRecord ivar rename.
+  it 'pins the lazily-created tenant pool detectably for PoolReaper' do
+    widget_class
+    reaper = Apartment::PoolReaper.new(
+      pool_manager: Apartment.pool_manager, interval: 60, idle_timeout: 60
+    )
+    pinned_mid_example = nil
+
+    FixtureLifecycleHost.new.run_example do
+      Apartment::Tenant.switch(write_tenant) do
+        Widget.create!
+        pool = Apartment.pool_manager.peek("#{write_tenant}:writing")
+        pinned_mid_example = reaper.send(:pool_pinned?, pool)
+      end
+    end
+
+    expect(pinned_mid_example).to(be(true))
   end
 end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe(Apartment::PoolManager) do
     end
   end
 
+  describe '#peek' do
+    it 'returns the pool for an existing tenant' do
+      manager.fetch_or_create('tenant_a') { 'pool_a' }
+      expect(manager.peek('tenant_a')).to(eq('pool_a'))
+    end
+
+    it 'returns nil for unknown tenants' do
+      expect(manager.peek('unknown')).to(be_nil)
+    end
+
+    it 'does not reset seconds_idle on access' do
+      manager.fetch_or_create('tenant_a') { 'pool_a' }
+      manager.instance_variable_get(:@timestamps)['tenant_a'] = Process.clock_gettime(Process::CLOCK_MONOTONIC) - 600
+      manager.peek('tenant_a')
+      expect(manager.stats_for('tenant_a')[:seconds_idle]).to(be_within(1).of(600))
+    end
+  end
+
   describe '#remove' do
     it 'removes a tracked pool' do
       manager.fetch_or_create('tenant_a') { 'pool_a' }

--- a/spec/unit/pool_reaper_spec.rb
+++ b/spec/unit/pool_reaper_spec.rb
@@ -113,6 +113,58 @@ RSpec.describe(Apartment::PoolReaper) do
     end
   end
 
+  describe 'pinned pool protection' do
+    # A pool Rails' transactional-fixture machinery has pinned to a single
+    # connection. Evicting it would strand the fixture transaction.
+    def pinned_pool
+      pool = Object.new
+      pool.instance_variable_set(:@pinned_connection, Object.new)
+      pool
+    end
+
+    it 'does not evict a pinned pool that is idle beyond timeout' do
+      pool_manager.fetch_or_create('pinned') { pinned_pool }
+      pool_manager.instance_variable_get(:@timestamps)['pinned'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      pool_manager.fetch_or_create('stale') { 'pool_stale' }
+      pool_manager.instance_variable_get(:@timestamps)['stale'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      reaper.start
+      sleep 0.2
+
+      expect(pool_manager.tracked?('pinned')).to(be(true))
+      expect(disconnect_calls).not_to(include('pinned'))
+      expect(pool_manager.tracked?('stale')).to(be(false))
+    end
+
+    it 'does not evict a pinned pool under max_total LRU pressure' do
+      lru_reaper = described_class.new(
+        pool_manager: pool_manager,
+        interval: 0.05,
+        idle_timeout: 999,
+        max_total: 1,
+        on_evict: on_evict
+      )
+
+      pool_manager.fetch_or_create('pinned') { pinned_pool }
+      pool_manager.instance_variable_get(:@timestamps)['pinned'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 300
+
+      pool_manager.fetch_or_create('evictable') { 'pool_evictable' }
+      pool_manager.instance_variable_get(:@timestamps)['evictable'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 100
+
+      lru_reaper.start
+      sleep 0.2
+      lru_reaper.stop
+
+      expect(pool_manager.tracked?('pinned')).to(be(true))
+      expect(disconnect_calls).not_to(include('pinned'))
+    end
+  end
+
   describe 'protected tenants' do
     let(:reaper) do
       described_class.new(


### PR DESCRIPTION
## Summary

Two changes hardening Apartment's interaction with Rails' transactional-fixture machinery, both centered on the same fact: Apartment creates tenant connection pools **lazily**, on first access — so a tenant pool can come into existence *after* `ActiveRecord::TestFixtures#setup_transactional_fixtures` has already snapshotted and pinned the `:writing` pools.

### 1. Regression guard for lazy-pool fixture visibility

When a lazy tenant pool is created mid-example, it is pinned late — by the `!connection.active_record` subscriber rather than the initial `setup_transactional_fixtures` snapshot. This raised the question of whether a write made inside an example could miss the fixture transaction and be invisible to a later read on the same tenant.

`spec/integration/v4/fixture_pin_visibility_spec.rb` drives the **real** Rails transactional-fixture lifecycle (`setup_fixtures` / `teardown_fixtures`) with `Apartment::TestFixtures` prepended exactly as the Railtie wires it, and triggers lazy pool creation via the first in-example write. It confirms the subscriber pins the lazy pool in time: writes stay visible to later reads on the same tenant across `with_tenants`, `each`, and nested `switch`. A final example asserts `PoolReaper#pool_pinned?` detects a real, freshly-pinned `ConnectionPool` — triangulating the private-ivar read (see below) against whatever Rails version CI runs, so an ActiveRecord rename fails loudly instead of silently. Kept as a guard against future regressions in the pool/pin lifecycle. PG-only (`:schema` strategy).

### 2. Skip pinned pools in `PoolReaper` eviction

`PoolReaper`'s idle/LRU eviction only exempted the default tenant. A background reap firing mid-suite could evict a tenant pool that Rails had pinned for the duration of a test — stranding the fixture transaction so that teardown's `unpin_connection!` raises or marks the database dirty.

`evict_idle` and `evict_lru` now skip pinned pools. Detection reads the `@pinned_connection` ivar that `ConnectionPool#pin_connection!` sets — ActiveRecord exposes no public predicate, and the ivar has been stable since `pin_connection!` landed in Rails 7.1. The check is best-effort: callers check-then-remove, so a pool can be pinned in that sub-millisecond window. Evicting one then orphans its fixture transaction — a test-isolation failure (dirty fixture state, rows leaking between examples), not production data corruption. `PoolManager` gains `#peek`, a non-touching reader, so the pinned-check does not reset the idle timestamp the reaper is measuring.

## Test plan

- [x] `bundle exec rspec spec/unit/` — 729 examples, 0 failures
- [x] `bundle exec rspec spec/unit/pool_reaper_spec.rb spec/unit/pool_manager_spec.rb` — pinned-pool eviction guards and `#peek` covered (42 examples)
- [x] `DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/fixture_pin_visibility_spec.rb` — 4 examples, 0 failures
- [x] `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/memory_stability_spec.rb spec/integration/v4/stress_spec.rb spec/integration/v4/tenant_lifecycle_spec.rb` — reaper-exercising specs green
- [x] `bundle exec rubocop` — clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)