### PR TITLE
Document pool-cycling escape hatch; drop unshipped Truncation module reference

### DIFF
--- a/docs/designs/fixture-pool-lifecycle.md
+++ b/docs/designs/fixture-pool-lifecycle.md
@@ -1,10 +1,10 @@
 # Fixture Pool Lifecycle
 
-Status: living. Last consolidated 2026-05-15 after PR #400, a downstream flake report, and three-CLI review.
+Status: living. Last consolidated 2026-05-19 after PRs #399, #400, and #403 (which squashed the `reset_tenant_pools!` guard, the integration spec, and the docs invariant section onto `main` as `abcf755`).
 
 ## TLDR
 
-Pool-lifecycle APIs invoked while Rails owns a fixture transaction can produce silent test pollution. The reaper variant of this class is closed (#399 pinned guard, #400 in-use guard). One member remains in active investigation (`reset_tenant_pools!` mid-suite); one is suspected but unproven (lazy pool creation after `setup_fixtures` without a prior reset). The plan: one invariant in code, one escape hatch, one integration spec that gates a contingent third fix.
+Pool-lifecycle APIs invoked while Rails owns a fixture transaction can produce silent test pollution. Members 1–4 of the failure class are closed: the reaper guards (#399 pinned, #400 in-use), the `reset_tenant_pools!` guard (`abcf755`), and the (a′) lazy-enrollment probe — the integration spec is green on Rails 7.2 / 8.0 / 8.1 + PG, re-verified 2026-05-19. The contingent `preload_test_pools!` helper retires as YAGNI on the same evidence. The escape-hatch piece (originally "`Apartment::Test::Truncation`") closes as docs-only: a three-CLI panel + guard-scope verification settled that `use_transactional_tests = false` is the Rails-native opt-out, and the existing guard already scopes to tenant pools. The recipe lives in [`docs/testing.md` § Cycling pools mid-suite](../testing.md#cycling-pools-mid-suite).
 
 ## The invariant
 
@@ -20,86 +20,76 @@ This is the broader rule the in-use guard from #400 specialized for the reaper c
 |---|---|---|---|
 | 1 | Reaper evicts pinned pool | Closed (#399) | `PoolReaper` removed the pool that fixtures had pinned for rollback. |
 | 2 | Reaper evicts pool with in-flight tx | Closed (#400) | `PoolReaper` removed a pool with leased connections or open transactions. |
-| 3 | `reset_tenant_pools!` mid-suite | Open, mechanism inferred | Cleanup hook discards tenant pools; next example's `setup_fixtures` snapshots `connection_pool_list` without them; lazy-recreated pools have new object identity and don't enroll in the fixture tx. |
-| 4 | Lazy create after `setup_fixtures` (no reset) | Suspected, unproven | First `switch(:foo)` in example body materializes a pool post-snapshot. May or may not enroll. The integration spec settles this. |
+| 3 | `reset_tenant_pools!` mid-suite | Closed (`abcf755`) | Cleanup hook discards tenant pools; next example's `setup_fixtures` snapshots `connection_pool_list` without them; lazy-recreated pools have new object identity and don't enroll in the fixture tx. Guard raises `Apartment::FixtureLifecycleViolation` in test env. |
+| 4 | Lazy create after `setup_fixtures` (no reset) | Closed (`abcf755`; re-verified 2026-05-19) | First `switch(:foo)` in example body materializes a pool post-snapshot. Integration spec's (a′) tiebreaker asserts rollback (not just visibility) of rows written via lazy pools; green on Rails 7.2 / 8.0 / 8.1 + PG. Lazy enrollment is reliable. |
 | 5 | Non-`:writing` roles / replicas | Suspected | `connection_pool_list` semantics differ in multi-DB / multi-role setups; the invariant must hold per handler, not globally. |
 | 6 | Parallel-example concurrency | Out of scope here | Order-dependent flakes and concurrent flakes are different families; this doc tracks the order-dependent class only. |
 | 7 | `PQTRANS_INERROR` taint after schema mutation | Suspected (downstream evidence) | Downstream consumers have shipped best-effort `ROLLBACK` loops in cross-tenant test cleanup. Existence of the workaround pattern is evidence the variant bites; gem-side coverage deferred. |
 | 8 | Schema cache / prepared-statement drift after tenant DDL | Suspected | Pinned-model joins after DDL in one tenant may resolve against stale caches in another. |
 | 9 | Within-process thread / job boundaries | Suspected | Sidekiq inline, async executors, parallel_tests workers, or app-level threads that `switch` a tenant inside a worker thread may resolve pools differently from the originating thread. Different family from #6 (RSpec parallel examples). |
 
-Members 1 and 2 stay closed. 3 and 4 are the active work. 5–9 are tracked but not in scope this iteration.
+Members 1–4 are closed; the workstream's escape-hatch question (originally tracked as workstream item 6) is closed docs-only — see Shipped #6. Failure-class members 5, 7, 8, 9 are tracked but not in scope this iteration. The next active piece of work is the multi-handler / `:reading` variant (Eventually #7), gated on the dummy app gaining replicas.
 
-## Now (this iteration)
+## Shipped
 
-Scope: one PR after the integration spec lands red and turns green.
+Failure-class members 1–4 and the workstream's escape-hatch resolution. Detail kept here so future contributors can find the work without git archaeology.
 
-1. **Integration spec**: `spec/integration/v4/fixture_pool_lifecycle_spec.rb` against the dummy Rails app. Asserts pool object identity (not tenant name) across the reset → recreate boundary; verifies rollback (not just visibility, since a leased connection can pass writes while rollback still fails later); tests the non-reset lazy path as a first-class case to settle the (a′) question below; covers Rails 7.2, 8.0, 8.1 in the existing matrix.
+1. **Reaper pinned-pool guard** (#399). `PoolReaper` skips pools where `pool_pinned?` returns true. Detection lives in `lib/apartment/pool_reaper.rb:164-168`.
 
-2. **`reset_tenant_pools!` guard**: refuse the call when any pool in `Apartment.pool_manager` carries `@pinned_connection`, raising `Apartment::FixtureLifecycleViolation` (a new subclass of `Apartment::ApartmentError`) with a message naming the offending tenant and pointing at the truncation strategy below. Test-env-scoped via `Rails.env.test?`; production keeps the existing semantics. Detection primitive is the same `@pinned_connection` ivar `pool_pinned?` already reads in `lib/apartment/pool_reaper.rb:164-168` — no new heuristics.
+2. **Reaper in-use guard** (#400). `PoolReaper` skips pools with leased connections or open transactions via `pool_in_use?` at `lib/apartment/pool_reaper.rb:175-182`.
 
-   Contract-locked error text:
+3. **`reset_tenant_pools!` guard** (`abcf755`, via PR #403's squash; PR #402 was closed as merged-via-#403 after a branching mistake). Refuses the call when any pool carries `@pinned_connection`, raising `Apartment::FixtureLifecycleViolation` (defined at `lib/apartment/errors.rb:47`). Test-env-scoped via `Rails.env.test?`; production keeps existing semantics. Reuses the same `@pinned_connection` detection primitive — no new heuristics.
+
+   Contract-locked error text (asserted by the integration spec):
 
    ```
    Apartment::FixtureLifecycleViolation: reset_tenant_pools! called while pool
-   'acme:writing' is pinned by transactional fixtures. Use
-   Apartment::Test::Truncation for cross-tenant specs that must cycle pools.
-   See docs/designs/fixture-pool-lifecycle.md.
+   'acme:writing' is pinned by transactional fixtures. To cycle pools mid-suite,
+   disable transactional fixtures for this test (use_transactional_tests = false)
+   and clean up by deletion. See docs/testing.md.
    ```
 
-3. **`docs/testing.md` invariant section**: opens with the v3→v4 posture (v3's pain was a variable problem — which `search_path` is current; v4's pain is a resource lifecycle problem — does the pool still exist with the object identity fixtures enrolled), then states the rule in one line, then points at this design doc for the failure-class detail. Consumers landing on the constraint without the model can't generalize it to future variants; the framing gives them the model.
+   The message previously pointed at an `Apartment::Test::Truncation` module on the roadmap. Member 6 (workstream item) is now closed as docs-only — see [docs/testing.md § Cycling pools mid-suite](../testing.md#cycling-pools-mid-suite) for the recipe. The message text was updated in lockstep so the violation directs users to the actual documented opt-out.
 
-4. **Downstream cleanup-pattern deletions**: once #1–3 land, three workaround patterns shipped by downstream consumers become delete-candidates — the `reset_tenant_pools!` call in cross-tenant cleanup, the companion best-effort `ROLLBACK` loop guarding against `PQTRANS_INERROR` taint, and any manual eager-load stubs added to work around the resulting query pollution. The gem-side guard lands here; downstream removals follow on the consumer's own timeline.
+4. **Integration spec** (`spec/integration/v4/fixture_pool_lifecycle_spec.rb`, `abcf755`). Five examples cover the guard, the contract-locked message, the negative case, the pool-identity mechanism, and the (a′) tiebreaker. Re-verified 2026-05-19: green on Rails 7.2 / 8.0 / 8.1 + PG, all matrix versions. The (a′) result settles member 6: lazy enrollment is reliable, `preload_test_pools!` stays unbuilt (see Never #6).
 
-   Kept-on-purpose (not in scope for deletion): around-hook helpers like `with_tenants` that consumers wrap test suites in to define a tenant set without cycling pools mid-test. These are consumer ergonomics, not workarounds for gem bugs, and survive the cleanup. Naming the category here prevents a future contributor from re-litigating its existence.
+5. **`docs/testing.md` invariant section** (`abcf755`). Opens with the v3→v4 posture (v3's pain was a variable problem — which `search_path` is current; v4's pain is a resource lifecycle problem — does the pool still exist with the object identity fixtures enrolled), then states the rule and points back here.
 
-## Eventually (within a month, evidence-gated)
+6. **Escape hatch for specs that cycle pools** (closed 2026-05-19, docs-only). The originally-scoped item was "ship `Apartment::Test::Truncation` / `Apartment::Test::CrossTenant` as code." A three-CLI panel (codex / gemini / cursor) converged on Rails' `self.use_transactional_tests = false` as the supported opt-out across the 7.2 / 8.0 / 8.1 matrix; an inspection of `Apartment.guard_pinned_pools_during_fixtures!` confirmed the guard iterates `@pool_manager.each_pair` only — primary is never checked, so the surgical "guard scopes to tenant pools" path is already in place by construction. The hatch is therefore the opt-out itself; cleanup is a documented recipe (`DatabaseCleaner.strategy = :deletion` + `clean_pinned_models!` + `reset_tenant_pools!` last). Recipe: [`docs/testing.md` § Cycling pools mid-suite](../testing.md#cycling-pools-mid-suite). Rejection of the code-shipping shapes recorded in Never #7.
 
-5. **`Apartment::Test::Truncation` strategy** (the escape hatch). Programmatic opt-out from fixture transactions for specs that must cycle pools. Two open shapes:
-   - RSpec metadata flag (`cross_tenant: true`) that flips `use_transactional_fixtures = false` for the marked example and registers a per-example truncation cleaner.
-   - A `helper include Apartment::Test::CrossTenant` that does the same via setup/teardown hooks.
+Downstream cleanup that becomes delete-candidates with these guards in place: the `reset_tenant_pools!` call in cross-tenant test cleanup, the companion best-effort `ROLLBACK` loop guarding `PQTRANS_INERROR` taint, and manual eager-load stubs added to work around the resulting query pollution. Consumer removals are on their own timeline. Kept-on-purpose: around-hook helpers like `with_tenants` that define a tenant set without cycling pools mid-test — these are ergonomics, not workarounds.
 
-   The shape needs its own design conversation before implementation — flipping `use_transactional_fixtures` per-example touches Rails internals that may shift across versions. Treat #5 as design-then-build, not build-then-document.
+## Eventually (>1mo, deferred)
 
-6. **`Apartment::Tenant.preload_test_pools!`** (the contingent fix). Opt-in helper that walks `tenants_provider` and materializes pools before the first `setup_fixtures` runs. Only built if step #1 proves the non-reset lazy path is broken on its own (i.e., step 4 of the integration spec lands red). If the lazy path enrolls correctly, this is YAGNI and stays unbuilt.
-
-   The helper is opt-in only: auto-invoke from the railtie is rejected (see Never #2).
-
-7. **Multi-handler / multi-role variants of the integration spec**. Parametrize over `:writing` and `:reading` roles once the dummy app supports replicas. Deferred until reading replicas are exercised in the main matrix — not blocking #1–4.
+7. **Multi-handler / multi-role variants of the integration spec**. Parametrize over `:writing` and `:reading` roles once the dummy app supports replicas. Deferred until reading replicas are exercised in the main matrix.
 
 ## Never
 
 These are explicit rejections, with the reason recorded so they don't get re-litigated.
 
-1. **Re-enroll lazy pools at switch time** (the original (a) shape). Hooking AR's `TestFixtures` rollback path symmetrically to enroll pools created mid-test fights AR internals that aren't designed for dynamic mid-transaction pool registration. Race-prone, version-fragile, and the same correctness budget buys #6 (`preload_test_pools!`) more cleanly.
+1. **Re-enroll lazy pools at switch time** (the original (a) shape). Hooking AR's `TestFixtures` rollback path symmetrically to enroll pools created mid-test fights AR internals that aren't designed for dynamic mid-transaction pool registration. Race-prone, version-fragile, and made redundant by the (a′) tiebreaker outcome — lazy enrollment already works.
 
-2. **Auto-invoke `preload_test_pools!` from the railtie**. `tenants_provider` may DB-query at boot, or reference tenants that don't yet exist. Opt-in is the contract; the gem doesn't decide preload semantics for the consumer.
+2. **Bypass fixture transactions on the gem's side without explicit user opt-in**. Test isolation strategy belongs to the consumer; the gem refuses to silently change it. The documented opt-out (workstream item 6) is Rails' `self.use_transactional_tests = false` — explicit, at the consumer's site, in a primitive they already know.
 
-3. **Bypass fixture transactions on the gem's side without explicit user opt-in**. Test isolation strategy belongs to the consumer; the gem refuses to silently change it. The truncation strategy (#5) requires explicit metadata or include.
+3. **Patch `connection_pool_list` to dynamically include lazy pools**. AR's snapshot semantics are deliberate; subverting them at the consumer's expense breaks isolation contracts elsewhere (savepoint enrollment, role resolution, role-specific pool lookup). The (a′) result shows the patch is also unnecessary — lazy pools enroll on first use.
 
-4. **Patch `connection_pool_list` to dynamically include lazy pools**. AR's snapshot semantics are deliberate; subverting them at the consumer's expense breaks isolation contracts elsewhere (savepoint enrollment, role resolution, role-specific pool lookup). #6 achieves the right outcome at fixture-setup time without monkey-patching AR.
+4. **Test-mode `SET search_path` switching** (rejected previously in `v4-test-fixtures-compatibility.md`). Re-introduces the runtime search_path mutation v4 eliminated; undermines pool-per-tenant as the production code path.
 
-5. **Test-mode `SET search_path` switching** (rejected previously in `v4-test-fixtures-compatibility.md`). Re-introduces the runtime search_path mutation v4 eliminated; undermines pool-per-tenant as the production code path.
+5. **Auto-invoke `preload_test_pools!` from the railtie**. Was the safety valve for the rejected helper below. If the helper ever returns, opt-in remains the contract — `tenants_provider` may DB-query at boot or reference tenants that don't yet exist.
+
+6. **`Apartment::Tenant.preload_test_pools!`** (retired 2026-05-19). The original contingent fix: walk `tenants_provider` and materialize pools before the first `setup_fixtures` so they would enroll in the fixture transaction. The (a′) tiebreaker in `spec/integration/v4/fixture_pool_lifecycle_spec.rb` proved lazy enrollment is reliable — rows written via a pool first materialized inside an example roll back at teardown on all matrix versions (Rails 7.2 / 8.0 / 8.1 + PG, re-verified 2026-05-19). The helper would be code shipped for a failure mode that doesn't occur. If multi-handler / `:reading` variants (workstream item 7) surface a divergence, revisit on fresh evidence.
+
+7. **Shipping a code module for the escape hatch** (rejected 2026-05-19). The original design listed two candidate shapes: an RSpec metadata flag flipping `use_transactional_fixtures` per-example, and an `include Apartment::Test::CrossTenant` (or `Truncation`) helper. Rejected on three grounds. (a) Per-example flipping fights Rails internals — `config.use_transactional_fixtures` is global; community recipes that flip it mid-suite are version-fragile (referenced explicitly as a constraint in the panel brief). (b) An include helper would wrap Rails' supported `self.use_transactional_tests = false` primitive plus a `DatabaseCleaner` recipe — the wrapping adds API surface for downstream consumers, version-coupling, and a third place for the cleanup contract to drift from docs. (c) The three-CLI panel (codex / gemini / cursor) distributed weight across "include helper" and "docs-only"; cursor explicitly allocated 0.20 to docs-only, and the post-panel guard-scope verification eliminated the architectural concern that motivated owning the contract in code. Net: the recipe is documented in [`docs/testing.md` § Cycling pools mid-suite](../testing.md#cycling-pools-mid-suite); the gem ships no `Apartment::Test::*` module.
 
 ## Wishlist (>1 month, deferred)
 
 Items the broader-class observation surfaced but that need their own design conversations before they enter a roadmap.
 
 - **Parallel-spec safety hardening**. Order-dependent flakes (this doc) and concurrent flakes are different families. Process-scoping the `reset_tenant_pools!` guard is one piece; broader concurrent-fixture-tx semantics is its own investigation.
-- **`PQTRANS_INERROR` recovery hooks**. The downstream `ROLLBACK` loop is evidence the variant exists. Gem-side coverage would mean an instrumented detection + recovery path, probably in `Apartment::Tenant.switch`'s ensure block. Real but lower priority than #1–6.
-- **Schema cache invalidation on tenant DDL**. Pinned-model joins after one tenant's DDL may resolve against stale caches. Needs adapter-specific design (PG vs MySQL diverge on cache invalidation primitives).
-- **Adapter-specific savepoint behavior**. PG schema adapter under `pin_connection!` with DDL inside a tenant tx may detach the savepoint stack. Sanity check inside the integration spec is in scope (#1); deeper coverage is wishlist.
-- **`with_tenants_provider`-style scoped overrides for test fixtures**. Currently tracked in `docs/plans/with-tenants-provider/`. Adjacent but separate work.
-
-## Decisions and probabilities
-
-Aggregate after three-CLI review (cursor / codex / gemini) and downstream agreement:
-
-- 0.45 — Ship #1 (integration spec), #2 (`reset_tenant_pools!` guard), #3 (docs invariant) now; #5 and #6 follow, with #6 gated on what #1 finds.
-- 0.37 — Same as above but ship #6 (`preload_test_pools!`) together with #2 without waiting on evidence. Justified if cost of waiting is high and one round-trip is preferred. Both cursor and codex flagged that "working multi-tenant suites" is weak evidence for #6 being unnecessary — preload patterns and accidental ordering can paper over the lazy-without-reset path.
-- 0.18 — Anything that makes #2 optional. Including the original "(a′) + (c) with (b) as supporting guardrail" lean. Rejected on grounds that the invariant being optional defeats the framing.
-
-Cross-CLI convergence on the YAGNI softening for #6 nudged the 0.45 path down from an initial 0.50 and lifted 0.37 from 0.32: two independent reviewers flagging the same risk is stronger signal than the original lean, and the bias-correction toward "do the cheap additive fix" deserves real weight. 0.45 is still preferred for evidence discipline, but the gap is narrower than the first cut suggested.
+- **`PQTRANS_INERROR` recovery hooks** (member 7). The downstream `ROLLBACK` loop is evidence the variant exists. Gem-side coverage would mean an instrumented detection + recovery path, probably in `Apartment::Tenant.switch`'s ensure block.
+- **Schema cache invalidation on tenant DDL** (member 8). Pinned-model joins after one tenant's DDL may resolve against stale caches. Needs adapter-specific design (PG vs MySQL diverge on cache invalidation primitives).
+- **Adapter-specific savepoint behavior**. PG schema adapter under `pin_connection!` with DDL inside a tenant tx may detach the savepoint stack. Sanity check is in the existing integration spec; deeper coverage is wishlist.
+- **Within-process thread / job boundaries** (member 9). Sidekiq inline, async executors, parallel_tests workers, or app-level threads that `switch` inside a worker thread may resolve pools differently from the originating thread.
 
 ## Detection primitives
 
@@ -114,10 +104,12 @@ Across Rails 7.2 / 8.0 / 8.1 the `@pinned_connection` semantics are stable. 8.x+
 ## Cross-references
 
 - `docs/designs/v4-test-fixtures-compatibility.md` — the `setup_shared_connection_pool` patch (PRs #379, #380). This doc generalizes that work to other lifecycle APIs.
-- `docs/testing.md` — consumer-facing summary of the invariant and the available test helpers. Updated as part of #3.
-- `lib/apartment/pool_reaper.rb` — existing pinned and in-use guards (PRs #399, #400). The `reset_tenant_pools!` guard reuses the same detection primitives.
-- `docs/plans/with-tenants-provider/` — adjacent test-fixtures work tracked separately.
+- `docs/testing.md` — consumer-facing summary of the invariant and the available test helpers.
+- `lib/apartment/pool_reaper.rb` — existing pinned and in-use guards (PRs #399, #400); the `reset_tenant_pools!` guard reuses the same primitives.
+- `lib/apartment/errors.rb` — `FixtureLifecycleViolation` definition.
+- `spec/integration/v4/fixture_pool_lifecycle_spec.rb` — the integration coverage that closes members 3 and 4.
+- `Apartment::Tenant.with_tenants_provider` / `with_tenants` (PRs #391, #395) — block-scoped tenant-resolver overrides that consumers use to define a tenant set for a test suite without cycling pools. Adjacent but independent of this failure class; named here so future contributors don't conflate them with the docs-only escape-hatch recipe (workstream item 6).
 
 ## Origin
 
-PR #400 closed the reaper variant of the failure class. A downstream consumer bumped to `a89aa0b` and reported a remaining order-dependent flake, bisected to a `reset_tenant_pools!` call in a `cross_tenant` shared context. Three-CLI consultation (cursor, codex, gemini) converged on (b) as the load-bearing invariant and on (a′) as evidence-gated, with several additions absorbed into the inventory above.
+PR #400 closed the reaper variant of the failure class. A downstream consumer bumped to `a89aa0b` and reported a remaining order-dependent flake, bisected to a `reset_tenant_pools!` call in a `cross_tenant` shared context. Three-CLI consultation (cursor, codex, gemini) converged on the lifecycle-invariant framing and on the (a′) lazy-enrollment question as evidence-gated. The integration spec landed the evidence: (a′) is green across the matrix, so the contingent `preload_test_pools!` helper retires unbuilt.

--- a/docs/designs/fixture-pool-lifecycle.md
+++ b/docs/designs/fixture-pool-lifecycle.md
@@ -1,6 +1,8 @@
 # Fixture Pool Lifecycle
 
-Status: living. Last consolidated 2026-05-19 after PRs #399, #400, and #403 (which squashed the `reset_tenant_pools!` guard, the integration spec, and the docs invariant section onto `main` as `abcf755`).
+Status: living. Last consolidated 2026-05-19 after PRs #399, #400, #403 (which squashed the `reset_tenant_pools!` guard, the integration spec, and the docs invariant section onto `main` as `abcf755`), and #404 (the escape-hatch docs pass).
+
+> **Numbering note.** Two independent number spaces appear below. *Failure-class members* (the table under "Failure class members") are numbered 1–9. *Workstream items* are numbered within their bucket — Shipped #1–6, Eventually #7, Never #1–7. References always name the space: "failure-class member 4" vs "Shipped #6" / "Never #6". A bare "#N" inside a bucket refers to that bucket.
 
 ## TLDR
 
@@ -28,7 +30,7 @@ This is the broader rule the in-use guard from #400 specialized for the reaper c
 | 8 | Schema cache / prepared-statement drift after tenant DDL | Suspected | Pinned-model joins after DDL in one tenant may resolve against stale caches in another. |
 | 9 | Within-process thread / job boundaries | Suspected | Sidekiq inline, async executors, parallel_tests workers, or app-level threads that `switch` a tenant inside a worker thread may resolve pools differently from the originating thread. Different family from #6 (RSpec parallel examples). |
 
-Members 1–4 are closed; the workstream's escape-hatch question (originally tracked as workstream item 6) is closed docs-only — see Shipped #6. Failure-class members 5, 7, 8, 9 are tracked but not in scope this iteration. The next active piece of work is the multi-handler / `:reading` variant (Eventually #7), gated on the dummy app gaining replicas.
+Failure-class members 1–4 are closed; the workstream's escape-hatch question (originally tracked as workstream item 6) is closed docs-only — see Shipped #6. Failure-class members 5, 7, 8, 9 are tracked but not in scope this iteration. The next active piece of work is the multi-handler / `:reading` variant (Eventually #7), gated on the dummy app gaining replicas.
 
 ## Shipped
 
@@ -49,9 +51,9 @@ Failure-class members 1–4 and the workstream's escape-hatch resolution. Detail
    and clean up by deletion. See docs/testing.md.
    ```
 
-   The message previously pointed at an `Apartment::Test::Truncation` module on the roadmap. Member 6 (workstream item) is now closed as docs-only — see [docs/testing.md § Cycling pools mid-suite](../testing.md#cycling-pools-mid-suite) for the recipe. The message text was updated in lockstep so the violation directs users to the actual documented opt-out.
+   The message previously pointed at an `Apartment::Test::Truncation` module on the roadmap. The escape-hatch workstream item (Shipped #6) is now closed docs-only — see [docs/testing.md § Cycling pools mid-suite](../testing.md#cycling-pools-mid-suite) for the recipe. The message text was updated in lockstep so the violation directs users to the actual documented opt-out.
 
-4. **Integration spec** (`spec/integration/v4/fixture_pool_lifecycle_spec.rb`, `abcf755`). Five examples cover the guard, the contract-locked message, the negative case, the pool-identity mechanism, and the (a′) tiebreaker. Re-verified 2026-05-19: green on Rails 7.2 / 8.0 / 8.1 + PG, all matrix versions. The (a′) result settles member 6: lazy enrollment is reliable, `preload_test_pools!` stays unbuilt (see Never #6).
+4. **Integration spec** (`spec/integration/v4/fixture_pool_lifecycle_spec.rb`, `abcf755`). Five examples cover the guard, the contract-locked message, the negative case, the pool-identity mechanism, and the (a′) tiebreaker. Re-verified 2026-05-19: green on Rails 7.2 / 8.0 / 8.1 + PG, all matrix versions. The (a′) result confirms lazy enrollment is reliable, so `preload_test_pools!` stays unbuilt (see Never #6).
 
 5. **`docs/testing.md` invariant section** (`abcf755`). Opens with the v3→v4 posture (v3's pain was a variable problem — which `search_path` is current; v4's pain is a resource lifecycle problem — does the pool still exist with the object identity fixtures enrolled), then states the rule and points back here.
 
@@ -86,10 +88,10 @@ These are explicit rejections, with the reason recorded so they don't get re-lit
 Items the broader-class observation surfaced but that need their own design conversations before they enter a roadmap.
 
 - **Parallel-spec safety hardening**. Order-dependent flakes (this doc) and concurrent flakes are different families. Process-scoping the `reset_tenant_pools!` guard is one piece; broader concurrent-fixture-tx semantics is its own investigation.
-- **`PQTRANS_INERROR` recovery hooks** (member 7). The downstream `ROLLBACK` loop is evidence the variant exists. Gem-side coverage would mean an instrumented detection + recovery path, probably in `Apartment::Tenant.switch`'s ensure block.
-- **Schema cache invalidation on tenant DDL** (member 8). Pinned-model joins after one tenant's DDL may resolve against stale caches. Needs adapter-specific design (PG vs MySQL diverge on cache invalidation primitives).
+- **`PQTRANS_INERROR` recovery hooks** (failure-class member 7). The downstream `ROLLBACK` loop is evidence the variant exists. Gem-side coverage would mean an instrumented detection + recovery path, probably in `Apartment::Tenant.switch`'s ensure block.
+- **Schema cache invalidation on tenant DDL** (failure-class member 8). Pinned-model joins after one tenant's DDL may resolve against stale caches. Needs adapter-specific design (PG vs MySQL diverge on cache invalidation primitives).
 - **Adapter-specific savepoint behavior**. PG schema adapter under `pin_connection!` with DDL inside a tenant tx may detach the savepoint stack. Sanity check is in the existing integration spec; deeper coverage is wishlist.
-- **Within-process thread / job boundaries** (member 9). Sidekiq inline, async executors, parallel_tests workers, or app-level threads that `switch` inside a worker thread may resolve pools differently from the originating thread.
+- **Within-process thread / job boundaries** (failure-class member 9). Sidekiq inline, async executors, parallel_tests workers, or app-level threads that `switch` inside a worker thread may resolve pools differently from the originating thread.
 
 ## Detection primitives
 
@@ -107,7 +109,7 @@ Across Rails 7.2 / 8.0 / 8.1 the `@pinned_connection` semantics are stable. 8.x+
 - `docs/testing.md` — consumer-facing summary of the invariant and the available test helpers.
 - `lib/apartment/pool_reaper.rb` — existing pinned and in-use guards (PRs #399, #400); the `reset_tenant_pools!` guard reuses the same primitives.
 - `lib/apartment/errors.rb` — `FixtureLifecycleViolation` definition.
-- `spec/integration/v4/fixture_pool_lifecycle_spec.rb` — the integration coverage that closes members 3 and 4.
+- `spec/integration/v4/fixture_pool_lifecycle_spec.rb` — the integration coverage that closes failure-class members 3 and 4.
 - `Apartment::Tenant.with_tenants_provider` / `with_tenants` (PRs #391, #395) — block-scoped tenant-resolver overrides that consumers use to define a tenant set for a test suite without cycling pools. Adjacent but independent of this failure class; named here so future contributors don't conflate them with the docs-only escape-hatch recipe (workstream item 6).
 
 ## Origin

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -181,15 +181,16 @@ In `Rails.env.test?`, `Apartment.reset_tenant_pools!` raises `Apartment::Fixture
 
 ```text
 Apartment::FixtureLifecycleViolation: reset_tenant_pools! called while pool
-'acme:writing' is pinned by transactional fixtures. Use Apartment::Test::Truncation
-for cross-tenant specs that must cycle pools. See docs/designs/fixture-pool-lifecycle.md.
+'acme:writing' is pinned by transactional fixtures. To cycle pools mid-suite,
+disable transactional fixtures for this test (use_transactional_tests = false)
+and clean up by deletion. See docs/testing.md.
 ```
 
 The guard fires when a tenant pool already exists in the pool manager AND has been pinned. The common bootstrap path — `Apartment::TestFixtures` calling `reset_tenant_pools!` before `setup_shared_connection_pool` runs, no tenant pools tracked yet — is unaffected. If you hit the violation, the call is happening at the wrong time, not from the wrong place.
 
 What to do instead, depending on the call site:
 
-- **Cleanup hook in a cross-tenant spec** (the most common cause): the spec needs to cycle pools mid-suite. Switch off transactional fixtures for that example or context and use a deletion/truncation strategy (`DatabaseCleaner.strategy = :deletion`). Programmatic opt-out via `Apartment::Test::Truncation` is on the roadmap (`docs/designs/fixture-pool-lifecycle.md` member #5).
+- **Cleanup hook in a cross-tenant spec** (the most common cause): the spec needs to cycle pools mid-suite. See ["Cycling pools mid-suite"](#cycling-pools-mid-suite) below for the documented opt-out recipe.
 - **Suite bootstrap or teardown**: move the call out of any `before(:each)` / `after(:each)` that runs under transactional fixtures. `before(:suite)` and `after(:suite)` are safe; `before(:all)` and `after(:all)` are safe if `use_transactional_tests` is the default (Rails enrols the fixture tx per-example, not per-group).
 - **Production cleanup script that imports Rails**: not a real call site, but if it shows up, ensure the script runs outside `Rails.env.test?` or call the pool-manager's `clear` directly.
 
@@ -217,3 +218,58 @@ Two narrow cases the in-use guard does **not** cover:
 - A pool whose connections have all been returned but a query-cache or prepared-statement cache remains warm — correctly evictable; the next access rebuilds both.
 
 When LRU pressure can't reach `max_total_connections` because too many pools are protected, the reaper emits `cap_unmet.apartment` instead of forcing eviction. The cap is best-effort under active workload — if you see it firing, check for the same leak signature in `skip_evict`.
+
+### Cycling pools mid-suite
+
+A small set of specs legitimately needs to cycle tenant pools — cross-tenant cleanup suites that drop and recreate tenants per example, integration tests that exercise `Apartment::Tenant.create` / `destroy` directly, or harness tests for the pool manager itself. Inside transactional fixtures, this trips `FixtureLifecycleViolation`. The opt-out is to take the offending example (or its enclosing TestCase / `describe` block) out of fixture transactions and clean up by deletion instead.
+
+Opting out at the class / group level uses Rails' supported primitive:
+
+```ruby
+RSpec.describe 'tenant lifecycle', cross_tenant: true do
+  self.use_transactional_tests = false
+  # … examples that switch, create, and destroy tenants freely
+end
+```
+
+```ruby
+# Minitest equivalent — per test method or per class
+class TenantLifecycleTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+  # …
+end
+
+class MixedTest < ActiveSupport::TestCase
+  uses_transaction :test_recreates_pool   # only this method opts out
+  # …
+end
+```
+
+With `use_transactional_tests = false`, no pool gets pinned and `Apartment.reset_tenant_pools!` runs without tripping the guard. The cost: nothing rolls back automatically — neither tenant data nor pinned-model writes to the default schema. You own the cleanup.
+
+A pragmatic cleanup recipe for the opted-out group:
+
+```ruby
+RSpec.shared_context 'cycles pools', cross_tenant: true do
+  before do
+    DatabaseCleaner.strategy = :deletion   # :truncation also works; :transaction does not
+    DatabaseCleaner.start
+  end
+
+  after do
+    DatabaseCleaner.clean
+    clean_pinned_models!                   # see "Cleaning shared (default) tenant data" above
+    Apartment.reset_tenant_pools!          # now safe — no pins left
+  end
+end
+
+RSpec.configure { |c| c.include_context 'cycles pools', cross_tenant: true }
+```
+
+Three notes on the recipe:
+
+- **Cleanup scope is yours.** `:deletion` cleans tables in the default and tenant schemas reached via the same handler. Pinned-model writes to the primary schema are *not* covered by tenant-pool cleanup alone — chain `clean_pinned_models!` (or the equivalent for your suite). The pinned-model helper is documented above.
+- **Reset pools last.** Calling `reset_tenant_pools!` before deletion would leave tenant rows behind in the DB; calling it after means the next example starts with no live pools and a clean slate.
+- **Inheritance is sticky.** `self.use_transactional_tests = false` at the group level applies to nested describes too. Prefer narrow opt-in (`describe '…', cross_tenant: true do`) over flipping it globally; the metadata makes the opt-out grep-able.
+
+Apartment does not ship an `Apartment::Test::CrossTenant` module. The mechanism above is Rails-native, the cleanup recipe is sensitive to the suite's other tools (DatabaseCleaner, test-prof, factory caching), and the cost of getting it wrong is a noisy `FixtureLifecycleViolation`, not silent data loss. Copy the recipe and adapt.

--- a/lib/apartment/errors.rb
+++ b/lib/apartment/errors.rb
@@ -57,9 +57,9 @@ module Apartment
     def default_message
       pool_clause = @pool_key ? "pool '#{@pool_key}'" : 'a tenant pool'
       "reset_tenant_pools! called while #{pool_clause} is pinned by " \
-        'transactional fixtures. Use Apartment::Test::Truncation for ' \
-        'cross-tenant specs that must cycle pools. ' \
-        'See docs/designs/fixture-pool-lifecycle.md.'
+        'transactional fixtures. To cycle pools mid-suite, disable ' \
+        'transactional fixtures for this test (use_transactional_tests = false) ' \
+        'and clean up by deletion. See docs/testing.md.'
     end
   end
 

--- a/lib/apartment/errors.rb
+++ b/lib/apartment/errors.rb
@@ -43,7 +43,8 @@ module Apartment
   # fresh object identity that never enrols in the rollback. Test-env-scoped
   # — production callers are unaffected.
   #
-  # See docs/designs/fixture-pool-lifecycle.md.
+  # See docs/testing.md for the consumer-facing opt-out recipe and
+  # docs/designs/fixture-pool-lifecycle.md for the failure-class design.
   class FixtureLifecycleViolation < ApartmentError
     attr_reader :pool_key
 

--- a/spec/integration/v4/fixture_pool_lifecycle_spec.rb
+++ b/spec/integration/v4/fixture_pool_lifecycle_spec.rb
@@ -18,8 +18,8 @@ require 'apartment/test_fixtures'
 # Five examples:
 #   1. The guard raises `Apartment::FixtureLifecycleViolation` when a tenant
 #      pool carries `@pinned_connection`.
-#   2. The violation message names the offending tenant pool and redirects to
-#      the truncation strategy (contract-locked text).
+#   2. The violation message names the offending tenant pool and points at the
+#      use_transactional_tests = false opt-out + docs/testing.md (contract-locked text).
 #   3. Negative case: with no pinned pools, the call passes (the guard must
 #      not over-trigger and break suite bootstrapping — `Apartment::TestFixtures`
 #      itself invokes `reset_tenant_pools!` before `setup_shared_connection_pool`
@@ -130,7 +130,7 @@ RSpec.describe('v4 fixture pool lifecycle guards', :integration, # rubocop:disab
     end.to(raise_error(Apartment::FixtureLifecycleViolation))
   end
 
-  it 'violation message names the offending tenant pool and redirects to the truncation strategy doc' do
+  it 'violation message names the offending tenant pool and points at the use_transactional_tests opt-out' do
     widget_class
 
     message = nil
@@ -146,8 +146,8 @@ RSpec.describe('v4 fixture pool lifecycle guards', :integration, # rubocop:disab
     expect(message).not_to(be_nil)
     expect(message).to(include("#{write_tenant}:writing"))
     expect(message).to(include('transactional fixtures'))
-    expect(message).to(include('Apartment::Test::Truncation'))
-    expect(message).to(include('docs/designs/fixture-pool-lifecycle.md'))
+    expect(message).to(include('use_transactional_tests = false'))
+    expect(message).to(include('docs/testing.md'))
   end
 
   it 'is allowed outside fixture-transaction ownership (negative case)' do

--- a/spec/integration/v4/fixture_pool_lifecycle_spec.rb
+++ b/spec/integration/v4/fixture_pool_lifecycle_spec.rb
@@ -6,7 +6,7 @@ require 'apartment/test_fixtures'
 
 # Integration coverage for the fixture pool lifecycle failure class.
 #
-# Design: docs/designs/fixture-pool-lifecycle.md (member #3).
+# Design: docs/designs/fixture-pool-lifecycle.md (failure-class members 3 and 4).
 #
 # The invariant: pool lifecycle changes during fixture-transaction ownership
 # are a violation. `reset_tenant_pools!` invoked mid-suite discards pools that
@@ -19,7 +19,7 @@ require 'apartment/test_fixtures'
 #   1. The guard raises `Apartment::FixtureLifecycleViolation` when a tenant
 #      pool carries `@pinned_connection`.
 #   2. The violation message names the offending tenant pool and points at the
-#      use_transactional_tests = false opt-out + docs/testing.md (contract-locked text).
+#      use_transactional_tests = false opt-out and docs/testing.md (contract-locked text).
 #   3. Negative case: with no pinned pools, the call passes (the guard must
 #      not over-trigger and break suite bootstrapping — `Apartment::TestFixtures`
 #      itself invokes `reset_tenant_pools!` before `setup_shared_connection_pool`
@@ -31,8 +31,9 @@ require 'apartment/test_fixtures'
 #   5. The (a′) tiebreaker: does a tenant pool created lazily inside an
 #      example (no prior reset) enroll in the fixture rollback? Asserts
 #      rollback, not visibility — a leased connection can pass in-example
-#      writes while teardown's rollback still misses them. Outcome determines
-#      whether design member #6 (`preload_test_pools!`) ships.
+#      writes while teardown's rollback still misses them. Settled green
+#      across the matrix; the `preload_test_pools!` helper was retired
+#      unbuilt. This example stays as the regression lock.
 #
 # Covers Rails 7.2 / 8.0 / 8.1 via the existing appraisal matrix.
 # :schema strategy is PG-only; `pin_connection!` semantics are crispest there.
@@ -187,13 +188,14 @@ RSpec.describe('v4 fixture pool lifecycle guards', :integration, # rubocop:disab
   end
 
   it 'rolls back rows written via lazy pool creation in the non-reset path (a′ tiebreaker)' do
-    # The (a′) question (design member #4, settles #6): `setup_fixtures` runs
+    # The (a′) question (failure-class member 4): `setup_fixtures` runs
     # first with no tenant pool, the example then switches to the tenant for
     # the first time and writes. Does the lazily-created pool enroll in the
     # fixture transaction so teardown rolls the row back?
     #
-    # If GREEN: lazy enrollment works; `preload_test_pools!` is YAGNI.
-    # If RED:   ship design member #6 to materialise pools pre-snapshot.
+    # Settled green across the matrix: lazy enrollment works, so the
+    # `preload_test_pools!` helper was retired unbuilt (see the design doc's
+    # Never list). This example stays as the regression lock.
     #
     # Asserting rollback (not visibility): a leased connection can return
     # in-example writes via the same handle while teardown's enrollment


### PR DESCRIPTION
## Summary

Closes the `docs/designs/fixture-pool-lifecycle.md` workstream's escape-hatch question as **docs-only**, and refreshes every artifact that still pointed at the never-shipped `Apartment::Test::Truncation` module.

A three-CLI panel (codex / gemini / cursor) plus a guard-scope verification settled two things:

- Rails' `self.use_transactional_tests = false` is the supported per-TestCase opt-out across our 7.2 / 8.0 / 8.1 matrix.
- `Apartment.guard_pinned_pools_during_fixtures!` already iterates only `@pool_manager.each_pair` — primary is never inspected, so the "guard scopes to tenant pools" path is in place by construction. The hatch *is* the opt-out; cleanup is a recipe.

## Changes

- **`docs/testing.md`** — new "Cycling pools mid-suite" subsection with the Rails-native opt-out + `DatabaseCleaner :deletion` + `clean_pinned_models!` + `reset_tenant_pools!`-last recipe. The existing `reset_tenant_pools!` bullet now links to it. Docstring example updated to the new violation message.
- **`lib/apartment/errors.rb`** — `FixtureLifecycleViolation#default_message` rewritten to point at `use_transactional_tests = false` + `docs/testing.md`; drops the `Apartment::Test::Truncation` reference.
- **`spec/integration/v4/fixture_pool_lifecycle_spec.rb`** — contract-locked assertions moved to `use_transactional_tests = false` and `docs/testing.md`; comment header and `it` description for example #2 refreshed.
- **`docs/designs/fixture-pool-lifecycle.md`** — TLDR reframed; failure-class summary line updated; "Next" section folded into Shipped as workstream item 6 (escape hatch closed docs-only with the panel + verification trail); Never gained item 7 recording the rejected code-shipping shapes (RSpec metadata flag, include helper).

## Test plan

- [x] `bundle exec appraisal rails-7.2-postgresql rspec spec/integration/v4/fixture_pool_lifecycle_spec.rb` — 5 examples, 0 failures
- [x] `bundle exec appraisal rails-8.0-postgresql rspec spec/integration/v4/fixture_pool_lifecycle_spec.rb` — 5 examples, 0 failures
- [x] `bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/fixture_pool_lifecycle_spec.rb` — 5 examples, 0 failures
- [x] `bundle exec rubocop lib/apartment/errors.rb spec/integration/v4/fixture_pool_lifecycle_spec.rb` — clean
- [x] No remaining `Apartment::Test::Truncation` references in `lib/` or `spec/`; the two remaining mentions in `docs/designs/fixture-pool-lifecycle.md` are intentional historical context (Shipped #6, Never #7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)