### PR TITLE
Guard reset_tenant_pools! against fixture-pinned pool discard

### DIFF
--- a/docs/designs/fixture-pool-lifecycle.md
+++ b/docs/designs/fixture-pool-lifecycle.md
@@ -1,0 +1,123 @@
+# Fixture Pool Lifecycle
+
+Status: living. Last consolidated 2026-05-15 after PR #400, a downstream flake report, and three-CLI review.
+
+## TLDR
+
+Pool-lifecycle APIs invoked while Rails owns a fixture transaction can produce silent test pollution. The reaper variant of this class is closed (#399 pinned guard, #400 in-use guard). One member remains in active investigation (`reset_tenant_pools!` mid-suite); one is suspected but unproven (lazy pool creation after `setup_fixtures` without a prior reset). The plan: one invariant in code, one escape hatch, one integration spec that gates a contingent third fix.
+
+## The invariant
+
+Pool lifecycle changes during fixture-transaction ownership are a violation.
+
+In code form: when Rails' transactional fixtures own one or more pools (detected via the `@pinned_connection` ivar that `ConnectionPool#pin_connection!` sets), no Apartment API should discard or replace those pools. Tests that need to cycle pools opt out of fixture transactions explicitly.
+
+This is the broader rule the in-use guard from #400 specialized for the reaper case. Generalizing it to other lifecycle APIs is the work in scope here.
+
+## Failure class members
+
+| # | Member | Status | Mechanism |
+|---|---|---|---|
+| 1 | Reaper evicts pinned pool | Closed (#399) | `PoolReaper` removed the pool that fixtures had pinned for rollback. |
+| 2 | Reaper evicts pool with in-flight tx | Closed (#400) | `PoolReaper` removed a pool with leased connections or open transactions. |
+| 3 | `reset_tenant_pools!` mid-suite | Open, mechanism inferred | Cleanup hook discards tenant pools; next example's `setup_fixtures` snapshots `connection_pool_list` without them; lazy-recreated pools have new object identity and don't enroll in the fixture tx. |
+| 4 | Lazy create after `setup_fixtures` (no reset) | Suspected, unproven | First `switch(:foo)` in example body materializes a pool post-snapshot. May or may not enroll. The integration spec settles this. |
+| 5 | Non-`:writing` roles / replicas | Suspected | `connection_pool_list` semantics differ in multi-DB / multi-role setups; the invariant must hold per handler, not globally. |
+| 6 | Parallel-example concurrency | Out of scope here | Order-dependent flakes and concurrent flakes are different families; this doc tracks the order-dependent class only. |
+| 7 | `PQTRANS_INERROR` taint after schema mutation | Suspected (downstream evidence) | Downstream consumers have shipped best-effort `ROLLBACK` loops in cross-tenant test cleanup. Existence of the workaround pattern is evidence the variant bites; gem-side coverage deferred. |
+| 8 | Schema cache / prepared-statement drift after tenant DDL | Suspected | Pinned-model joins after DDL in one tenant may resolve against stale caches in another. |
+| 9 | Within-process thread / job boundaries | Suspected | Sidekiq inline, async executors, parallel_tests workers, or app-level threads that `switch` a tenant inside a worker thread may resolve pools differently from the originating thread. Different family from #6 (RSpec parallel examples). |
+
+Members 1 and 2 stay closed. 3 and 4 are the active work. 5–9 are tracked but not in scope this iteration.
+
+## Now (this iteration)
+
+Scope: one PR after the integration spec lands red and turns green.
+
+1. **Integration spec**: `spec/integration/v4/fixture_pool_lifecycle_spec.rb` against the dummy Rails app. Asserts pool object identity (not tenant name) across the reset → recreate boundary; verifies rollback (not just visibility, since a leased connection can pass writes while rollback still fails later); tests the non-reset lazy path as a first-class case to settle the (a′) question below; covers Rails 7.2, 8.0, 8.1 in the existing matrix.
+
+2. **`reset_tenant_pools!` guard**: refuse the call when any pool in `Apartment.pool_manager` carries `@pinned_connection`, raising `Apartment::FixtureLifecycleViolation` (a new subclass of `Apartment::ApartmentError`) with a message naming the offending tenant and pointing at the truncation strategy below. Test-env-scoped via `Rails.env.test?`; production keeps the existing semantics. Detection primitive is the same `@pinned_connection` ivar `pool_pinned?` already reads in `lib/apartment/pool_reaper.rb:164-168` — no new heuristics.
+
+   Contract-locked error text:
+
+   ```
+   Apartment::FixtureLifecycleViolation: reset_tenant_pools! called while pool
+   'acme:writing' is pinned by transactional fixtures. Use
+   Apartment::Test::Truncation for cross-tenant specs that must cycle pools.
+   See docs/designs/fixture-pool-lifecycle.md.
+   ```
+
+3. **`docs/testing.md` invariant section**: opens with the v3→v4 posture (v3's pain was a variable problem — which `search_path` is current; v4's pain is a resource lifecycle problem — does the pool still exist with the object identity fixtures enrolled), then states the rule in one line, then points at this design doc for the failure-class detail. Consumers landing on the constraint without the model can't generalize it to future variants; the framing gives them the model.
+
+4. **Downstream cleanup-pattern deletions**: once #1–3 land, three workaround patterns shipped by downstream consumers become delete-candidates — the `reset_tenant_pools!` call in cross-tenant cleanup, the companion best-effort `ROLLBACK` loop guarding against `PQTRANS_INERROR` taint, and any manual eager-load stubs added to work around the resulting query pollution. The gem-side guard lands here; downstream removals follow on the consumer's own timeline.
+
+   Kept-on-purpose (not in scope for deletion): around-hook helpers like `with_tenants` that consumers wrap test suites in to define a tenant set without cycling pools mid-test. These are consumer ergonomics, not workarounds for gem bugs, and survive the cleanup. Naming the category here prevents a future contributor from re-litigating its existence.
+
+## Eventually (within a month, evidence-gated)
+
+5. **`Apartment::Test::Truncation` strategy** (the escape hatch). Programmatic opt-out from fixture transactions for specs that must cycle pools. Two open shapes:
+   - RSpec metadata flag (`cross_tenant: true`) that flips `use_transactional_fixtures = false` for the marked example and registers a per-example truncation cleaner.
+   - A `helper include Apartment::Test::CrossTenant` that does the same via setup/teardown hooks.
+
+   The shape needs its own design conversation before implementation — flipping `use_transactional_fixtures` per-example touches Rails internals that may shift across versions. Treat #5 as design-then-build, not build-then-document.
+
+6. **`Apartment::Tenant.preload_test_pools!`** (the contingent fix). Opt-in helper that walks `tenants_provider` and materializes pools before the first `setup_fixtures` runs. Only built if step #1 proves the non-reset lazy path is broken on its own (i.e., step 4 of the integration spec lands red). If the lazy path enrolls correctly, this is YAGNI and stays unbuilt.
+
+   The helper is opt-in only: auto-invoke from the railtie is rejected (see Never #2).
+
+7. **Multi-handler / multi-role variants of the integration spec**. Parametrize over `:writing` and `:reading` roles once the dummy app supports replicas. Deferred until reading replicas are exercised in the main matrix — not blocking #1–4.
+
+## Never
+
+These are explicit rejections, with the reason recorded so they don't get re-litigated.
+
+1. **Re-enroll lazy pools at switch time** (the original (a) shape). Hooking AR's `TestFixtures` rollback path symmetrically to enroll pools created mid-test fights AR internals that aren't designed for dynamic mid-transaction pool registration. Race-prone, version-fragile, and the same correctness budget buys #6 (`preload_test_pools!`) more cleanly.
+
+2. **Auto-invoke `preload_test_pools!` from the railtie**. `tenants_provider` may DB-query at boot, or reference tenants that don't yet exist. Opt-in is the contract; the gem doesn't decide preload semantics for the consumer.
+
+3. **Bypass fixture transactions on the gem's side without explicit user opt-in**. Test isolation strategy belongs to the consumer; the gem refuses to silently change it. The truncation strategy (#5) requires explicit metadata or include.
+
+4. **Patch `connection_pool_list` to dynamically include lazy pools**. AR's snapshot semantics are deliberate; subverting them at the consumer's expense breaks isolation contracts elsewhere (savepoint enrollment, role resolution, role-specific pool lookup). #6 achieves the right outcome at fixture-setup time without monkey-patching AR.
+
+5. **Test-mode `SET search_path` switching** (rejected previously in `v4-test-fixtures-compatibility.md`). Re-introduces the runtime search_path mutation v4 eliminated; undermines pool-per-tenant as the production code path.
+
+## Wishlist (>1 month, deferred)
+
+Items the broader-class observation surfaced but that need their own design conversations before they enter a roadmap.
+
+- **Parallel-spec safety hardening**. Order-dependent flakes (this doc) and concurrent flakes are different families. Process-scoping the `reset_tenant_pools!` guard is one piece; broader concurrent-fixture-tx semantics is its own investigation.
+- **`PQTRANS_INERROR` recovery hooks**. The downstream `ROLLBACK` loop is evidence the variant exists. Gem-side coverage would mean an instrumented detection + recovery path, probably in `Apartment::Tenant.switch`'s ensure block. Real but lower priority than #1–6.
+- **Schema cache invalidation on tenant DDL**. Pinned-model joins after one tenant's DDL may resolve against stale caches. Needs adapter-specific design (PG vs MySQL diverge on cache invalidation primitives).
+- **Adapter-specific savepoint behavior**. PG schema adapter under `pin_connection!` with DDL inside a tenant tx may detach the savepoint stack. Sanity check inside the integration spec is in scope (#1); deeper coverage is wishlist.
+- **`with_tenants_provider`-style scoped overrides for test fixtures**. Currently tracked in `docs/plans/with-tenants-provider/`. Adjacent but separate work.
+
+## Decisions and probabilities
+
+Aggregate after three-CLI review (cursor / codex / gemini) and downstream agreement:
+
+- 0.45 — Ship #1 (integration spec), #2 (`reset_tenant_pools!` guard), #3 (docs invariant) now; #5 and #6 follow, with #6 gated on what #1 finds.
+- 0.37 — Same as above but ship #6 (`preload_test_pools!`) together with #2 without waiting on evidence. Justified if cost of waiting is high and one round-trip is preferred. Both cursor and codex flagged that "working multi-tenant suites" is weak evidence for #6 being unnecessary — preload patterns and accidental ordering can paper over the lazy-without-reset path.
+- 0.18 — Anything that makes #2 optional. Including the original "(a′) + (c) with (b) as supporting guardrail" lean. Rejected on grounds that the invariant being optional defeats the framing.
+
+Cross-CLI convergence on the YAGNI softening for #6 nudged the 0.45 path down from an initial 0.50 and lifted 0.37 from 0.32: two independent reviewers flagging the same risk is stronger signal than the original lean, and the bias-correction toward "do the cheap additive fix" deserves real weight. 0.45 is still preferred for evidence discipline, but the gap is narrower than the first cut suggested.
+
+## Detection primitives
+
+Where the invariant lives in code:
+
+- `ConnectionPool#pin_connection!` (Rails 7.1+) sets `@pinned_connection`. Apartment reads this ivar in `lib/apartment/pool_reaper.rb:164-168` via `pool_pinned?`. The `reset_tenant_pools!` guard (#2) reuses the same primitive; no new heuristics.
+- `ConnectionPool#in_use?` and `Connection#open_transactions` (public API). Reaper already uses these for the in-use guard (`pool_in_use?` at `lib/apartment/pool_reaper.rb:175-182`). Available for any future lifecycle guard.
+- `ActiveRecord::Base.connection_handler.connection_pool_list(:all)` — snapshot consumed by fixture machinery. Read-only from Apartment's side; do not mutate.
+
+Across Rails 7.2 / 8.0 / 8.1 the `@pinned_connection` semantics are stable. 8.x+ may rename or refactor; the integration spec covers all matrix versions, and any divergence surfaces there.
+
+## Cross-references
+
+- `docs/designs/v4-test-fixtures-compatibility.md` — the `setup_shared_connection_pool` patch (PRs #379, #380). This doc generalizes that work to other lifecycle APIs.
+- `docs/testing.md` — consumer-facing summary of the invariant and the available test helpers. Updated as part of #3.
+- `lib/apartment/pool_reaper.rb` — existing pinned and in-use guards (PRs #399, #400). The `reset_tenant_pools!` guard reuses the same detection primitives.
+- `docs/plans/with-tenants-provider/` — adjacent test-fixtures work tracked separately.
+
+## Origin
+
+PR #400 closed the reaper variant of the failure class. A downstream consumer bumped to `a89aa0b` and reported a remaining order-dependent flake, bisected to a `reset_tenant_pools!` call in a `cross_tenant` shared context. Three-CLI consultation (cursor, codex, gemini) converged on (b) as the load-bearing invariant and on (a′) as evidence-gated, with several additions absorbed into the inventory above.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -167,6 +167,34 @@ end
 
 ## Pool lifecycle in tests
 
+### The invariant
+
+v3's test-suite pain was a **variable problem**: at any given moment, which `search_path` is current? Tests that crossed tenants had to reason about an in-flight setting and reset it carefully. v4 swapped that for a **resource lifecycle problem**: does the connection pool that fixtures enrolled for rollback still exist with the same object identity? Rails' transactional fixtures pin pools by object reference (`ConnectionPool#pin_connection!`) and unwind them by walking that same reference at teardown. Discard a pinned pool mid-suite and the recreated one has a fresh `object_id`; the fixture transaction never enrolled it; rollback misses its writes.
+
+The rule, in one line: **pool lifecycle changes during fixture-transaction ownership are a violation.** Any Apartment API that discards or replaces a pool must refuse to do so while Rails owns it. `Apartment::PoolReaper` already implements this for eviction (see the reaper subsection below); `Apartment.reset_tenant_pools!` extends it to the explicit-reset path.
+
+The failure-class inventory, rejected alternatives, and ongoing investigation live in `docs/designs/fixture-pool-lifecycle.md`.
+
+### `Apartment.reset_tenant_pools!` in test env
+
+In `Rails.env.test?`, `Apartment.reset_tenant_pools!` raises `Apartment::FixtureLifecycleViolation` when any tenant pool in `Apartment.pool_manager` is currently pinned by fixtures. Outside test env, semantics are unchanged.
+
+```text
+Apartment::FixtureLifecycleViolation: reset_tenant_pools! called while pool
+'acme:writing' is pinned by transactional fixtures. Use Apartment::Test::Truncation
+for cross-tenant specs that must cycle pools. See docs/designs/fixture-pool-lifecycle.md.
+```
+
+The guard fires when a tenant pool already exists in the pool manager AND has been pinned. The common bootstrap path — `Apartment::TestFixtures` calling `reset_tenant_pools!` before `setup_shared_connection_pool` runs, no tenant pools tracked yet — is unaffected. If you hit the violation, the call is happening at the wrong time, not from the wrong place.
+
+What to do instead, depending on the call site:
+
+- **Cleanup hook in a cross-tenant spec** (the most common cause): the spec needs to cycle pools mid-suite. Switch off transactional fixtures for that example or context and use a deletion/truncation strategy (`DatabaseCleaner.strategy = :deletion`). Programmatic opt-out via `Apartment::Test::Truncation` is on the roadmap (`docs/designs/fixture-pool-lifecycle.md` member #5).
+- **Suite bootstrap or teardown**: move the call out of any `before(:each)` / `after(:each)` that runs under transactional fixtures. `before(:suite)` and `after(:suite)` are safe; `before(:all)` and `after(:all)` are safe if `use_transactional_tests` is the default (Rails enrols the fixture tx per-example, not per-group).
+- **Production cleanup script that imports Rails**: not a real call site, but if it shows up, ensure the script runs outside `Rails.env.test?` or call the pool-manager's `clear` directly.
+
+### Pool reaper
+
 `Apartment::PoolReaper` evicts idle and excess tenant pools on a background timer. In production it bounds memory under high tenant counts; in test suites it's typically a liability — short runs, few tenants, no memory pressure, and an eviction mid-example can orphan transactional-fixture state. **The Railtie stops the reaper automatically when `Rails.env.test?`.** A suite that genuinely needs eviction (long-running parallel tenant churn, large fixtures) can opt back in:
 
 ```ruby

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -207,6 +207,7 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     # @return [void]
     # @see Apartment::TestFixtures
     def reset_tenant_pools!
+      guard_pinned_pools_during_fixtures!
       deregister_all_tenant_pools
       @pool_manager&.clear
       Apartment::Current.reset
@@ -226,6 +227,30 @@ module Apartment # rubocop:disable Metrics/ModuleLength
       deregister_all_tenant_pools
       @pool_manager&.clear
       @adapter = nil
+    end
+
+    # Refuse to discard tenant pools while Rails' transactional fixtures own
+    # them. The recreated pool would have a fresh object identity that the
+    # fixture transaction never enrolled, causing silent test pollution.
+    # Test-env-scoped via +Rails.env.test?+ so production keeps the existing
+    # semantics; reuses the same +@pinned_connection+ primitive the reaper
+    # already reads. See docs/designs/fixture-pool-lifecycle.md.
+    def guard_pinned_pools_during_fixtures!
+      return unless rails_test_env?
+      return unless @pool_manager
+
+      @pool_manager.each_pair do |tenant_key, pool|
+        next unless Apartment::PoolReaper.pool_pinned?(pool)
+
+        raise(Apartment::FixtureLifecycleViolation, tenant_key)
+      end
+    end
+
+    def rails_test_env?
+      return false unless defined?(Rails) && Rails.respond_to?(:env)
+
+      env = Rails.env
+      env.respond_to?(:test?) ? env.test? : env.to_s == 'test'
     end
 
     def deregister_all_tenant_pools

--- a/lib/apartment/errors.rb
+++ b/lib/apartment/errors.rb
@@ -36,6 +36,33 @@ module Apartment
   # Raised when schema loading fails during tenant creation.
   class SchemaLoadError < ApartmentError; end
 
+  # Raised when a pool-lifecycle API (e.g. {Apartment.reset_tenant_pools!})
+  # is invoked while Rails' transactional fixtures own one or more tenant
+  # pools. Discarding a pinned pool mid-fixture-tx leaves the next example's
+  # fixture-setup snapshot without those pools; the recreated pool has a
+  # fresh object identity that never enrols in the rollback. Test-env-scoped
+  # — production callers are unaffected.
+  #
+  # See docs/designs/fixture-pool-lifecycle.md.
+  class FixtureLifecycleViolation < ApartmentError
+    attr_reader :pool_key
+
+    def initialize(pool_key = nil, message: nil)
+      @pool_key = pool_key
+      super(message || default_message)
+    end
+
+    private
+
+    def default_message
+      pool_clause = @pool_key ? "pool '#{@pool_key}'" : 'a tenant pool'
+      "reset_tenant_pools! called while #{pool_clause} is pinned by " \
+        'transactional fixtures. Use Apartment::Test::Truncation for ' \
+        'cross-tenant specs that must cycle pools. ' \
+        'See docs/designs/fixture-pool-lifecycle.md.'
+    end
+  end
+
   # Raised in development when a tenant has pending migrations.
   class PendingMigrationError < ApartmentError
     attr_reader :tenant

--- a/lib/apartment/pool_manager.rb
+++ b/lib/apartment/pool_manager.rb
@@ -96,6 +96,14 @@ module Apartment
       }
     end
 
+    # Yields each tracked pool as +[tenant_key, pool]+. Snapshot semantics
+    # follow Concurrent::Map#each_pair: keys observed during iteration are
+    # those present at the time the iterator visits them. Read-only; do not
+    # mutate the manager from inside the block.
+    def each_pair(&)
+      @pools.each_pair(&)
+    end
+
     # Disconnect all pools before clearing to prevent connection leaks.
     # Each pool's disconnect! is individually rescued so one broken pool
     # doesn't prevent cleanup of others.

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -8,6 +8,21 @@ module Apartment
   # Complementary to ActiveRecord's ConnectionPool::Reaper which handles
   # intra-pool connection reaping — this handles inter-pool (tenant) eviction.
   class PoolReaper
+    # True when Rails' transactional-fixture machinery has pinned the pool
+    # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting or discarding a
+    # pinned pool strands the fixture transaction; teardown then errors or
+    # marks the DB dirty. ActiveRecord exposes no public predicate, so we
+    # read the ivar it sets. TOCTOU caveat applies — see docs/testing.md
+    # "Pool lifecycle in tests".
+    #
+    # Exposed as a class method so {Apartment.reset_tenant_pools!} can reuse
+    # the same primitive without instantiating a reaper.
+    def self.pool_pinned?(pool)
+      return false unless pool&.instance_variable_defined?(:@pinned_connection)
+
+      !pool.instance_variable_get(:@pinned_connection).nil?
+    end
+
     def initialize(pool_manager:, interval:, idle_timeout:, max_total: nil,
                    default_tenant: nil, shard_key_prefix: nil, on_evict: nil)
       raise(ArgumentError, 'interval must be a positive number') unless interval.is_a?(Numeric) && interval.positive?
@@ -156,15 +171,10 @@ module Apartment
       false
     end
 
-    # True when Rails' transactional-fixture machinery has pinned the pool
-    # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting a pinned pool
-    # strands the fixture transaction; teardown then errors or marks the DB
-    # dirty. AR exposes no public predicate, so we read the ivar it sets.
-    # TOCTOU caveat applies — see docs/testing.md "Pool lifecycle in tests".
+    # Instance-side wrapper around the class predicate; kept for callers
+    # (and specs) that already hold a reaper instance.
     def pool_pinned?(pool)
-      return false unless pool&.instance_variable_defined?(:@pinned_connection)
-
-      !pool.instance_variable_get(:@pinned_connection).nil?
+      self.class.pool_pinned?(pool)
     end
 
     # True when at least one connection is leased or holds an open

--- a/spec/integration/v4/fixture_pool_lifecycle_spec.rb
+++ b/spec/integration/v4/fixture_pool_lifecycle_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+require 'active_support/string_inquirer'
+require 'apartment/test_fixtures'
+
+# The guard under test (`reset_tenant_pools!`) checks `Rails.env.test?`. The
+# integration env loads ActiveRecord without the Rails framework, so stub a
+# minimal Rails returning a StringInquirer to honour `.test?`. Examples that
+# need to simulate non-test env override this per-example via `allow(Rails)`.
+unless defined?(Rails)
+  module Rails
+    def self.env
+      ActiveSupport::StringInquirer.new('test')
+    end
+  end
+end
+
+# Integration coverage for the fixture pool lifecycle failure class.
+#
+# Design: docs/designs/fixture-pool-lifecycle.md (member #3).
+#
+# The invariant: pool lifecycle changes during fixture-transaction ownership
+# are a violation. `reset_tenant_pools!` invoked mid-suite discards pools that
+# Rails' transactional fixtures pinned for rollback; the next example's
+# `setup_fixtures` snapshots `connection_pool_list` without them, and any
+# lazy-recreated pool has fresh object identity that never enrolls in the
+# fixture transaction.
+#
+# Five examples:
+#   1. The guard raises `Apartment::FixtureLifecycleViolation` when a tenant
+#      pool carries `@pinned_connection`.
+#   2. The violation message names the offending tenant pool and redirects to
+#      the truncation strategy (contract-locked text).
+#   3. Negative case: with no pinned pools, the call passes (the guard must
+#      not over-trigger and break suite bootstrapping — `Apartment::TestFixtures`
+#      itself invokes `reset_tenant_pools!` before `setup_shared_connection_pool`
+#      pins primary).
+#   4. Mechanism documentation: with the test-env guard bypassed, mid-tx
+#      reset discards the pinned pool and the recreated pool has a fresh
+#      object identity. Asserts pool object identity (not tenant name) — the
+#      thing fixtures actually enroll for rollback.
+#   5. The (a′) tiebreaker: does a tenant pool created lazily inside an
+#      example (no prior reset) enroll in the fixture rollback? Asserts
+#      rollback, not visibility — a leased connection can pass in-example
+#      writes while teardown's rollback still misses them. Outcome determines
+#      whether design member #6 (`preload_test_pools!`) ships.
+#
+# Covers Rails 7.2 / 8.0 / 8.1 via the existing appraisal matrix.
+# :schema strategy is PG-only; `pin_connection!` semantics are crispest there.
+RSpec.describe('v4 fixture pool lifecycle guards', :integration, # rubocop:disable RSpec/MultipleMemoizedHelpers
+               skip: (V4_INTEGRATION_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires PostgreSQL')) do
+  include V4IntegrationHelper
+
+  # Drives the real Rails transactional-fixture lifecycle (the same
+  # `setup_fixtures` / `teardown_fixtures` machinery rspec-rails invokes
+  # around every example when `use_transactional_tests` is true).
+  # `Apartment::TestFixtures` is prepended exactly as the v4 Railtie wires it
+  # in a host application.
+  if V4_INTEGRATION_AVAILABLE
+    class FixtureLifecycleGuardHost
+      include ActiveRecord::TestFixtures
+      prepend Apartment::TestFixtures
+
+      def initialize
+        @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+      end
+
+      # `false` keeps transactional fixtures (and the pinning subscriber) ON.
+      def self.uses_transaction?(_name) = false
+      def name = 'fixture_pool_lifecycle_host'
+
+      # Mirrors the rspec-rails example wrapper: setup -> body -> teardown.
+      def run_example
+        setup_fixtures
+        yield
+      ensure
+        teardown_fixtures
+      end
+    end
+  end
+
+  let(:tmp_dir)      { Dir.mktmpdir('apartment_fixture_lifecycle') }
+  let(:rand_suffix)  { SecureRandom.hex(4) }
+  let(:tenants)      { ["acme_#{rand_suffix}", "globex_#{rand_suffix}"] }
+  let(:write_tenant) { tenants.first }
+  let(:table_name)   { "widgets_#{rand_suffix}" }
+  let(:widget_class) do
+    klass = Class.new(ActiveRecord::Base)
+    klass.table_name = table_name
+    stub_const('Widget', klass)
+    klass
+  end
+
+  before do
+    V4IntegrationHelper.ensure_test_database!
+    config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+    ActiveRecord::Base.connection.execute('CREATE SCHEMA IF NOT EXISTS extensions')
+
+    Apartment.configure do |c|
+      c.tenant_strategy   = :schema
+      c.tenants_provider  = -> { tenants }
+      c.default_tenant    = 'public'
+      c.check_pending_migrations = false
+      c.configure_postgres { |pg| pg.persistent_schemas = ['extensions'] }
+    end
+    Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+    Apartment.activate!
+
+    tenants.each do |name|
+      Apartment.adapter.create(name)
+      Apartment::Tenant.switch(name) do
+        V4IntegrationHelper.create_test_table!(table_name)
+      end
+    end
+
+    # Bring each example to the baseline a real suite starts from: tenant
+    # schemas exist, tenant pools do not. `setup_shared_connection_pool` will
+    # then pin only `primary`; the first in-example switch is what
+    # lazily (re-)creates a tenant pool.
+    Apartment.reset_tenant_pools!
+  end
+
+  after do
+    ActiveRecord::Base.connection.execute('DROP SCHEMA IF EXISTS extensions CASCADE')
+  ensure
+    V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter)
+    Apartment.clear_config
+    Apartment::Current.reset
+  end
+
+  it 'raises Apartment::FixtureLifecycleViolation when a tenant pool is pinned by fixtures' do
+    widget_class
+
+    expect do
+      FixtureLifecycleGuardHost.new.run_example do
+        Apartment::Tenant.switch(write_tenant) { Widget.create! }
+        expect(Apartment.pool_manager.peek("#{write_tenant}:writing")).not_to(be_nil)
+
+        Apartment.reset_tenant_pools!
+      end
+    end.to(raise_error(Apartment::FixtureLifecycleViolation))
+  end
+
+  it 'violation message names the offending tenant pool and redirects to the truncation strategy doc' do
+    widget_class
+
+    message = nil
+    begin
+      FixtureLifecycleGuardHost.new.run_example do
+        Apartment::Tenant.switch(write_tenant) { Widget.create! }
+        Apartment.reset_tenant_pools!
+      end
+    rescue Apartment::FixtureLifecycleViolation => e
+      message = e.message
+    end
+
+    expect(message).not_to(be_nil)
+    expect(message).to(include("#{write_tenant}:writing"))
+    expect(message).to(include('transactional fixtures'))
+    expect(message).to(include('Apartment::Test::Truncation'))
+    expect(message).to(include('docs/designs/fixture-pool-lifecycle.md'))
+  end
+
+  it 'is allowed outside fixture-transaction ownership (negative case)' do
+    # No pool carries `@pinned_connection` here. The guard must let the call
+    # through; over-broad guarding would break suite bootstrap (Apartment's
+    # own `TestFixtures` patch invokes `reset_tenant_pools!` *before*
+    # `setup_shared_connection_pool` pins primary).
+    widget_class
+    Apartment::Tenant.switch(write_tenant) { Widget.create! }
+    expect(Apartment.pool_manager.peek("#{write_tenant}:writing")).not_to(be_nil)
+
+    expect { Apartment.reset_tenant_pools! }.not_to(raise_error)
+    expect(Apartment.pool_manager.peek("#{write_tenant}:writing")).to(be_nil)
+  end
+
+  it 'mid-tx reset discards the pinned pool: the recreated pool has fresh object identity' do
+    # The mechanism the guard prevents. With the test-env guard bypassed
+    # (`Rails.env.test?` → false), reset proceeds and the rebuilt pool's
+    # `object_id` differs from the one fixtures pinned — pool identity, not
+    # tenant name, is what fixture rollback enrols.
+    widget_class
+
+    FixtureLifecycleGuardHost.new.run_example do
+      Apartment::Tenant.switch(write_tenant) { Widget.create! }
+      pool_before = Apartment.pool_manager.peek("#{write_tenant}:writing")
+
+      # Simulate the production path the guard does not enforce.
+      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('development')))
+      Apartment.reset_tenant_pools!
+
+      Apartment::Tenant.switch(write_tenant) { Widget.create! }
+      pool_after = Apartment.pool_manager.peek("#{write_tenant}:writing")
+
+      expect(pool_after).not_to(be(pool_before))
+      expect(pool_after.object_id).not_to(eq(pool_before.object_id))
+    end
+  end
+
+  it 'rolls back rows written via lazy pool creation in the non-reset path (a′ tiebreaker)' do
+    # The (a′) question (design member #4, settles #6): `setup_fixtures` runs
+    # first with no tenant pool, the example then switches to the tenant for
+    # the first time and writes. Does the lazily-created pool enroll in the
+    # fixture transaction so teardown rolls the row back?
+    #
+    # If GREEN: lazy enrollment works; `preload_test_pools!` is YAGNI.
+    # If RED:   ship design member #6 to materialise pools pre-snapshot.
+    #
+    # Asserting rollback (not visibility): a leased connection can return
+    # in-example writes via the same handle while teardown's enrollment
+    # walk still misses the pool — fixture_pin_visibility_spec covers
+    # visibility; rollback is the untested half.
+    widget_class
+
+    FixtureLifecycleGuardHost.new.run_example do
+      Apartment::Tenant.switch(write_tenant) { Widget.create! }
+    end
+
+    post_rollback_count = nil
+    Apartment::Tenant.switch(write_tenant) { post_rollback_count = Widget.count }
+
+    expect(post_rollback_count).to(eq(0))
+  end
+end

--- a/spec/integration/v4/fixture_pool_lifecycle_spec.rb
+++ b/spec/integration/v4/fixture_pool_lifecycle_spec.rb
@@ -2,20 +2,7 @@
 
 require 'spec_helper'
 require_relative 'support'
-require 'active_support/string_inquirer'
 require 'apartment/test_fixtures'
-
-# The guard under test (`reset_tenant_pools!`) checks `Rails.env.test?`. The
-# integration env loads ActiveRecord without the Rails framework, so stub a
-# minimal Rails returning a StringInquirer to honour `.test?`. Examples that
-# need to simulate non-test env override this per-example via `allow(Rails)`.
-unless defined?(Rails)
-  module Rails
-    def self.env
-      ActiveSupport::StringInquirer.new('test')
-    end
-  end
-end
 
 # Integration coverage for the fixture pool lifecycle failure class.
 #

--- a/spec/integration/v4/mysql_spec.rb
+++ b/spec/integration/v4/mysql_spec.rb
@@ -3,14 +3,6 @@
 require 'spec_helper'
 require_relative 'support'
 
-unless defined?(Rails)
-  module Rails
-    def self.env
-      'test'
-    end
-  end
-end
-
 RSpec.describe('v4 MySQL integration', :integration,
                skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
   include V4IntegrationHelper

--- a/spec/integration/v4/postgresql_database_rbac_spec.rb
+++ b/spec/integration/v4/postgresql_database_rbac_spec.rb
@@ -4,14 +4,6 @@ require 'spec_helper'
 require_relative 'support'
 require_relative 'support/rbac_helper'
 
-unless defined?(Rails)
-  module Rails
-    def self.env
-      'test'
-    end
-  end
-end
-
 RSpec.describe('PostgreSQL database-per-tenant callable app_role', :integration, :postgresql_only, :rbac,
                skip: (V4_INTEGRATION_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires PG')) do
   include V4IntegrationHelper

--- a/spec/integration/v4/postgresql_database_spec.rb
+++ b/spec/integration/v4/postgresql_database_spec.rb
@@ -3,14 +3,6 @@
 require 'spec_helper'
 require_relative 'support'
 
-unless defined?(Rails)
-  module Rails
-    def self.env
-      'test'
-    end
-  end
-end
-
 RSpec.describe('v4 PostgreSQL database-per-tenant integration', :integration,
                skip: (V4_INTEGRATION_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires PostgreSQL')) do
   include V4IntegrationHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ rescue LoadError
 end
 
 require 'apartment'
+require_relative 'support/rails_stub'
 
 RSpec.configure do |config|
   config.after do

--- a/spec/support/rails_stub.rb
+++ b/spec/support/rails_stub.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'active_support/string_inquirer'
+require 'pathname'
+
+# Minimal Rails stub for specs that load ActiveRecord without booting the
+# Rails framework (the dummy app in spec/dummy/ remains the path for specs
+# that need a real Rails — see spec/integration/v4/request_lifecycle_spec.rb).
+#
+# `Rails.env` returns an `ActiveSupport::StringInquirer` so `.test?` and the
+# string-comparison form (`Rails.env == 'test'`) both work. `Rails.root` is
+# provided for adapter specs that resolve schema-file paths against it.
+#
+# Specs that need to simulate a different env override per-example via
+# `allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('...')))`.
+#
+# `unless defined?(Rails)` keeps the stub out of the way when a spec
+# subsequently loads the dummy app — the real Rails framework re-opens the
+# module and its own singleton methods replace these.
+unless defined?(Rails)
+  module Rails
+    def self.env
+      ActiveSupport::StringInquirer.new('test')
+    end
+
+    def self.root
+      Pathname.new('/rails/app')
+    end
+  end
+end

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -30,19 +30,6 @@ class TestAdapter < Apartment::Adapters::AbstractAdapter
   end
 end
 
-# Minimal Rails stub for environmentify tests.
-unless defined?(Rails)
-  module Rails
-    def self.env
-      'test'
-    end
-
-    def self.root
-      Pathname.new('/rails/app')
-    end
-  end
-end
-
 # Minimal ActiveRecord stub for migrate tests.
 unless defined?(ActiveRecord::Base)
   module ActiveRecord

--- a/spec/unit/adapters/mysql2_adapter_spec.rb
+++ b/spec/unit/adapters/mysql2_adapter_spec.rb
@@ -15,15 +15,6 @@ unless defined?(ActiveRecord::Base)
   end
 end
 
-# Minimal Rails stub for environmentify tests.
-unless defined?(Rails)
-  module Rails
-    def self.env
-      'test'
-    end
-  end
-end
-
 # Shared examples for MySQL-family adapters (MySQL2 and Trilogy share identical behavior).
 RSpec.shared_examples('a MySQL adapter') do
   let(:connection_config) { { adapter: adapter_name, host: 'localhost', database: 'myapp' } }

--- a/spec/unit/adapters/postgresql_database_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_database_adapter_spec.rb
@@ -14,15 +14,6 @@ unless defined?(ActiveRecord::Base)
   end
 end
 
-# Minimal Rails stub for environmentify tests.
-unless defined?(Rails)
-  module Rails
-    def self.env
-      'test'
-    end
-  end
-end
-
 RSpec.describe(Apartment::Adapters::PostgresqlDatabaseAdapter) do
   let(:connection_config) { { adapter: 'postgresql', host: 'localhost', database: 'myapp' } }
   let(:adapter) { described_class.new(connection_config) }

--- a/spec/unit/adapters/sqlite3_adapter_spec.rb
+++ b/spec/unit/adapters/sqlite3_adapter_spec.rb
@@ -3,15 +3,6 @@
 require 'spec_helper'
 require_relative '../../../lib/apartment/adapters/sqlite3_adapter'
 
-# Minimal Rails stub for environmentify tests.
-unless defined?(Rails)
-  module Rails
-    def self.env
-      'test'
-    end
-  end
-end
-
 RSpec.describe(Apartment::Adapters::Sqlite3Adapter) do
   let(:connection_config) { { adapter: 'sqlite3', database: 'db/myapp.sqlite3' } }
   let(:adapter) { described_class.new(connection_config) }


### PR DESCRIPTION
## Summary

Closes failure-class member #3 in `docs/designs/fixture-pool-lifecycle.md` (the `reset_tenant_pools!`-mid-fixture-tx variant; reaper variants #1+#2 shipped in #399 + #400).

In `Rails.env.test?`, `Apartment.reset_tenant_pools!` now raises `Apartment::FixtureLifecycleViolation` when any tenant pool tracked by `Apartment.pool_manager` carries `@pinned_connection`. Without the guard, discarding a pinned pool mid-fixture-tx and recreating it on the next switch hands fixtures a pool with fresh object identity that never enrols in the rollback — silent test pollution at teardown. Production semantics are unchanged.

## What's in the PR (3 commits)

1. **Integration spec** (`spec/integration/v4/fixture_pool_lifecycle_spec.rb`): 5 examples driving real Rails `setup_fixtures` / `teardown_fixtures` against `Apartment::TestFixtures`. Locks the guard's contract (typed raise + message text) and settles the **(a′) tiebreaker**: lazy pool creation in the non-reset path enrols in the fixture rollback across Rails 7.2 / 8.0 / 8.1 on PostgreSQL — design member #6 (`preload_test_pools!`) stays unbuilt.
2. **Test-helper dedup** (`spec/support/rails_stub.rb` + auto-load from `spec_helper`): 8 spec files were each carrying a near-identical `unless defined?(Rails); module Rails; def self.env; 'test'; end; end; end` block. Extracted to one shared helper that returns `ActiveSupport::StringInquirer('test')` (so `.test?` and string-compare both work) and `Pathname` `root`. `tenant_tagged_logging_spec.rb` keeps its inline `stub_const` shape (per-example logger reassignment, not a static stub).
3. **Guard + error class + docs**:
   - `Apartment::FixtureLifecycleViolation < ApartmentError` with a `pool_key` reader and the locked-text default message.
   - `Apartment::PoolReaper.pool_pinned?(pool)` promoted to a public class method; the existing private instance method becomes a 1-line delegator so existing callers (and `reaper.send(:pool_pinned?, …)` in `fixture_pin_visibility_spec`) keep working.
   - `Apartment::PoolManager#each_pair(&)` exposes the minimum read-only iteration the guard needs.
   - `Apartment.reset_tenant_pools!` runs `guard_pinned_pools_during_fixtures!` before any state change; `rails_test_env?` handles `defined?(Rails)` and `Rails.env.respond_to?(:test?)` so the guard is a no-op without Rails or outside test env.
   - `docs/testing.md` adds the v3→v4 posture (variable problem vs resource lifecycle problem), states the invariant in one line, documents the typed raise + remediation guidance, and points at the design doc for the failure-class detail.

`Apartment::TestFixtures`' bootstrap call is unaffected: it runs before `setup_shared_connection_pool` pins anything, so the pool manager has nothing to refuse. The guard fires only when a tenant pool already exists and has been pinned.

## Locked error contract

```
Apartment::FixtureLifecycleViolation: reset_tenant_pools! called while pool
'acme:writing' is pinned by transactional fixtures. Use Apartment::Test::Truncation
for cross-tenant specs that must cycle pools. See docs/designs/fixture-pool-lifecycle.md.
```

The integration spec asserts message substrings (offender pool key, `transactional fixtures`, `Apartment::Test::Truncation`, design-doc path) rather than exact equality.

## Test plan

- [x] Rails 7.2 / 8.0 / 8.1 + PostgreSQL — `fixture_pool_lifecycle_spec` 5/5 GREEN
- [x] Rails 7.2 / 8.0 / 8.1 + PostgreSQL — sibling `fixture_pin_visibility_spec` 5/5 GREEN (exercises the `pool_pinned?` instance delegator)
- [x] Unit suite — 740 examples, 0 failures (no regressions from the `pool_pinned?` promotion or the helper dedup)
- [x] Rubocop clean

## Out of scope (deferred per the design doc)

- Design member #5 — `Apartment::Test::Truncation` programmatic opt-out. Needs its own design conversation before implementation; tracked in the design doc.
- Design member #6 — `preload_test_pools!`. Settled YAGNI by the (a′) result above; will land only if a future Rails version flips the lazy-enrollment behavior.
- Members 5–9 in the failure-class inventory (multi-handler/multi-role, parallel-spec, `PQTRANS_INERROR` recovery, schema-cache invalidation, thread/job boundaries).

## Design reference

`docs/designs/fixture-pool-lifecycle.md` — failure-class inventory, invariant, rejected alternatives, three-CLI probability allocation, and the (a′) tiebreaker outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)