### PR TITLE
Bump version to 3.4.2

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -164,17 +164,22 @@ module Apartment
   end
 
   # Exceptions
-  ApartmentError = Class.new(StandardError)
+  class ApartmentError < StandardError
+  end
 
   # Raised when apartment cannot find the adapter specified in <tt>config/database.yml</tt>
-  AdapterNotFound = Class.new(ApartmentError)
+  class AdapterNotFound < ApartmentError
+  end
 
   # Raised when apartment cannot find the file to be loaded
-  FileNotFound = Class.new(ApartmentError)
+  class FileNotFound < ApartmentError
+  end
 
   # Tenant specified is unknown
-  TenantNotFound = Class.new(ApartmentError)
+  class TenantNotFound < ApartmentError
+  end
 
   # The Tenant attempting to be created already exists
-  TenantExists = Class.new(ApartmentError)
+  class TenantExists < ApartmentError
+  end
 end

--- a/lib/apartment/active_record/postgresql_adapter.rb
+++ b/lib/apartment/active_record/postgresql_adapter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/ClassAndModuleChildren
+# rubocop:disable Style/ClassAndModuleChildren, Style/OneClassPerFile
 
 # NOTE: This patch is meant to remove any schema_prefix appart from the ones for
 # excluded models. The schema_prefix would be resolved by apartment's setting
@@ -55,4 +55,4 @@ require 'active_record/connection_adapters/postgresql_adapter'
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   include Apartment::PostgreSqlAdapterPatch
 end
-# rubocop:enable Style/ClassAndModuleChildren
+# rubocop:enable Style/ClassAndModuleChildren, Style/OneClassPerFile

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '3.4.1'
+  VERSION = '3.4.2'
 end

--- a/spec/dummy_engine/Rakefile
+++ b/spec/dummy_engine/Rakefile
@@ -3,7 +3,7 @@
 begin
   require('bundler/setup')
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks' # rubocop:disable RSpec/Output
 end
 
 require 'rdoc/task'

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -3,7 +3,6 @@
 module Apartment
   module Spec
     module Setup
-      # rubocop:disable Metrics/AbcSize
       def self.included(base)
         base.instance_eval do
           let(:db1) { Apartment::Test.next_db }
@@ -41,7 +40,6 @@ module Apartment
           end
         end
       end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end


### PR DESCRIPTION
## Summary

- Bumps `Apartment::VERSION` from 3.4.1 to 3.4.2.
- Releases the fix from #397 (silent tenant switch on Rails 8.1's `schema_search_path=` memoization, originally reported in #396).
- Also clears 8 pre-existing rubocop offenses on `3-4-stable` so the lint check goes green; details in commit `dbc0cde`. None of these were introduced by the version bump — `main` had diverged enough that the rubocop workflow's recent runs were only triggering there.

## Release

Merging this PR pushes to `3-4-stable`, which triggers `.github/workflows/gem-publish.yml` (`rubygems/release-gem@v1` → `rake release`). That publishes `ros-apartment-3.4.2` to RubyGems.org and creates the `v3.4.2` git tag.

## Post-merge follow-ups (per RELEASING.md)

- [ ] **Step 5 — Create GitHub Release** at https://github.com/rails-on-services/apartment/releases/new for the `v3.4.2` tag (click "Generate release notes", edit, publish). The workflow only creates the git tag, not the Release entry.
- [ ] **Step 6 — Backport to `main`** by cherry-picking the version bump commit so `main`'s `version.rb` doesn't lag behind `3-4-stable`.

## Test plan

- [x] `lib/apartment/version.rb` change is the only release-relevant content
- [x] `bundle exec rubocop` passes locally on the modified files
- [ ] Post-merge: `gem-publish` workflow run succeeds and `ros-apartment 3.4.2` appears on rubygems.org
- [ ] Post-merge: `v3.4.2` tag is created on `3-4-stable`