### PR TITLE
Stop reset_tenant_pools! from clearing Apartment::Current

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -197,12 +197,17 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     end
 
     # Deregister all tenant pools from AR's ConnectionHandler and clear the
-    # pool manager cache. Tenant context is also reset. Pools rebuild lazily
-    # on the next +connection_pool+ call.
+    # pool manager cache. Pools rebuild lazily on the next +connection_pool+
+    # call.
+    #
+    # Execution context (+Apartment::Current+: tenant, tenant_override, etc.)
+    # is left untouched — pool lifecycle and tenant context are separate
+    # concerns. A caller that also wants to drop tenant context resets it
+    # explicitly via +Apartment::Tenant.reset+.
     #
     # Called automatically by +Apartment::TestFixtures+ before Rails' fixture
-    # setup iterates shards. Can also be called manually in custom test harnesses
-    # that need to clear tenant state between examples.
+    # setup iterates shards. Can also be called manually in custom test
+    # harnesses that cycle tenant pools between examples.
     #
     # @return [void]
     # @see Apartment::TestFixtures
@@ -210,7 +215,6 @@ module Apartment # rubocop:disable Metrics/ModuleLength
       guard_pinned_pools_during_fixtures!
       deregister_all_tenant_pools
       @pool_manager&.clear
-      Apartment::Current.reset
     end
 
     private

--- a/lib/apartment/current.rb
+++ b/lib/apartment/current.rb
@@ -5,6 +5,13 @@ require 'active_support/current_attributes'
 module Apartment
   # Fiber-safe tenant context using ActiveSupport::CurrentAttributes.
   # Replaces the v3 Thread.current[:apartment_adapter] approach.
+  #
+  # Do not call the bare +reset+ on this class from domain or lifecycle
+  # methods. +reset+ clears every attribute, so adding one here silently
+  # widens the blast radius of every existing call site. +reset+ belongs at
+  # true execution boundaries only — the Rails executor, test teardown
+  # hooks, +Apartment.clear_config+. Inside domain code, assign the specific
+  # attributes you mean to clear.
   class Current < ActiveSupport::CurrentAttributes
     attribute :tenant, :previous_tenant, :migrating, :tenant_override
   end

--- a/lib/apartment/current.rb
+++ b/lib/apartment/current.rb
@@ -9,9 +9,9 @@ module Apartment
   # Do not call the bare +reset+ on this class from domain or lifecycle
   # methods. +reset+ clears every attribute, so adding one here silently
   # widens the blast radius of every existing call site. +reset+ belongs at
-  # true execution boundaries only — the Rails executor, test teardown
-  # hooks, +Apartment.clear_config+. Inside domain code, assign the specific
-  # attributes you mean to clear.
+  # true execution boundaries only: the Rails executor clears it once per
+  # request; a test suite clears it in an +after+ hook. Inside domain code,
+  # assign the specific attributes you mean to clear.
   class Current < ActiveSupport::CurrentAttributes
     attribute :tenant, :previous_tenant, :migrating, :tenant_override
   end

--- a/spec/integration/v4/fixture_pool_lifecycle_spec.rb
+++ b/spec/integration/v4/fixture_pool_lifecycle_spec.rb
@@ -15,7 +15,7 @@ require 'apartment/test_fixtures'
 # lazy-recreated pool has fresh object identity that never enrolls in the
 # fixture transaction.
 #
-# Five examples:
+# Six examples:
 #   1. The guard raises `Apartment::FixtureLifecycleViolation` when a tenant
 #      pool carries `@pinned_connection`.
 #   2. The violation message names the offending tenant pool and points at the
@@ -34,6 +34,10 @@ require 'apartment/test_fixtures'
 #      writes while teardown's rollback still misses them. Settled green
 #      across the matrix; the `preload_test_pools!` helper was retired
 #      unbuilt. This example stays as the regression lock.
+#   6. reset_tenant_pools! resets pools only — it must not clear
+#      Apartment::Current. Drives the real around-hook -> setup_fixtures ->
+#      setup_shared_connection_pool -> reset_tenant_pools! chain and asserts
+#      a with_tenants override survives it.
 #
 # Covers Rails 7.2 / 8.0 / 8.1 via the existing appraisal matrix.
 # :schema strategy is PG-only; `pin_connection!` semantics are crispest there.
@@ -211,5 +215,30 @@ RSpec.describe('v4 fixture pool lifecycle guards', :integration, # rubocop:disab
     Apartment::Tenant.switch(write_tenant) { post_rollback_count = Widget.count }
 
     expect(post_rollback_count).to(eq(0))
+  end
+
+  it 'preserves a with_tenants override across fixture setup (reset_tenant_pools! leaves Current intact)' do
+    # The downstream failure path, end to end: an outer scope sets
+    # tenant_override, then setup_fixtures runs reset_tenant_pools! via
+    # setup_shared_connection_pool. reset_tenant_pools! must not clear
+    # Apartment::Current — pool lifecycle and tenant context are separate.
+    # The unit specs lock the method in isolation; this locks the real
+    # fixture-setup chain (around-hook -> setup_fixtures -> reset).
+    widget_class
+    observed_override = nil
+    observed_names    = nil
+
+    Apartment::Tenant.with_tenants(write_tenant) do
+      FixtureLifecycleGuardHost.new.run_example do
+        observed_override = Apartment::Current.tenant_override
+        observed_names    = Apartment.tenant_names
+      end
+    end
+
+    # tenants_provider returns the full `tenants` list; the override is the
+    # single write_tenant. A wiped override falls back to the provider, so
+    # the one-element result distinguishes survived-override from fallback.
+    expect(observed_override).to(eq([write_tenant]))
+    expect(observed_names).to(eq([write_tenant]))
   end
 end

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -94,6 +94,41 @@ RSpec.describe(Apartment) do
     end
   end
 
+  describe '.reset_tenant_pools!' do
+    # Regression: reset_tenant_pools! is a pool-lifecycle method. It must not
+    # touch Apartment::Current — that bag holds execution context (tenant,
+    # previous_tenant, migrating, tenant_override), none of which is pool
+    # state. A blanket Current.reset here clobbered the tenant_override set
+    # by a with_tenants around-hook, silently breaking tenant iteration for
+    # the whole example. See docs/designs/fixture-pool-lifecycle.md.
+    it 'preserves a with_tenants override so tenant_names still scopes to it' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { %w[ambient] }
+      end
+
+      Apartment::Tenant.with_tenants('acme', 'widgets') do
+        described_class.reset_tenant_pools!
+        expect(described_class.tenant_names).to(eq(%w[acme widgets]))
+      end
+    end
+
+    it 'does not reset Current tenant context' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+      end
+
+      Apartment::Current.tenant = 'acme'
+      Apartment::Current.tenant_override = %w[acme widgets]
+
+      described_class.reset_tenant_pools!
+
+      expect(Apartment::Current.tenant).to(eq('acme'))
+      expect(Apartment::Current.tenant_override).to(eq(%w[acme widgets]))
+    end
+  end
+
   describe '.excluded_models' do
     it 'delegates to config.excluded_models' do
       described_class.configure do |config|

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -120,11 +120,15 @@ RSpec.describe(Apartment) do
       end
 
       Apartment::Current.tenant = 'acme'
+      Apartment::Current.previous_tenant = 'public'
+      Apartment::Current.migrating = true
       Apartment::Current.tenant_override = %w[acme widgets]
 
       described_class.reset_tenant_pools!
 
       expect(Apartment::Current.tenant).to(eq('acme'))
+      expect(Apartment::Current.previous_tenant).to(eq('public'))
+      expect(Apartment::Current.migrating).to(be(true))
       expect(Apartment::Current.tenant_override).to(eq(%w[acme widgets]))
     end
   end


### PR DESCRIPTION
## Summary

`Apartment.reset_tenant_pools!` is a pool-lifecycle method, but it ended with a blanket `Apartment::Current.reset` that wiped all four `Current` attributes — `tenant`, `previous_tenant`, `migrating`, `tenant_override`. None of those is pool state; they are execution context. This decouples the two: `reset_tenant_pools!` now resets pools and nothing else.

## Root cause

`git blame`: the `Current.reset` line was written in PR #379, when `Current` had **three** attributes. PR #391 later added a **fourth** — `tenant_override`, backing the `with_tenants` / `with_tenants_provider` iteration-scoping API — without re-auditing `reset_tenant_pools!`. Adding an attribute to a shared `ActiveSupport::CurrentAttributes` bag silently widens the blast radius of every existing bare `reset` call.

`Apartment::TestFixtures#setup_shared_connection_pool` calls `reset_tenant_pools!` on every example's fixture setup, so the blanket `Current.reset` ran once per example — discarding any `tenant_override` a consumer had established.

## Scope — one of two independent clobbers

`Apartment::Current` can be reset by two unrelated mechanisms during a test run. **This PR closes the first; the second is out of the gem's reach:**

1. **`reset_tenant_pools!`'s blanket `Current.reset`** — gem code, fixed here.
2. **rspec-rails' per-example reset** — `ActiveSupport::CurrentAttributes::TestHelper#before_setup` calls `CurrentAttributes.clear_all`, resetting every `CurrentAttributes` subclass (including `Apartment::Current`) before every typed example. This is Rails/rspec-rails test infrastructure.

A downstream suite that establishes `tenant_override` in a global `config.around` hook is hit by #2 regardless of this PR — `config.around` wraps outside the rspec-rails reset. The fix for that is to establish tenant context in `before(:each)`, documented in a separate `docs/testing.md` update. **This PR does not, on its own, resolve a `with_tenants`-in-`config.around` flake.**

It is still correct and necessary on its own merits: `reset_tenant_pools!` should not touch `Current`, and removing the blanket reset matters for `with_tenants` used in a `before(:each)` and for any manual `reset_tenant_pools!` call.

## Changes

- **`lib/apartment.rb`** — `reset_tenant_pools!` no longer calls `Apartment::Current.reset`. Docstring rewritten: it previously promised "tenant context is also reset", so this is a deliberate **contract narrowing** (see release-note callout below). Callers that also want tenant context cleared do so explicitly via `Apartment::Tenant.reset`.
- **`lib/apartment/current.rb`** — policy comment added: do not call bare `reset` from domain/lifecycle methods; it clears every attribute, so adding one silently widens every call site. `reset` belongs at execution boundaries only (Rails executor, test teardown).
- **`spec/unit/apartment_spec.rb`** — new `.reset_tenant_pools!` group: one test asserts a `with_tenants` override survives the call (the exact downstream failure, reproduced), one asserts `Current` tenant context is left intact. Both fail against the old behavior.
- **`spec/integration/v4/fixture_pool_lifecycle_spec.rb`** — sixth example drives the real around-hook → setup_fixtures → reset_tenant_pools! chain and asserts a `with_tenants` override survives.

## Release note (next alpha)

Behavior change to a public method: `Apartment.reset_tenant_pools!` no longer resets `Apartment::Current`. A consumer that relied on it also dropping them back to the default tenant should call `Apartment::Tenant.reset` explicitly. In a Rails test env the executor already resets `CurrentAttributes` per example, so most suites are unaffected.

## Test plan

- [x] `bundle exec rspec spec/unit/` — 742 examples, 0 failures (TDD: the 2 new tests fail on `main`, pass here)
- [x] `bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/fixture_pool_lifecycle_spec.rb spec/integration/v4/with_tenants_each_routing_spec.rb spec/integration/v4/fixture_pin_visibility_spec.rb` — 17 examples, 0 failures
- [x] `bundle exec rubocop lib/apartment.rb lib/apartment/current.rb spec/unit/apartment_spec.rb spec/integration/v4/fixture_pool_lifecycle_spec.rb` — clean
- [x] CI: all 42 matrix jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)