### PR TITLE
Pool lifecycle safety: in-use guard, observability, test-env default

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -181,6 +181,8 @@ The reaper is also defensive against transactional state when it does run. Two g
 
 Both skip paths emit `skip_evict.apartment` notifications with `reason:` `:pinned` or `:in_use` (the `:in_use` payload includes `busy_connections` and `open_transactions`). If a tenant key shows up repeatedly in `skip_evict` events over time, that's the signal for a leaked connection or forgotten transaction — fix the leak, don't tune the reaper.
 
+Both guards are best-effort: the reaper checks the pool state and then removes it as separate steps, so a pool can become pinned or in-use in the sub-millisecond window between. The cost of an unlucky race is a test-isolation failure (dirty fixture state, rows leaking between examples), not production data corruption.
+
 Two narrow cases the in-use guard does **not** cover:
 
 - A server-side cursor (`WITH HOLD`, certain `COPY` paths) holding server state without an open transaction. ActiveRecord exposes no public predicate for this; rare in typical Rails code.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -164,3 +164,26 @@ end
 ```
 
 > **Footnote on test-prof.** If your suite uses test-prof's `let_it_be` / `before_all`, prefer the suite-level `switch!` shown above over per-example `around { switch(...) { example.run } }`. `let_it_be` commits its setup data inside its own transaction; wrapping examples in an `around switch` can interact with the savepoint hierarchy in a way that DatabaseCleaner's rollback can't unwind cleanly when an example raises — producing a transaction-poisoning cascade where every subsequent example fails with `PG::InFailedSqlTransaction`. Suite-level `switch!` avoids this because there's no per-example switching wrapping `let_it_be` setup.
+
+## Pool lifecycle in tests
+
+`Apartment::PoolReaper` evicts idle and excess tenant pools on a background timer. In production it bounds memory under high tenant counts; in test suites it's typically a liability — short runs, few tenants, no memory pressure, and an eviction mid-example can orphan transactional-fixture state. **The Railtie stops the reaper automatically when `Rails.env.test?`.** A suite that genuinely needs eviction (long-running parallel tenant churn, large fixtures) can opt back in:
+
+```ruby
+# spec/rails_helper.rb
+Apartment.pool_reaper&.start
+```
+
+The reaper is also defensive against transactional state when it does run. Two guards block eviction of a candidate pool:
+
+- **Pinned pools** (`ConnectionPool#pin_connection!`) — the path Rails' transactional fixtures use, plus the lazy-creation case where the `!connection.active_record` subscriber pins after-the-fact.
+- **In-use pools** — at least one connection is leased (`Connection#in_use?`) or holds an open transaction (`Connection#open_transactions > 0`). Covers any consumer that opened a transaction outside the fixture machinery: long migrations, batch jobs, an explicit `ActiveRecord::Base.transaction` block.
+
+Both skip paths emit `skip_evict.apartment` notifications with `reason:` `:pinned` or `:in_use` (the `:in_use` payload includes `busy_connections` and `open_transactions`). If a tenant key shows up repeatedly in `skip_evict` events over time, that's the signal for a leaked connection or forgotten transaction — fix the leak, don't tune the reaper.
+
+Two narrow cases the in-use guard does **not** cover:
+
+- A server-side cursor (`WITH HOLD`, certain `COPY` paths) holding server state without an open transaction. ActiveRecord exposes no public predicate for this; rare in typical Rails code.
+- A pool whose connections have all been returned but a query-cache or prepared-statement cache remains warm — correctly evictable; the next access rebuilds both.
+
+When LRU pressure can't reach `max_total_connections` because too many pools are protected, the reaper emits `cap_unmet.apartment` instead of forcing eviction. The cap is best-effort under active workload — if you see it firing, check for the same leak signature in `skip_evict`.

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -104,7 +104,7 @@ module Apartment
       if evicted < excess
         Instrumentation.instrument(:cap_unmet,
                                    max_total: @max_total,
-                                   current: @pool_manager.stats[:total_pools],
+                                   current: total - evicted,
                                    unevicted: excess - evicted)
       end
 
@@ -113,9 +113,11 @@ module Apartment
 
     # The LRU loop body, factored out so evict_lru reads as "evict up to
     # excess, then report the cap if we couldn't get there."
-    def perform_lru_eviction(excess, total)
+    # The LRU loop body, factored out so evict_lru reads as "evict up to
+    # excess, then report the cap if we couldn't get there."
+    def perform_lru_eviction(excess, candidate_count)
       evicted = 0
-      @pool_manager.lru_tenants(count: total).each do |tenant|
+      @pool_manager.lru_tenants(count: candidate_count).each do |tenant|
         break if evicted >= excess
         next if default_tenant_pool?(tenant)
         next if protected_pool?(tenant, eviction_reason: :lru)
@@ -164,6 +166,11 @@ module Apartment
     # that sub-millisecond window. Evicting one then orphans its fixture
     # transaction — a test-isolation failure (dirty fixture state, rows
     # leaking between examples), not production data corruption.
+    # True when Rails' transactional-fixture machinery has pinned the pool
+    # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting a pinned pool
+    # strands the fixture transaction; teardown then errors or marks the DB
+    # dirty. AR exposes no public predicate, so we read the ivar it sets.
+    # TOCTOU caveat applies — see docs/testing.md "Pool lifecycle in tests".
     def pool_pinned?(pool)
       return false unless pool&.instance_variable_defined?(:@pinned_connection)
 
@@ -187,6 +194,10 @@ module Apartment
     # Build and emit the :skip_evict payload. For :in_use, include
     # connection-state details so a tenant skipped for many cycles is
     # diagnosable from instrumentation alone.
+    # Build and emit the :skip_evict payload. :pinned is a binary state
+    # with nothing useful to surface; :in_use carries busy_connections and
+    # open_transactions so a tenant skipped for many cycles is diagnosable
+    # from instrumentation alone.
     def instrument_skip(reason:, tenant:, eviction_reason:, pool:)
       payload = { tenant: tenant, reason: reason, eviction_reason: eviction_reason }
       if reason == :in_use && pool.respond_to?(:connections)

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -113,8 +113,6 @@ module Apartment
 
     # The LRU loop body, factored out so evict_lru reads as "evict up to
     # excess, then report the cap if we couldn't get there."
-    # The LRU loop body, factored out so evict_lru reads as "evict up to
-    # excess, then report the cap if we couldn't get there."
     def perform_lru_eviction(excess, candidate_count)
       evicted = 0
       @pool_manager.lru_tenants(count: candidate_count).each do |tenant|
@@ -162,14 +160,6 @@ module Apartment
     # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting a pinned pool
     # strands the fixture transaction; teardown then errors or marks the DB
     # dirty. AR exposes no public predicate, so we read the ivar it sets.
-    # Best-effort: callers check-then-remove, so a pool can be pinned in
-    # that sub-millisecond window. Evicting one then orphans its fixture
-    # transaction — a test-isolation failure (dirty fixture state, rows
-    # leaking between examples), not production data corruption.
-    # True when Rails' transactional-fixture machinery has pinned the pool
-    # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting a pinned pool
-    # strands the fixture transaction; teardown then errors or marks the DB
-    # dirty. AR exposes no public predicate, so we read the ivar it sets.
     # TOCTOU caveat applies — see docs/testing.md "Pool lifecycle in tests".
     def pool_pinned?(pool)
       return false unless pool&.instance_variable_defined?(:@pinned_connection)
@@ -191,9 +181,6 @@ module Apartment
       end
     end
 
-    # Build and emit the :skip_evict payload. For :in_use, include
-    # connection-state details so a tenant skipped for many cycles is
-    # diagnosable from instrumentation alone.
     # Build and emit the :skip_evict payload. :pinned is a binary state
     # with nothing useful to surface; :in_use carries busy_connections and
     # open_transactions so a tenant skipped for many cycles is diagnosable

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -81,7 +81,7 @@ module Apartment
       count = 0
       @pool_manager.idle_tenants(timeout: @idle_timeout).each do |tenant|
         next if default_tenant_pool?(tenant)
-        next if pool_pinned?(@pool_manager.peek(tenant))
+        next if protected_pool?(tenant, eviction_reason: :idle)
 
         pool = @pool_manager.remove(tenant)
         deregister_from_ar_handler(tenant)
@@ -95,15 +95,30 @@ module Apartment
     end
 
     def evict_lru
-      excess = @pool_manager.stats[:total_pools] - @max_total
+      total = @pool_manager.stats[:total_pools]
+      excess = total - @max_total
       return 0 if excess <= 0
 
-      candidates = @pool_manager.lru_tenants(count: excess + 1)
+      evicted = perform_lru_eviction(excess, total)
+
+      if evicted < excess
+        Instrumentation.instrument(:cap_unmet,
+                                   max_total: @max_total,
+                                   current: @pool_manager.stats[:total_pools],
+                                   unevicted: excess - evicted)
+      end
+
+      evicted
+    end
+
+    # The LRU loop body, factored out so evict_lru reads as "evict up to
+    # excess, then report the cap if we couldn't get there."
+    def perform_lru_eviction(excess, total)
       evicted = 0
-      candidates.each do |tenant|
+      @pool_manager.lru_tenants(count: total).each do |tenant|
         break if evicted >= excess
         next if default_tenant_pool?(tenant)
-        next if pool_pinned?(@pool_manager.peek(tenant))
+        next if protected_pool?(tenant, eviction_reason: :lru)
 
         pool = @pool_manager.remove(tenant)
         deregister_from_ar_handler(tenant)
@@ -134,10 +149,70 @@ module Apartment
     # that sub-millisecond window. Evicting one then orphans its fixture
     # transaction — a test-isolation failure (dirty fixture state, rows
     # leaking between examples), not production data corruption.
+    # Returns true and emits :skip_evict if the candidate pool is currently
+    # protected. Used as a single guard for both eviction paths.
+    def protected_pool?(tenant, eviction_reason:)
+      pool = @pool_manager.peek(tenant)
+      if pool_pinned?(pool)
+        instrument_skip(reason: :pinned, tenant: tenant, eviction_reason: eviction_reason, pool: pool)
+        return true
+      end
+      if pool_in_use?(pool)
+        instrument_skip(reason: :in_use, tenant: tenant, eviction_reason: eviction_reason, pool: pool)
+        return true
+      end
+      false
+    end
+
+    # True when Rails' transactional-fixture machinery has pinned the pool
+    # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting a pinned pool
+    # strands the fixture transaction; teardown then errors or marks the DB
+    # dirty. AR exposes no public predicate, so we read the ivar it sets.
+    # Best-effort: callers check-then-remove, so a pool can be pinned in
+    # that sub-millisecond window. Evicting one then orphans its fixture
+    # transaction — a test-isolation failure (dirty fixture state, rows
+    # leaking between examples), not production data corruption.
     def pool_pinned?(pool)
       return false unless pool&.instance_variable_defined?(:@pinned_connection)
 
       !pool.instance_variable_get(:@pinned_connection).nil?
+    end
+
+    # True when at least one connection in the pool is leased or holds an
+    # open transaction (long-running migration, batch job, unpinned fixture
+    # tx). Forced eviction here would orphan that work, so we skip and let
+    # the next reap cycle re-evaluate. Note: a server-side cursor without
+    # an open transaction is not detectable via AR's public API and falls
+    # outside this guard — rare in typical Rails.
+    # True when at least one connection in the pool is leased or holds an
+    # open transaction (long-running migration, batch job, unpinned fixture
+    # tx). Forced eviction here would orphan that work, so we skip and let
+    # the next reap cycle re-evaluate. Note: a server-side cursor without
+    # an open transaction is not detectable via AR's public API and falls
+    # outside this guard — rare in typical Rails.
+    def pool_in_use?(pool)
+      return false unless pool.respond_to?(:connections)
+
+      pool.connections.any? do |conn|
+        (conn.respond_to?(:in_use?) && conn.in_use?) ||
+          (conn.respond_to?(:open_transactions) && conn.open_transactions.positive?)
+      end
+    end
+
+    # Build and emit the :skip_evict payload. For :in_use, include
+    # connection-state details so a tenant skipped for many cycles is
+    # diagnosable from instrumentation alone.
+    def instrument_skip(reason:, tenant:, eviction_reason:, pool:)
+      payload = { tenant: tenant, reason: reason, eviction_reason: eviction_reason }
+      if reason == :in_use && pool.respond_to?(:connections)
+        payload[:busy_connections] = pool.connections.count do |c|
+          c.respond_to?(:in_use?) && c.in_use?
+        end
+        payload[:open_transactions] = pool.connections.sum do |c|
+          c.respond_to?(:open_transactions) ? c.open_transactions : 0
+        end
+      end
+      Instrumentation.instrument(:skip_evict, payload)
     end
   end
 end

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -141,14 +141,6 @@ module Apartment
       pool_key == @default_tenant || pool_key.start_with?("#{@default_tenant}:")
     end
 
-    # True when Rails' transactional-fixture machinery has pinned the pool
-    # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting a pinned pool
-    # strands the fixture transaction; teardown then errors or marks the DB
-    # dirty. AR exposes no public predicate, so we read the ivar it sets.
-    # Best-effort: callers check-then-remove, so a pool can be pinned in
-    # that sub-millisecond window. Evicting one then orphans its fixture
-    # transaction — a test-isolation failure (dirty fixture state, rows
-    # leaking between examples), not production data corruption.
     # Returns true and emits :skip_evict if the candidate pool is currently
     # protected. Used as a single guard for both eviction paths.
     def protected_pool?(tenant, eviction_reason:)
@@ -178,18 +170,11 @@ module Apartment
       !pool.instance_variable_get(:@pinned_connection).nil?
     end
 
-    # True when at least one connection in the pool is leased or holds an
-    # open transaction (long-running migration, batch job, unpinned fixture
-    # tx). Forced eviction here would orphan that work, so we skip and let
-    # the next reap cycle re-evaluate. Note: a server-side cursor without
-    # an open transaction is not detectable via AR's public API and falls
-    # outside this guard — rare in typical Rails.
-    # True when at least one connection in the pool is leased or holds an
-    # open transaction (long-running migration, batch job, unpinned fixture
-    # tx). Forced eviction here would orphan that work, so we skip and let
-    # the next reap cycle re-evaluate. Note: a server-side cursor without
-    # an open transaction is not detectable via AR's public API and falls
-    # outside this guard — rare in typical Rails.
+    # True when at least one connection is leased or holds an open
+    # transaction (long migration, batch job, unpinned fixture tx). Forcing
+    # eviction would potentially orphan that work, so skip and let the next
+    # reap cycle re-evaluate. See docs/testing.md for the server-side-cursor
+    # case this misses.
     def pool_in_use?(pool)
       return false unless pool.respond_to?(:connections)
 

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -27,6 +27,8 @@ module Apartment
       rescue ActiveRecord::NoDatabaseError
         warn '[Apartment] Database not found during init — skipping. Run db:create first.'
       end
+
+      Apartment::Railtie.deactivate_pool_reaper_in_test_env!
     end
 
     # Insert elevator middleware if configured.
@@ -88,6 +90,15 @@ module Apartment
     # Whether the Header elevator trust warning should fire. Class method for testability.
     def self.header_trust_warning?(elevator_class, opts)
       elevator_class <= Apartment::Elevators::Header && !opts[:trusted]
+    end
+
+    # In test environments the reaper is more liability than asset: suites
+    # are short, tenant counts low, memory pressure absent, and an eviction
+    # mid-example orphans transactional-fixture state. Stop the reaper that
+    # Apartment.configure started; a suite that genuinely needs eviction
+    # can call Apartment.pool_reaper.start explicitly.
+    def self.deactivate_pool_reaper_in_test_env!
+      Apartment.pool_reaper&.stop if Rails.env.test?
     end
 
     # Resolve an elevator symbol/string to its class. Class method for testability.

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -96,9 +96,15 @@ module Apartment
     # are short, tenant counts low, memory pressure absent, and an eviction
     # mid-example orphans transactional-fixture state. Stop the reaper that
     # Apartment.configure started; a suite that genuinely needs eviction
-    # can call Apartment.pool_reaper.start explicitly.
+    # can call Apartment.pool_reaper.start explicitly. Emits :reaper_stopped
+    # so an upgrading adopter notices the behavior change without combing
+    # release notes.
     def self.deactivate_pool_reaper_in_test_env!
-      Apartment.pool_reaper&.stop if Rails.env.test?
+      return unless Rails.env.test?
+      return unless Apartment.pool_reaper
+
+      Apartment.pool_reaper.stop
+      Apartment::Instrumentation.instrument(:reaper_stopped, reason: :test_env)
     end
 
     # Resolve an elevator symbol/string to its class. Class method for testability.

--- a/spec/integration/v4/coverage_gaps_spec.rb
+++ b/spec/integration/v4/coverage_gaps_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe('v4 Coverage gaps integration', :integration,
       sleep(0.02)
       Apartment::Tenant.switch('lru_6') { Widget.create!(name: 'most_recent') }
 
+      # Mirror the request/job boundary that releases sticky leases in
+      # production. Without this the in-use guard correctly skips every
+      # pool — none of them are evictable while the test thread holds
+      # checked-out connections.
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
       # Directly invoke run_cycle to avoid timing-dependent background thread.
       Apartment.pool_reaper.run_cycle
 

--- a/spec/integration/v4/fixture_pin_visibility_spec.rb
+++ b/spec/integration/v4/fixture_pin_visibility_spec.rb
@@ -193,4 +193,35 @@ RSpec.describe('v4 transactional-fixture visibility for lazy tenant pools', :int
 
     expect(pinned_mid_example).to(be(true))
   end
+
+  # Covers the case PR #399 cannot: a pool that holds an open transaction
+  # without being formally pinned (production migration, batch job, an app
+  # `ActiveRecord::Base.transaction` block outside fixture machinery). The
+  # in-use guard must skip eviction and emit :skip_evict.
+  it 'PoolReaper skips a tenant pool with an open transaction even when unpinned' do
+    widget_class
+    reaper = Apartment::PoolReaper.new(
+      pool_manager: Apartment.pool_manager, interval: 60, idle_timeout: 0.001
+    )
+    skips = Concurrent::Array.new
+    subscription = ActiveSupport::Notifications.subscribe('skip_evict.apartment') { |e| skips << e }
+
+    Apartment::Tenant.switch(write_tenant) do
+      ActiveRecord::Base.connection.begin_transaction
+      Widget.create!
+      sleep(0.01)
+
+      expect(reaper.run_cycle).to(eq(0))
+      expect(Apartment.pool_manager.tracked?("#{write_tenant}:writing")).to(be(true))
+
+      skip_event = skips.find { |e| e.payload[:tenant] == "#{write_tenant}:writing" }
+      expect(skip_event).not_to(be_nil)
+      expect(skip_event.payload).to(include(reason: :in_use))
+      expect(skip_event.payload[:open_transactions]).to(be_positive)
+    ensure
+      ActiveRecord::Base.connection.rollback_transaction if ActiveRecord::Base.connection.transaction_open?
+    end
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+  end
 end

--- a/spec/integration/v4/memory_stability_spec.rb
+++ b/spec/integration/v4/memory_stability_spec.rb
@@ -65,6 +65,10 @@ RSpec.describe('v4 Memory stability integration', :integration,
                               "Cycle 0: expected > 5 pools before reap, got #{pre_reap}")
         end
 
+        # Mirror the request/job boundary that releases sticky leases in
+        # production; without it the in-use guard correctly skips every pool.
+        ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
         Apartment.pool_reaper.run_cycle
 
         pool_count = Apartment.pool_manager.stats[:total_pools]

--- a/spec/integration/v4/stress_spec.rb
+++ b/spec/integration/v4/stress_spec.rb
@@ -274,6 +274,11 @@ RSpec.describe('v4 Stress / concurrency integration', :integration, :stress,
       role = ActiveRecord::Base.current_role
       expect(Apartment.pool_manager.tracked?("reap_me:#{role}")).to(be(true))
 
+      # Mirror the request/job boundary that releases sticky leases in
+      # production; the in-use guard correctly skips a pool whose
+      # connection is still checked out.
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
       # Poll until reaper evicts the idle pool or timeout
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
       until !Apartment.pool_manager.tracked?("reap_me:#{role}") ||

--- a/spec/unit/pool_reaper_spec.rb
+++ b/spec/unit/pool_reaper_spec.rb
@@ -165,6 +165,99 @@ RSpec.describe(Apartment::PoolReaper) do
     end
   end
 
+  describe 'in-use pool protection' do
+    # A pool with at least one connection currently leased or holding an
+    # open transaction — e.g., a long-running migration, a Sidekiq job that
+    # opened a transaction, or an unpinned per-example fixture transaction.
+    def in_use_pool(leased: true, open_tx: 0)
+      pool = Object.new
+      conn = Object.new
+      conn.define_singleton_method(:in_use?) { leased }
+      conn.define_singleton_method(:open_transactions) { open_tx }
+      pool.define_singleton_method(:connections) { [conn] }
+      pool
+    end
+
+    it 'does not evict a pool with a leased connection idle beyond timeout' do
+      pool_manager.fetch_or_create('busy') { in_use_pool(leased: true) }
+      pool_manager.instance_variable_get(:@timestamps)['busy'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      pool_manager.fetch_or_create('stale') { in_use_pool(leased: false) }
+      pool_manager.instance_variable_get(:@timestamps)['stale'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      reaper.start
+      sleep 0.2
+
+      expect(pool_manager.tracked?('busy')).to(be(true))
+      expect(disconnect_calls).not_to(include('busy'))
+      expect(pool_manager.tracked?('stale')).to(be(false))
+    end
+
+    it 'does not evict a pool with an open transaction (no formal pin)' do
+      pool_manager.fetch_or_create('tx_open') { in_use_pool(leased: false, open_tx: 1) }
+      pool_manager.instance_variable_get(:@timestamps)['tx_open'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      reaper.start
+      sleep 0.2
+
+      expect(pool_manager.tracked?('tx_open')).to(be(true))
+      expect(disconnect_calls).not_to(include('tx_open'))
+    end
+
+    it 'does not evict an in-use pool under max_total LRU pressure' do
+      lru_reaper = described_class.new(
+        pool_manager: pool_manager,
+        interval: 0.05,
+        idle_timeout: 999,
+        max_total: 1,
+        on_evict: on_evict
+      )
+
+      pool_manager.fetch_or_create('busy') { in_use_pool(leased: true) }
+      pool_manager.instance_variable_get(:@timestamps)['busy'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 300
+
+      pool_manager.fetch_or_create('evictable') { in_use_pool(leased: false) }
+      pool_manager.instance_variable_get(:@timestamps)['evictable'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 100
+
+      lru_reaper.start
+      sleep 0.2
+      lru_reaper.stop
+
+      expect(pool_manager.tracked?('busy')).to(be(true))
+      expect(disconnect_calls).not_to(include('busy'))
+    end
+
+    it 'evicts the pool on a later cycle once connections are released' do
+      flag = { leased: true }
+      live_pool = Object.new
+      conn = Object.new
+      conn.define_singleton_method(:in_use?) { flag[:leased] }
+      conn.define_singleton_method(:open_transactions) { 0 }
+      live_pool.define_singleton_method(:connections) { [conn] }
+
+      pool_manager.fetch_or_create('transient') { live_pool }
+      pool_manager.instance_variable_get(:@timestamps)['transient'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      reaper.start
+      sleep 0.15
+      expect(pool_manager.tracked?('transient')).to(be(true))
+
+      flag[:leased] = false
+      pool_manager.instance_variable_get(:@timestamps)['transient'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+      sleep 0.15
+
+      expect(pool_manager.tracked?('transient')).to(be(false))
+      expect(disconnect_calls).to(include('transient'))
+    end
+  end
+
   describe 'protected tenants' do
     let(:reaper) do
       described_class.new(
@@ -268,6 +361,84 @@ RSpec.describe(Apartment::PoolReaper) do
       expect(events.any? { |e| e.payload[:tenant] == 'stale' }).to(be(true))
     ensure
       ActiveSupport::Notifications.unsubscribe('evict.apartment')
+    end
+
+    it 'emits skip_evict.apartment with reason :pinned when a pinned pool is preserved' do
+      events = Concurrent::Array.new
+      ActiveSupport::Notifications.subscribe('skip_evict.apartment') { |e| events << e }
+
+      pinned = Object.new
+      pinned.instance_variable_set(:@pinned_connection, Object.new)
+      pool_manager.fetch_or_create('pinned') { pinned }
+      pool_manager.instance_variable_get(:@timestamps)['pinned'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      reaper.start
+      sleep(0.2)
+
+      pinned_skip = events.find { |e| e.payload[:tenant] == 'pinned' }
+      expect(pinned_skip).not_to(be_nil)
+      expect(pinned_skip.payload).to(include(reason: :pinned, eviction_reason: :idle))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('skip_evict.apartment')
+    end
+
+    it 'emits skip_evict.apartment with reason :in_use including connection state' do
+      events = Concurrent::Array.new
+      ActiveSupport::Notifications.subscribe('skip_evict.apartment') { |e| events << e }
+
+      busy = Object.new
+      conn = Object.new
+      conn.define_singleton_method(:in_use?) { true }
+      conn.define_singleton_method(:open_transactions) { 2 }
+      busy.define_singleton_method(:connections) { [conn] }
+      pool_manager.fetch_or_create('busy') { busy }
+      pool_manager.instance_variable_get(:@timestamps)['busy'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 10
+
+      reaper.start
+      sleep(0.2)
+
+      busy_skip = events.find { |e| e.payload[:tenant] == 'busy' }
+      expect(busy_skip).not_to(be_nil)
+      expect(busy_skip.payload).to(include(reason: :in_use, eviction_reason: :idle,
+                                           busy_connections: 1, open_transactions: 2))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('skip_evict.apartment')
+    end
+
+    it 'emits cap_unmet.apartment when protected pools prevent LRU eviction from reaching max_total' do
+      events = Concurrent::Array.new
+      ActiveSupport::Notifications.subscribe('cap_unmet.apartment') { |e| events << e }
+
+      lru_reaper = described_class.new(
+        pool_manager: pool_manager,
+        interval: 0.05,
+        idle_timeout: 999,
+        max_total: 1,
+        on_evict: on_evict
+      )
+
+      pinned = Object.new
+      pinned.instance_variable_set(:@pinned_connection, Object.new)
+      pool_manager.fetch_or_create('pinned_a') { pinned }
+      pool_manager.fetch_or_create('pinned_b') { pinned }
+      pool_manager.instance_variable_get(:@timestamps)['pinned_a'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 300
+      pool_manager.instance_variable_get(:@timestamps)['pinned_b'] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - 200
+
+      lru_reaper.start
+      sleep(0.2)
+      lru_reaper.stop
+
+      cap_event = events.last
+      expect(cap_event).not_to(be_nil)
+      expect(cap_event.payload).to(include(max_total: 1))
+      expect(cap_event.payload[:current]).to(be >= 2)
+      expect(cap_event.payload[:unevicted]).to(be_positive)
+    ensure
+      ActiveSupport::Notifications.unsubscribe('cap_unmet.apartment')
     end
   end
 

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe('Apartment::Railtie') do
       expect(reaper).to(have_received(:stop))
     end
 
+    it 'emits reaper_stopped.apartment with reason :test_env when it stops the reaper' do
+      reaper = instance_double(Apartment::PoolReaper, stop: nil)
+      allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+      events = []
+      sub = ActiveSupport::Notifications.subscribe('reaper_stopped.apartment') { |e| events << e }
+
+      Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+      expect(events.size).to(eq(1))
+      expect(events.first.payload).to(eq(reason: :test_env))
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub) if sub
+    end
+
     it 'does nothing outside the test environment' do
       reaper = instance_double(Apartment::PoolReaper, stop: nil)
       allow(Apartment).to(receive(:pool_reaper).and_return(reaper))

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -95,4 +95,33 @@ RSpec.describe('Apartment::Railtie') do
       expect(Apartment::Railtie.header_trust_warning?(Apartment::Elevators::Subdomain, {})).to(be(false))
     end
   end
+
+  describe '.deactivate_pool_reaper_in_test_env!' do
+    it 'stops Apartment.pool_reaper when Rails.env.test? is true' do
+      reaper = instance_double(Apartment::PoolReaper, stop: nil)
+      allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+      Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+      expect(reaper).to(have_received(:stop))
+    end
+
+    it 'does nothing outside the test environment' do
+      reaper = instance_double(Apartment::PoolReaper, stop: nil)
+      allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('production')))
+
+      Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+      expect(reaper).not_to(have_received(:stop))
+    end
+
+    it 'is a no-op when no reaper is configured' do
+      allow(Apartment).to(receive(:pool_reaper).and_return(nil))
+      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+      expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

A follow-up to #399, addressing the sibling foot-gun the pinned-pool guard cannot cover. Three coordinated changes:

### 1. `PoolReaper` skips in-use pools

`#399` made the reaper safe against pools that ActiveRecord's transactional-fixture machinery had formally pinned (`ConnectionPool#pin_connection!`). A pool can also hold an open transaction or a leased connection **without** being formally pinned — a production migration, a long-running batch job, an `ActiveRecord::Base.transaction` block opened by application code. Evicting that pool mid-flight orphans the transaction.

`evict_idle` and `evict_lru` now consult `Connection#in_use?` and `#open_transactions` across the pool's connections (public AR API; runs once per reap interval, not per switch), skipping any pool with active work. The narrow case the predicate cannot cover — a server-side cursor without an open transaction — is documented; AR exposes no public signal for it.

### 2. Observability: `:skip_evict` and `:cap_unmet` notifications

Both skip paths (pinned and in-use) now emit `skip_evict.apartment` notifications. The `:in_use` payload carries `busy_connections` and `open_transactions` so a tenant repeatedly skipped over many cycles is diagnosable from instrumentation alone — leaks become *visible* rather than coerced (the HikariCP `leakDetectionThreshold` posture: warn, don't force).

`evict_lru` now iterates all LRU candidates instead of just `excess + 1`. When protected pools prevent reaching `max_total_connections`, it emits `cap_unmet.apartment` with the shortfall — honest about the soft-cap semantics under active workload rather than silently breaching.

### 3. Reaper stopped by default in `Rails.env.test?`

Test suites are short, hold few tenants, have no memory pressure, and are exactly where an eviction mid-example does the most damage. The reaper that `Apartment.configure` starts is more liability than asset in this environment. The Railtie's `after_initialize` now stops it whenever `Rails.env.test?` is true. A suite that genuinely needs eviction can call `Apartment.pool_reaper.start` explicitly — no new configuration knob (YAGNI).

## Notes for adopters

- **The reaper is off in test by default.** If a suite was depending on eviction (uncommon — most test suites don't approach `max_total`), call `Apartment.pool_reaper.start` in `spec_helper.rb` to opt back in.
- **`max_total_connections` is now explicitly a soft cap** under transactional workload. If `cap_unmet.apartment` fires, the same tenants will appear in `skip_evict.apartment` — that's where the leak is.
- **No new config flags.** Existing knobs (`pool_idle_timeout`, `max_total_connections`) are unchanged.

## Test plan

- [x] `bundle exec rspec spec/unit/` — 739 examples, 0 failures, 56 pending (3 new railtie pendings consistent with the file's existing Rails-gated pattern)
- [x] `bundle exec rspec spec/unit/pool_reaper_spec.rb spec/unit/pool_manager_spec.rb` — 26 examples; new in-use guard, `:skip_evict`, and `:cap_unmet` coverage
- [x] `DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/fixture_pin_visibility_spec.rb` — 5 examples, 0 failures (includes the new real-`ConnectionPool` in-use guard test)
- [x] `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/memory_stability_spec.rb spec/integration/v4/stress_spec.rb spec/integration/v4/tenant_lifecycle_spec.rb` — reaper-exercising specs green
- [x] `bundle exec rubocop` — clean on all changed Ruby files

🤖 Generated with [Claude Code](https://claude.com/claude-code)