### PR TITLE
Elevator tenant validation & not-found handling

### DIFF
--- a/docs/designs/apartment-v4.md
+++ b/docs/designs/apartment-v4.md
@@ -305,7 +305,7 @@ Apartment.configure do |config|
   # config.elevator = Apartment::Elevators::Header
   # config.elevator_options = { header: "X-Tenant-Id", trusted: true }
 
-  # Tenant-not-found handling
+  # Tenant-not-found handling — see docs/designs/elevator-tenant-validation.md
   config.tenant_not_found_handler = ->(tenant, request) {
     [404, {}, ["Tenant not found"]]
   }
@@ -694,7 +694,7 @@ Apartment::ApartmentError               # Base class
 
 ### Elevator Error Handling
 
-- **Tenant not found** (elevator resolves a tenant name that doesn't exist): Calls `config.tenant_not_found_handler` if configured. Default behavior: raises `Apartment::TenantNotFound`.
+- **Tenant not found** (elevator resolves a tenant name that is not a real tenant): the elevator validates the resolved name via `config.tenant_validator` (a built-in in-process validator by default) before switching. An unknown tenant is routed through `config.tenant_not_found_handler` if configured, otherwise `Apartment::TenantNotFound` is raised and the railtie maps it to a 404. See `docs/designs/elevator-tenant-validation.md`.
 - **Elevator raises**: Exception propagates to Rack error handling. No tenant context is set.
 
 ## Generator

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -99,12 +99,16 @@ a database query.
 - **Rebuild-on-miss — rate-limited and single-flight.** A name absent from the
   set triggers a rebuild from the source, *at most once per rebuild interval* (a
   flood of distinct unknown names cannot hammer `tenants_provider`) and
-  *single-flight* (a mutex; one thread rebuilds, concurrent callers use the
-  current set rather than piling on). A tenant created out of band — by another
-  process, or direct SQL — heals on the first request that names it, within the
-  rebuild interval. There is **no negative cache**: the rate limit already bounds
-  source calls, and a cache of arbitrary unknown names is an unbounded-memory /
-  DoS vector for no benefit.
+  *single-flight* (a mutex; one thread rebuilds). The **first build is
+  blocking** — concurrent callers wait for it, since there is no usable current
+  set to fall back on yet; a non-blocking first build would evaluate against the
+  empty initial set and 404 a valid tenant. Later refreshes are non-blocking: a
+  caller that loses the lock uses the still-valid current set and rechecks on its
+  next request. A tenant created out of band — by another process, or direct
+  SQL — heals on the first request that names it, within the rebuild interval.
+  There is **no negative cache**: the rate limit already bounds source calls, and
+  a cache of arbitrary unknown names is an unbounded-memory / DoS vector for no
+  benefit.
 - **Positive-set TTL** — the set is also rebuilt after a TTL even absent a miss;
   the backstop for out-of-band *drops* (a dropped name stays valid until the next
   rebuild — rebuild-on-miss only heals creates, not drops).
@@ -114,9 +118,14 @@ a database query.
   `drop` is hooked via a new `:drop` callback or the existing `drop.apartment`
   `ActiveSupport::Notifications` event. In-process create/drop is immediate;
   cross-process changes heal via rebuild-on-miss (creates) or the TTL (drops).
+  A create/drop that lands *during* a rebuild is captured and re-applied to the
+  freshly built set, so the whole-set swap never silently discards it.
 - **Thread-safety** — the registry is process-global and read on every request
-  across threads; backed by `concurrent-ruby` (or an atomic whole-set swap on
-  rebuild). Timestamps use `Process.clock_gettime(Process::CLOCK_MONOTONIC)`,
+  across threads. The positive set is a `concurrent-ruby` set; a rebuild swaps
+  in a whole new set under a state mutex, re-applying lifecycle deltas captured
+  during the (unlocked) provider call. The built-in validator is itself memoized
+  behind a mutex, so concurrent first access cannot construct (and leak) more
+  than one. Timestamps use `Process.clock_gettime(Process::CLOCK_MONOTONIC)`,
   consistent with `PoolManager`/`PoolReaper`.
 - **Fail-open on source error** — if `tenants_provider` raises during a build,
   the validator allows the request (today's behavior) rather than blanket-404ing

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -125,12 +125,14 @@ a database query.
   scheduler as well as under threads, and every lock is released by the fiber
   that took it. Timestamps use `Process.clock_gettime(Process::CLOCK_MONOTONIC)`,
   consistent with `PoolManager`/`PoolReaper`.
-- **Fail-open on source error** — if `tenants_provider` raises during a build,
-  the validator allows the request rather than blanket-404ing the app (also
-  correct at boot, before the tenant table exists). A raising provider means
-  validation has silently degraded, so it is logged at `error` for operators to
-  alert on. A *successful* provider call that simply does not contain the name is
-  a real miss → 404.
+- **Fail-open on source error** — if `tenants_provider` raises, *or returns a
+  non-Enumerable* (e.g. `nil` from a misconfigured provider), the validator
+  degrades: it allows every request rather than blanket-404ing the app, logged
+  at `error` for operators to alert on. (Also correct at boot, before the tenant
+  table exists.) A *successful* call returning an Enumerable that does not list
+  the name is a real miss → 404 — including an empty `[]`, the right answer for a
+  fresh install with no tenants. The `nil`-vs-`[]` distinction is deliberate:
+  `[]` is "zero tenants," `nil` is "the provider didn't answer."
 
 Defaults: positive-set TTL ~5 minutes, rebuild interval ~5–10s; both configurable.
 
@@ -221,7 +223,8 @@ note in `docs/upgrading-to-v4.md`. Apps depending on the old behavior set
   heals a name added to the source, rebuild-on-miss is rate-limited (a second
   miss inside the interval does not re-hit the source), single-flight (concurrent
   misses trigger one rebuild), positive-set TTL refresh, `Tenant.create`/`drop`
-  lifecycle invalidation, fail-open when `tenants_provider` raises. The
+  lifecycle invalidation, fail-open when `tenants_provider` raises or returns a
+  non-Enumerable (and an empty `[]` is *not* a failure — it 404s). The
   validator's registry is process-global, so its specs reset it per example
   (mirroring the pinned-model registry pattern documented in `spec/CLAUDE.md`).
 - **Unit — `Generic`/elevators**: valid name → `switch`; invalid → handler called

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -87,47 +87,79 @@ own reasons is never swallowed.
 
 ### Built-in validator
 
-`Apartment::TenantValidator` — a memoized registry, not a per-request
-`tenants_provider` call. `tenants_provider` is the *source* of tenant names; it
-may be a database query and must never run on every request.
+`Apartment::TenantValidator` — a process-local memoized registry. It never calls
+`tenants_provider` per request; that callable is the *source* of names and may be
+a database query.
 
-- **Positive set** — a `Set` of valid tenant names, built lazily from
-  `Apartment.tenant_names` on first use.
-- **Negative cache** — names recently found invalid, with a short TTL. Without
-  it, an attacker looping `random1.example.com`, `random2…` misses the positive
-  set every time and hits the tenant source per junk request; the negative cache
-  bounds that to one lookup per name per TTL window.
-- **Positive-set TTL** — the positive set is rebuilt after a TTL elapses, a
-  safety net for tenants created or dropped out of band (another process, direct
-  SQL) that the in-process callbacks below never observed.
-- **Lifecycle invalidation** — the validator updates its set when a tenant is
-  created or dropped through `Apartment::Tenant`, via the adapter's lifecycle
-  callbacks. A create/drop *in this process* updates the set immediately;
-  out-of-band changes heal on the TTL. (`:create` is an existing adapter
-  callback; a `:drop` hook is added if one does not already exist.)
+- **Positive set** — a thread-safe `Set` of valid tenant names, built lazily on
+  first use from `config.tenants_provider` directly. Not via
+  `Apartment.tenant_names`, which honors the per-block `with_tenants` override —
+  the process-global registry must reflect the configured provider, not a
+  block-scoped (test) override.
+- **Rebuild-on-miss — rate-limited and single-flight.** A name absent from the
+  set triggers a rebuild from the source, *at most once per rebuild interval* (a
+  flood of distinct unknown names cannot hammer `tenants_provider`) and
+  *single-flight* (a mutex; one thread rebuilds, concurrent callers use the
+  current set rather than piling on). A tenant created out of band — by another
+  process, or direct SQL — heals on the first request that names it, within the
+  rebuild interval. There is **no negative cache**: the rate limit already bounds
+  source calls, and a cache of arbitrary unknown names is an unbounded-memory /
+  DoS vector for no benefit.
+- **Positive-set TTL** — the set is also rebuilt after a TTL even absent a miss;
+  the backstop for out-of-band *drops* (a dropped name stays valid until the next
+  rebuild — rebuild-on-miss only heals creates, not drops).
+- **Lifecycle invalidation** — the set is updated when a tenant is created or
+  dropped through `Apartment::Tenant`, *after* the operation succeeds: created
+  names added, dropped names removed. `:create` is an existing adapter callback;
+  `drop` is hooked via a new `:drop` callback or the existing `drop.apartment`
+  `ActiveSupport::Notifications` event. In-process create/drop is immediate;
+  cross-process changes heal via rebuild-on-miss (creates) or the TTL (drops).
 - **Thread-safety** — the registry is process-global and read on every request
-  across threads; backed by `concurrent-ruby` structures. Timestamps use
-  `Process.clock_gettime(Process::CLOCK_MONOTONIC)`, consistent with
-  `PoolManager`/`PoolReaper`.
-- **Fail-open on source error** — if `tenants_provider` raises while the set is
-  being built (e.g. the tenant table does not exist yet during initial setup),
-  the validator logs a warning and treats the request as valid (the switch
-  proceeds — today's behavior). Validation is a UX improvement; a flaky tenant
-  source must not brick the whole application with blanket 404s. A *successful*
-  provider call that simply does not contain the name is a real miss → 404.
+  across threads; backed by `concurrent-ruby` (or an atomic whole-set swap on
+  rebuild). Timestamps use `Process.clock_gettime(Process::CLOCK_MONOTONIC)`,
+  consistent with `PoolManager`/`PoolReaper`.
+- **Fail-open on source error** — if `tenants_provider` raises during a build,
+  the validator allows the request (today's behavior) rather than blanket-404ing
+  the app. Correct at boot (the tenant table may not exist yet during
+  `db:migrate`); in a running app a raising provider means validation silently
+  degrades, so it is logged at `error` outside the setup phase, and operators
+  should alert on it. A *successful* provider call that simply does not contain
+  the name is a real miss → 404.
 
-TTL defaults: positive set 60s, negative cache 10s (negative kept short so a
-genuinely new tenant is not rejected for long). Both configurable on the
-validator.
+Defaults: positive-set TTL ~5 minutes (only the drop / out-of-band backstop —
+rebuild-on-miss handles creates); rebuild interval ~5–10s. Both configurable.
+
+### Multi-process deployments
+
+The registry is per-process. With several app processes or containers, a
+`Tenant.create` in one process does not reach the others' registries directly —
+but rebuild-on-miss heals it: the first request naming the new tenant on any
+process rebuilds that process's set. A *dropped* tenant lingers in other
+processes' sets until their TTL; a request to it in that window degrades to the
+pre-existing behavior (a database error), not a data leak.
+
+The gem ships **no cache backend** and stores nothing globally. An app needing
+strict cross-process consistency plugs a custom `tenant_validator` — backed by a
+**dedicated, un-namespaced store**. Tenant validity is *global* data; multi-tenant
+apps commonly namespace `Rails.cache` per tenant (so one tenant's cached values
+cannot be read in another's context), and routing global registry data through
+such a cache fragments it across tenant namespaces — a category error. A shared
+validator should use a dedicated keyspace keyed purely by tenant name:
+`Rails.cache` only if it is *not* tenant-namespaced, otherwise a separate cache
+instance or store. If strict, immediate cross-process *drop* enforcement is a
+requirement, that custom validator (with its own pub/sub or version key) is the
+mechanism — the in-process default does not guarantee it.
 
 ### Configuration
 
 ```ruby
 Apartment.configure do |config|
   # Validation (on by default — uses the built-in TenantValidator):
-  #   config.tenant_validator = false                      # disable entirely
-  #   config.tenant_validator = ->(name) { Account.exists?(subdomain: name) }  # custom
-  #   config.tenant_validator = Apartment::TenantValidator.new(positive_ttl: 300)
+  #   config.tenant_validator = false   # disable entirely
+  #   config.tenant_validator = Apartment::TenantValidator.new(positive_ttl: 600)
+  #   # custom — note a bare callable runs on EVERY request, so it must do its
+  #   # own memoizing / caching; do not put an unmemoized DB query here:
+  #   config.tenant_validator = MyTenantValidator.new
 
   # Response on a miss (default: raise Apartment::TenantNotFound):
   #   config.tenant_not_found_handler = ->(tenant, request) {
@@ -193,12 +225,13 @@ entry. Apps depending on the old behavior set `config.tenant_validator = false`.
 
 ## Testing
 
-- **Unit — `TenantValidator`**: positive-set hit, negative-cache hit, lazy build,
-  positive-set TTL refresh, negative-cache TTL expiry, `Tenant.create`/`drop`
-  lifecycle invalidation, fail-open when `tenants_provider` raises,
-  thread-safety smoke. The validator's registry is process-global, so its specs
-  reset it per example (mirroring the pinned-model registry pattern documented
-  in `spec/CLAUDE.md`).
+- **Unit — `TenantValidator`**: positive-set hit, lazy build, rebuild-on-miss
+  heals a name added to the source, rebuild-on-miss is rate-limited (a second
+  miss inside the interval does not re-hit the source), single-flight (concurrent
+  misses trigger one rebuild), positive-set TTL refresh, `Tenant.create`/`drop`
+  lifecycle invalidation, fail-open when `tenants_provider` raises. The
+  validator's registry is process-global, so its specs reset it per example
+  (mirroring the pinned-model registry pattern documented in `spec/CLAUDE.md`).
 - **Unit — `Generic`/elevators**: valid name → `switch`; invalid → handler called
   with `(name, request)`; invalid + no handler → raises `TenantNotFound`; `nil`
   name → no switch; `default_tenant` → valid; `HostHash` miss → handler path.
@@ -235,3 +268,14 @@ entry. Apps depending on the old behavior set `config.tenant_validator = false`.
 - **Bare `[404, {}, …]` from the gem** — rejected in favor of raise +
   `rescue_responses` mapping, so the app's own 404 page renders instead of a
   gem-rendered body.
+- **`Rails.cache`-backed validator as the built-in default** — rejected (a
+  four-model panel review was unanimous). It puts a network round-trip on every
+  request, couples each request to cache availability, `Rails.cache` is not
+  guaranteed to be a shared store, and — most concretely — multi-tenant apps
+  commonly namespace `Rails.cache` per tenant, which is the wrong home for global
+  registry data. A shared cache stays available through the `tenant_validator`
+  seam for apps that opt in; see [Multi-process deployments](#multi-process-deployments).
+- **A negative cache of confirmed-invalid names** — rejected. Once rebuild-on-miss
+  is rate-limited, the rate limit alone bounds `tenants_provider` calls; a cache
+  keyed by arbitrary unknown names adds no protection and is itself an
+  unbounded-memory / DoS vector.

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -120,12 +120,15 @@ a database query.
   cross-process changes heal via rebuild-on-miss (creates) or the TTL (drops).
   A create/drop that lands *during* a rebuild is captured and re-applied to the
   freshly built set, so the whole-set swap never silently discards it.
-- **Thread-safety** — the registry is process-global and read on every request
-  across threads. The positive set is a `concurrent-ruby` set; a rebuild swaps
-  in a whole new set under a state mutex, re-applying lifecycle deltas captured
-  during the (unlocked) provider call. The built-in validator is itself memoized
-  behind a mutex, so concurrent first access cannot construct (and leak) more
-  than one. Timestamps use `Process.clock_gettime(Process::CLOCK_MONOTONIC)`,
+- **Thread- and fiber-safety** — the registry is process-global and read on
+  every request across threads and fibers. The positive set is a
+  `concurrent-ruby` set; a rebuild swaps in a whole new set under a state mutex,
+  re-applying lifecycle deltas captured during the (unlocked) provider call. The
+  built-in validator is itself memoized behind a mutex, so concurrent first
+  access cannot construct (and leak) more than one. `Mutex` is owned per-fiber
+  (Ruby 3.0+; apartment requires ≥ 3.3), so single-flight holds under a fiber
+  scheduler as well as under threads, and every lock is released by the fiber
+  that took it. Timestamps use `Process.clock_gettime(Process::CLOCK_MONOTONIC)`,
   consistent with `PoolManager`/`PoolReaper`.
 - **Fail-open on source error** — if `tenants_provider` raises during a build,
   the validator allows the request (today's behavior) rather than blanket-404ing
@@ -288,3 +291,15 @@ entry. Apps depending on the old behavior set `config.tenant_validator = false`.
   is rate-limited, the rate limit alone bounds `tenants_provider` calls; a cache
   keyed by arbitrary unknown names adds no protection and is itself an
   unbounded-memory / DoS vector.
+- **The positive set in `ActiveSupport::CurrentAttributes` (a `Current` bag)** —
+  rejected as a category error. `CurrentAttributes` is *request-scoped*: Rails
+  resets it before and after every request and job. The registry is the
+  opposite — long-lived process infrastructure, and that persistence across
+  requests is exactly what lets it avoid re-querying `tenants_provider` each
+  time. A `Current` bag would wipe the set every request, collapsing the
+  memoized cache back into a per-request DB query — the failure mode the design
+  exists to remove. `CurrentAttributes` is the right home for the *current
+  tenant* (`Apartment::Current` — per-request execution context); the *set of
+  all valid tenants* is shared global data. Process-global state behind a
+  `Mutex` and `concurrent-ruby` structures is the correct shape, matching
+  `PoolManager`'s `Concurrent::Map` and the `pinned_models` `Concurrent::Set`.

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -177,6 +177,27 @@ keyspace keyed purely by tenant name. Strict, immediate cross-process *drop*
 enforcement specifically needs that custom validator (with its own pub/sub or
 version key); the in-process default does not guarantee it.
 
+### When to disable validation
+
+Set `config.tenant_validator = false` when your elevator already rejects unknown
+tenants against the same source the validator would query. The common shape:
+a `Generic` / `Subdomain` / `FirstSubdomain` subclass whose `parse_tenant_name`
+filters against a shared cache of valid names (e.g., a Redis-backed lookup
+invalidated by the app's own model lifecycle hooks). In that setup, the
+validator only rubber-stamps what the parser already accepted, and the
+rebuild-on-miss / TTL machinery costs a `tenants_provider` call the parser
+already made.
+
+The same shape often pairs with a custom `tenant_not_found_handler` (or a
+direct rescue inside the elevator subclass) that returns a redirect or a
+branded page instead of a 404 — so the railtie's `TenantNotFound -> :not_found`
+mapping is also unused. Both seams are independent: an app can keep validation
+and override only the handler, or vice versa.
+
+Keep the defaults when the elevator does *not* pre-filter (stock `Generic` /
+`Subdomain` and friends) — the validator is the only thing standing between an
+unknown subdomain and an opaque 500.
+
 ### Configuration
 
 ```ruby

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -1,0 +1,237 @@
+# Elevator Tenant Validation & Not-Found Handling
+
+Status: draft. Living doc — updated in place as the feature lands.
+
+## TLDR
+
+Elevators switch to whatever tenant name they resolve, with no check that the
+tenant exists. An unknown or typo'd subdomain switches into a non-existent
+schema, and a raw database error surfaces deep in the first query as an opaque
+500. This design adds two pluggable seams to `Generic#call`: a `tenant_validator`
+("is this a real tenant?") and the existing-but-dead `tenant_not_found_handler`
+("what response on a miss?"). A built-in memoized validator runs **on by
+default**; an unknown tenant raises `Apartment::TenantNotFound`, which the
+railtie maps to `:not_found` so the app's own 404 page renders with zero config.
+
+## Problem
+
+`Apartment::Elevators::Generic#call` resolves a tenant name from the request and
+calls `Apartment::Tenant.switch(name) { @app.call }` **unconditionally**. Nothing
+verifies that `name` is a real tenant.
+
+`Tenant.switch` only sets `Current.tenant`; the actual database work happens
+later, when ActiveRecord asks for a connection pool. So an unknown tenant fails
+late and opaquely: a `PG`/adapter error (often re-wrapped as a generic
+`Apartment::ApartmentError`) surfaces mid-request and the app returns a 500 that
+looks like a database fault, not a routing miss.
+
+Two pieces meant to address this already exist but are inert:
+
+- `config.tenant_not_found_handler` — a `Config` accessor (defaults to `nil`),
+  **wired nowhere**.
+- The v4 design docs describe the intended behavior but **contradict each other**
+  on the layer: `apartment-v4.md` says the elevator calls the handler when it
+  resolves a name that doesn't exist; `v4-elevators.md` calls
+  `tenant_not_found_handler` "an adapter-level hook, not a middleware-level one."
+  The handler's own shape — `->(tenant, request) { [status, headers, body] }`,
+  taking a request and returning a Rack response — settles it: this is
+  middleware-level. This design treats `v4-elevators.md`'s line as the error and
+  resolves it (see [Resolving the doc contradiction](#resolving-the-doc-contradiction)).
+
+Apartment has never validated tenants in the elevator, in v3 or v4. Consumers
+hand-roll "rescued tenant elevator" subclasses that override `call` and rescue.
+
+## Design
+
+### Two seams
+
+The fix is two pluggable hooks in `Generic#call`, between *resolve* and *switch*:
+
+| Config | Shape | Question it answers | Default |
+|---|---|---|---|
+| `tenant_validator` | `->(tenant_name) { true \| false }` | Is this a real tenant? | built-in validator (on) |
+| `tenant_not_found_handler` | `->(tenant, request) { [status, headers, body] }` | What response on a miss? | `nil` → raise `TenantNotFound` |
+
+The validator is **name-only** by deliberate design: resolving a tenant from
+request context (header, custom domain, SSO param) is already `parse_tenant_name`'s
+job. The validator answers a narrower question — given a resolved name, is it a
+tenant — and keeping it name-only makes it trivially cacheable and reusable
+outside a request.
+
+### `Generic#call` flow
+
+```
+request → parse_tenant_name
+            │
+            ├─ nil  ──────────────→ @app.call            (no switch; default tenant — unchanged)
+            │
+            └─ name → tenant_valid?(name)
+                         ├─ true  → Tenant.switch(name) { @app.call }
+                         └─ false → handle_tenant_not_found(name, request)
+```
+
+`handle_tenant_not_found` calls `config.tenant_not_found_handler` if configured
+(returning its Rack response), otherwise raises `Apartment::TenantNotFound`.
+
+`tenant_valid?` consults `config.tenant_validator`: `false` disables validation
+(every name passes — today's behavior); a callable is invoked; the default
+built-in validator is used when unset. The default tenant is always treated as
+valid — it is not an isolated tenant subject to the registry.
+
+A `TenantNotFound` raised *during tenant resolution itself* — `HostHash` raises
+it from `parse_tenant_name` on an unmapped host — is caught **narrowly around the
+`@processor.call`** and routed through the same `handle_tenant_not_found` path,
+so every elevator's not-found case flows through one handler. The rescue does
+**not** wrap `@app.call`; a `TenantNotFound` raised by the application for its
+own reasons is never swallowed.
+
+### Built-in validator
+
+`Apartment::TenantValidator` — a memoized registry, not a per-request
+`tenants_provider` call. `tenants_provider` is the *source* of tenant names; it
+may be a database query and must never run on every request.
+
+- **Positive set** — a `Set` of valid tenant names, built lazily from
+  `Apartment.tenant_names` on first use.
+- **Negative cache** — names recently found invalid, with a short TTL. Without
+  it, an attacker looping `random1.example.com`, `random2…` misses the positive
+  set every time and hits the tenant source per junk request; the negative cache
+  bounds that to one lookup per name per TTL window.
+- **Positive-set TTL** — the positive set is rebuilt after a TTL elapses, a
+  safety net for tenants created or dropped out of band (another process, direct
+  SQL) that the in-process callbacks below never observed.
+- **Lifecycle invalidation** — the validator updates its set when a tenant is
+  created or dropped through `Apartment::Tenant`, via the adapter's lifecycle
+  callbacks. A create/drop *in this process* updates the set immediately;
+  out-of-band changes heal on the TTL. (`:create` is an existing adapter
+  callback; a `:drop` hook is added if one does not already exist.)
+- **Thread-safety** — the registry is process-global and read on every request
+  across threads; backed by `concurrent-ruby` structures. Timestamps use
+  `Process.clock_gettime(Process::CLOCK_MONOTONIC)`, consistent with
+  `PoolManager`/`PoolReaper`.
+- **Fail-open on source error** — if `tenants_provider` raises while the set is
+  being built (e.g. the tenant table does not exist yet during initial setup),
+  the validator logs a warning and treats the request as valid (the switch
+  proceeds — today's behavior). Validation is a UX improvement; a flaky tenant
+  source must not brick the whole application with blanket 404s. A *successful*
+  provider call that simply does not contain the name is a real miss → 404.
+
+TTL defaults: positive set 60s, negative cache 10s (negative kept short so a
+genuinely new tenant is not rejected for long). Both configurable on the
+validator.
+
+### Configuration
+
+```ruby
+Apartment.configure do |config|
+  # Validation (on by default — uses the built-in TenantValidator):
+  #   config.tenant_validator = false                      # disable entirely
+  #   config.tenant_validator = ->(name) { Account.exists?(subdomain: name) }  # custom
+  #   config.tenant_validator = Apartment::TenantValidator.new(positive_ttl: 300)
+
+  # Response on a miss (default: raise Apartment::TenantNotFound):
+  #   config.tenant_not_found_handler = ->(tenant, request) {
+  #     [302, { 'Location' => 'https://example.com' }, []]
+  #   }
+end
+```
+
+`tenant_validator`: `nil` (unset) → built-in validator; `false` → validation
+disabled; a callable (or any object responding to `call`) → used as-is.
+
+### Railtie
+
+The railtie registers:
+
+```ruby
+ActionDispatch::ExceptionWrapper.rescue_responses['Apartment::TenantNotFound'] = :not_found
+```
+
+So when no `tenant_not_found_handler` is configured, an unknown tenant raises
+`TenantNotFound`, and Rails renders the application's own 404 (`public/404.html`
+or its dynamic equivalent) — zero config, the app's real error page, and the
+exception stays honest and catchable. An app can override the mapping or set a
+handler for a custom response.
+
+### Scope
+
+The check lives in `Generic`, so every name-resolving elevator inherits it:
+`Subdomain`, `FirstSubdomain`, `Domain`, `Host`, `Header`. `HostHash` already
+raises `TenantNotFound` on an unmapped host; it is routed through the same
+handler (above) rather than left as a parallel path.
+
+## Edge cases
+
+- **`parse_tenant_name` returns `nil`** (no subdomain, excluded subdomain) — no
+  switch, request runs in the default tenant. Unchanged; not a not-found case.
+- **Resolved name equals `default_tenant`** — always valid; never sent to the
+  registry.
+- **Malformed name** — a structurally invalid name simply is not in the valid
+  set → treated as not-found (404). No separate 400 path; format validation
+  remains the adapter's concern (`TenantNameValidator`).
+- **Known tenant, database unavailable** — not a not-found case. The validator
+  passes (the name is valid); a genuine connection error surfaces as before.
+  Validation does not mask infrastructure failure.
+- **`Header` elevator** — validation confirms a resolved header value is a real
+  tenant; it does **not** establish trust. Header trust remains infrastructure's
+  responsibility (`trusted:` option).
+
+## Resolving the doc contradiction
+
+`docs/designs/v4-elevators.md` and `docs/designs/apartment-v4.md` are updated so
+both describe the elevator-level handler consistently. `v4-elevators.md`'s "Error
+Handling" section — currently stating Generic does not rescue and the handler is
+adapter-level — is rewritten to describe the `tenant_validator` /
+`tenant_not_found_handler` seams.
+
+## Breaking change
+
+On-by-default validation changes observable behavior: an unknown subdomain that
+previously produced a deep 500 now produces `TenantNotFound` → 404. v4 is in the
+alpha line, where behavior changes are expected; this ships with a CHANGELOG
+entry. Apps depending on the old behavior set `config.tenant_validator = false`.
+
+## Testing
+
+- **Unit — `TenantValidator`**: positive-set hit, negative-cache hit, lazy build,
+  positive-set TTL refresh, negative-cache TTL expiry, `Tenant.create`/`drop`
+  lifecycle invalidation, fail-open when `tenants_provider` raises,
+  thread-safety smoke. The validator's registry is process-global, so its specs
+  reset it per example (mirroring the pinned-model registry pattern documented
+  in `spec/CLAUDE.md`).
+- **Unit — `Generic`/elevators**: valid name → `switch`; invalid → handler called
+  with `(name, request)`; invalid + no handler → raises `TenantNotFound`; `nil`
+  name → no switch; `default_tenant` → valid; `HostHash` miss → handler path.
+- **Unit — railtie**: `rescue_responses['Apartment::TenantNotFound']` registered.
+- **Integration** (`spec/integration/v4/`): request to an unknown subdomain →
+  404 (not 500); custom `tenant_not_found_handler` → its response; disabled
+  validator → switch proceeds.
+
+## Out of scope
+
+- **Multi-source tenant resolution** (header / custom domain / SSO param) — that
+  is `parse_tenant_name`'s job and already customizable by subclassing.
+- **Validating programmatic `Tenant.switch('typo')`** — `switch` stays a thin
+  context-setter usable from jobs, console, rake, and migrations; it is not made
+  HTTP-aware or globally-validating. This feature is request-path only.
+- **Distributed / shared-process cache** — the built-in cache is per-process.
+  Apps needing cross-process invalidation plug a custom `tenant_validator`
+  backed by their own cache.
+
+## Alternatives considered
+
+- **Validate inside `Tenant.switch`** — rejected. `switch` is used by non-request
+  code (jobs, console, rake, migrations); making it validate globally or carry
+  HTTP concerns is the wrong layer and would surprise non-request callers.
+- **Validate in the adapter / on pool creation** — rejected. The database is the
+  ground truth, but this preserves the "fail on first query" timing and has no
+  Rack request for a redirect or rendered response.
+- **Opt-in validator (default off)** — rejected. The gem's default experience
+  would stay broken; the opaque 500 persists for anyone who does not opt in.
+- **Unknown subdomain falls through to the default tenant** — rejected as a
+  *default*. Silently serving the default tenant for a typo'd or hostile
+  subdomain is a data-exposure footgun. It remains available to apps that want
+  it via a `tenant_not_found_handler` that returns the default-tenant response.
+- **Bare `[404, {}, …]` from the gem** — rejected in favor of raise +
+  `rescue_responses` mapping, so the app's own 404 page renders instead of a
+  gem-rendered body.

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -136,6 +136,29 @@ a database query.
 
 Defaults: positive-set TTL ~5 minutes, rebuild interval ~5–10s; both configurable.
 
+### External schema provisioning
+
+`Apartment::Tenant.create` / `.drop` publish `create.apartment` / `drop.apartment`
+themselves, so the in-process validator picks them up for free. Apps that
+provision tenants through some other path — raw `psql`, `pg_restore`, a separate
+schema-cloning job, an out-of-band migration tool — bypass that publication and
+fall back to rebuild-on-miss latency (one extra `tenants_provider` call per
+process on the new tenant's first hit; *drops* linger until the TTL).
+
+For zero-delay propagation in that case, instrument the matching event after
+the schema is live:
+
+```ruby
+Apartment::Lifecycle.notify_created('acme')   # after the schema/db exists
+Apartment::Lifecycle.notify_dropped('acme')   # after it's gone
+```
+
+These are thin wrappers over `ActiveSupport::Notifications.instrument` with the
+event names the validator already subscribes to; calling them when the
+lifecycle *did* go through `Apartment::Tenant` is redundant but harmless. They
+are in-process only — multi-process propagation is still the next section's
+problem.
+
 ### Multi-process deployments
 
 The registry is per-process. With several app processes or containers, a

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -35,8 +35,7 @@ Two pieces meant to address this already exist but are inert:
   `tenant_not_found_handler` "an adapter-level hook, not a middleware-level one."
   The handler's own shape — `->(tenant, request) { [status, headers, body] }`,
   taking a request and returning a Rack response — settles it: this is
-  middleware-level. This design treats `v4-elevators.md`'s line as the error and
-  resolves it (see [Resolving the doc contradiction](#resolving-the-doc-contradiction)).
+  middleware-level, and `v4-elevators.md`'s contradicting line is corrected.
 
 Apartment has never validated tenants in the elevator, in v3 or v4. Consumers
 hand-roll "rescued tenant elevator" subclasses that override `call` and rescue.
@@ -75,8 +74,7 @@ request → parse_tenant_name
 
 `tenant_valid?` consults `config.tenant_validator`: `false` disables validation
 (every name passes — today's behavior); a callable is invoked; the default
-built-in validator is used when unset. The default tenant is always treated as
-valid — it is not an isolated tenant subject to the registry.
+built-in validator is used when unset.
 
 A `TenantNotFound` raised *during tenant resolution itself* — `HostHash` raises
 it from `parse_tenant_name` on an unmapped host — is caught **narrowly around the
@@ -106,9 +104,6 @@ a database query.
   caller that loses the lock uses the still-valid current set and rechecks on its
   next request. A tenant created out of band — by another process, or direct
   SQL — heals on the first request that names it, within the rebuild interval.
-  There is **no negative cache**: the rate limit already bounds source calls, and
-  a cache of arbitrary unknown names is an unbounded-memory / DoS vector for no
-  benefit.
 - **Positive-set TTL** — the set is also rebuilt after a TTL even absent a miss;
   the backstop for out-of-band *drops* (a dropped name stays valid until the next
   rebuild — rebuild-on-miss only heals creates, not drops).
@@ -131,15 +126,13 @@ a database query.
   that took it. Timestamps use `Process.clock_gettime(Process::CLOCK_MONOTONIC)`,
   consistent with `PoolManager`/`PoolReaper`.
 - **Fail-open on source error** — if `tenants_provider` raises during a build,
-  the validator allows the request (today's behavior) rather than blanket-404ing
-  the app. Correct at boot (the tenant table may not exist yet during
-  `db:migrate`); in a running app a raising provider means validation silently
-  degrades, so it is logged at `error` outside the setup phase, and operators
-  should alert on it. A *successful* provider call that simply does not contain
-  the name is a real miss → 404.
+  the validator allows the request rather than blanket-404ing the app (also
+  correct at boot, before the tenant table exists). A raising provider means
+  validation has silently degraded, so it is logged at `error` for operators to
+  alert on. A *successful* provider call that simply does not contain the name is
+  a real miss → 404.
 
-Defaults: positive-set TTL ~5 minutes (only the drop / out-of-band backstop —
-rebuild-on-miss handles creates); rebuild interval ~5–10s. Both configurable.
+Defaults: positive-set TTL ~5 minutes, rebuild interval ~5–10s; both configurable.
 
 ### Multi-process deployments
 
@@ -150,17 +143,14 @@ process rebuilds that process's set. A *dropped* tenant lingers in other
 processes' sets until their TTL; a request to it in that window degrades to the
 pre-existing behavior (a database error), not a data leak.
 
-The gem ships **no cache backend** and stores nothing globally. An app needing
-strict cross-process consistency plugs a custom `tenant_validator` — backed by a
-**dedicated, un-namespaced store**. Tenant validity is *global* data; multi-tenant
-apps commonly namespace `Rails.cache` per tenant (so one tenant's cached values
-cannot be read in another's context), and routing global registry data through
-such a cache fragments it across tenant namespaces — a category error. A shared
-validator should use a dedicated keyspace keyed purely by tenant name:
-`Rails.cache` only if it is *not* tenant-namespaced, otherwise a separate cache
-instance or store. If strict, immediate cross-process *drop* enforcement is a
-requirement, that custom validator (with its own pub/sub or version key) is the
-mechanism — the in-process default does not guarantee it.
+The gem ships **no cache backend**. An app needing strict cross-process
+consistency plugs a custom `tenant_validator` backed by a **dedicated,
+un-namespaced store**. Tenant validity is *global* data, so it must not go
+through a `Rails.cache` that is namespaced per tenant (a common multi-tenant
+setup) — that fragments one global registry across tenant namespaces. Use a
+keyspace keyed purely by tenant name. Strict, immediate cross-process *drop*
+enforcement specifically needs that custom validator (with its own pub/sub or
+version key); the in-process default does not guarantee it.
 
 ### Configuration
 
@@ -180,9 +170,6 @@ Apartment.configure do |config|
 end
 ```
 
-`tenant_validator`: `nil` (unset) → built-in validator; `false` → validation
-disabled; a callable (or any object responding to `call`) → used as-is.
-
 ### Railtie
 
 The railtie registers:
@@ -199,10 +186,10 @@ handler for a custom response.
 
 ### Scope
 
-The check lives in `Generic`, so every name-resolving elevator inherits it:
-`Subdomain`, `FirstSubdomain`, `Domain`, `Host`, `Header`. `HostHash` already
-raises `TenantNotFound` on an unmapped host; it is routed through the same
-handler (above) rather than left as a parallel path.
+The check lives in `Generic`, so all six elevators inherit it: `Subdomain`,
+`FirstSubdomain`, `Domain`, `Host`, `Header`, `HostHash`. `HostHash`'s
+resolution-time `TenantNotFound` routes through the same handler (see the flow
+above).
 
 ## Edge cases
 
@@ -220,20 +207,13 @@ handler (above) rather than left as a parallel path.
   tenant; it does **not** establish trust. Header trust remains infrastructure's
   responsibility (`trusted:` option).
 
-## Resolving the doc contradiction
-
-`docs/designs/v4-elevators.md` and `docs/designs/apartment-v4.md` are updated so
-both describe the elevator-level handler consistently. `v4-elevators.md`'s "Error
-Handling" section — currently stating Generic does not rescue and the handler is
-adapter-level — is rewritten to describe the `tenant_validator` /
-`tenant_not_found_handler` seams.
-
 ## Breaking change
 
 On-by-default validation changes observable behavior: an unknown subdomain that
 previously produced a deep 500 now produces `TenantNotFound` → 404. v4 is in the
-alpha line, where behavior changes are expected; this ships with a CHANGELOG
-entry. Apps depending on the old behavior set `config.tenant_validator = false`.
+alpha line, where behavior changes are expected; it ships with a breaking-change
+note in `docs/upgrading-to-v4.md`. Apps depending on the old behavior set
+`config.tenant_validator = false`.
 
 ## Testing
 
@@ -254,8 +234,8 @@ entry. Apps depending on the old behavior set `config.tenant_validator = false`.
 
 ## Out of scope
 
-- **Multi-source tenant resolution** (header / custom domain / SSO param) — that
-  is `parse_tenant_name`'s job and already customizable by subclassing.
+- **Multi-source tenant resolution** (header, custom domain, SSO param) — already
+  `parse_tenant_name`'s job; customize by subclassing.
 - **Validating programmatic `Tenant.switch('typo')`** — `switch` stays a thin
   context-setter usable from jobs, console, rake, and migrations; it is not made
   HTTP-aware or globally-validating. This feature is request-path only.
@@ -281,25 +261,19 @@ entry. Apps depending on the old behavior set `config.tenant_validator = false`.
   `rescue_responses` mapping, so the app's own 404 page renders instead of a
   gem-rendered body.
 - **`Rails.cache`-backed validator as the built-in default** — rejected (a
-  four-model panel review was unanimous). It puts a network round-trip on every
-  request, couples each request to cache availability, `Rails.cache` is not
-  guaranteed to be a shared store, and — most concretely — multi-tenant apps
-  commonly namespace `Rails.cache` per tenant, which is the wrong home for global
-  registry data. A shared cache stays available through the `tenant_validator`
-  seam for apps that opt in; see [Multi-process deployments](#multi-process-deployments).
+  four-model panel review was unanimous): a network round-trip on every request,
+  each request coupled to cache availability, and `Rails.cache` is not guaranteed
+  to be a shared store. It stays available for opt-in via the `tenant_validator`
+  seam — see [Multi-process deployments](#multi-process-deployments) for how to
+  back one correctly.
 - **A negative cache of confirmed-invalid names** — rejected. Once rebuild-on-miss
   is rate-limited, the rate limit alone bounds `tenants_provider` calls; a cache
   keyed by arbitrary unknown names adds no protection and is itself an
   unbounded-memory / DoS vector.
-- **The positive set in `ActiveSupport::CurrentAttributes` (a `Current` bag)** —
-  rejected as a category error. `CurrentAttributes` is *request-scoped*: Rails
-  resets it before and after every request and job. The registry is the
-  opposite — long-lived process infrastructure, and that persistence across
-  requests is exactly what lets it avoid re-querying `tenants_provider` each
-  time. A `Current` bag would wipe the set every request, collapsing the
-  memoized cache back into a per-request DB query — the failure mode the design
-  exists to remove. `CurrentAttributes` is the right home for the *current
-  tenant* (`Apartment::Current` — per-request execution context); the *set of
-  all valid tenants* is shared global data. Process-global state behind a
-  `Mutex` and `concurrent-ruby` structures is the correct shape, matching
-  `PoolManager`'s `Concurrent::Map` and the `pinned_models` `Concurrent::Set`.
+- **The positive set in `ActiveSupport::CurrentAttributes`** — rejected as a
+  category error. `CurrentAttributes` is request-scoped: Rails resets it before
+  and after every request, so the set would be wiped each request, collapsing the
+  cache into a per-request query. `CurrentAttributes` is for the *current tenant*
+  (`Apartment::Current`, per-request context); the *set of all valid tenants* is
+  shared global data. The correct shape is process-global state behind a `Mutex`
+  plus `concurrent-ruby` structures, as in `PoolManager` and `pinned_models`.

--- a/docs/designs/v4-elevators.md
+++ b/docs/designs/v4-elevators.md
@@ -199,13 +199,18 @@ Symbols are the canonical form for built-in elevators. Classes are for custom el
 
 ## Error Handling
 
-Generic's `call` method does not rescue exceptions. If `Apartment::Tenant.switch` raises `TenantNotFound` (e.g., from HostHash), the exception propagates through the Rack stack. This is intentional:
+`Generic#call` validates the resolved tenant name before switching, via
+`config.tenant_validator` (a built-in in-process validator by default). An
+unknown tenant is routed through `config.tenant_not_found_handler` if one is
+configured (it returns a Rack response), otherwise `Apartment::TenantNotFound`
+is raised. The railtie maps that exception to `:not_found`.
 
-- Custom elevators handle errors by wrapping `super` in their own `call` override (as DynamicElevator does with rescue -> redirect).
-- The `tenant_not_found_handler` config is an adapter-level hook, not a middleware-level one.
-- Generic adding rescue logic would interfere with custom error handling in subclasses.
+A `TenantNotFound` raised during resolution itself — e.g. `HostHash` on an
+unmapped host — is caught narrowly around the processor call and routed through
+the same handler. The rescue does not wrap `@app.call`, so an application's own
+`TenantNotFound` is never swallowed.
 
-Users who want middleware-level error handling should subclass Generic and override `call`.
+See `docs/designs/elevator-tenant-validation.md` for the full design.
 
 ## Configuration Examples
 

--- a/docs/plans/elevator-tenant-validation/implementation.md
+++ b/docs/plans/elevator-tenant-validation/implementation.md
@@ -1,0 +1,945 @@
+# Elevator Tenant Validation & Not-Found Handling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make apartment's elevators validate a resolved tenant name before switching, so an unknown subdomain returns a clean 404 instead of an opaque 500 from a non-existent schema.
+
+**Architecture:** Two pluggable seams in `Generic#call` — `config.tenant_validator` (name → bool) and `config.tenant_not_found_handler` (`(tenant, request)` → Rack response). A built-in in-process `TenantValidator` runs on by default: a memoized `Set` of valid names, rate-limited single-flight rebuild-on-miss, TTL backstop, lifecycle invalidation via `create.apartment`/`drop.apartment` notifications, fail-open on source error. The railtie maps `Apartment::TenantNotFound` to `:not_found` so an unconfigured app still renders its own 404.
+
+**Tech Stack:** Ruby, Rails (Railtie, ActionDispatch, ActiveSupport::Notifications), `concurrent-ruby`, RSpec.
+
+**Spec:** `docs/designs/elevator-tenant-validation.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `lib/apartment/config.rb` | `tenant_validator` accessor + validation of both hooks | Modify |
+| `lib/apartment/tenant_validator.rb` | The built-in in-process validator | Create |
+| `lib/apartment.rb` | `Apartment.tenant_validator` resolver; built-in teardown on `clear_config`/`configure` | Modify |
+| `lib/apartment/elevators/generic.rb` | Validate before switch; route not-found through the handler | Modify |
+| `lib/apartment/railtie.rb` | Register `rescue_responses['Apartment::TenantNotFound'] = :not_found` | Modify |
+| `lib/apartment.rb` (require) | `require 'apartment/tenant_validator'` | Modify |
+| `docs/designs/v4-elevators.md`, `docs/designs/apartment-v4.md` | Resolve the elevator-vs-adapter contradiction | Modify |
+| `CHANGELOG.md` | Breaking-change entry | Modify |
+| `spec/unit/config_spec.rb` | Config accessor/validation specs | Modify |
+| `spec/unit/tenant_validator_spec.rb` | `TenantValidator` specs | Create |
+| `spec/unit/elevators/generic_spec.rb` | `Generic#call` validation specs | Modify |
+| `spec/unit/railtie_spec.rb` | `rescue_responses` registration spec | Modify |
+| `spec/integration/v4/request_lifecycle_spec.rb` | Unknown-subdomain → 404 integration spec | Modify |
+
+Build order: Config → TenantValidator → resolver → Generic → railtie → docs → integration.
+
+---
+
+## Task 1: Config — `tenant_validator` accessor and hook validation
+
+**Files:**
+- Modify: `lib/apartment/config.rb`
+- Test: `spec/unit/config_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/unit/config_spec.rb` (inside the top-level `RSpec.describe(Apartment::Config)` block):
+
+```ruby
+describe '#tenant_validator' do
+  it 'defaults to nil' do
+    expect(Apartment::Config.new.tenant_validator).to(be_nil)
+  end
+
+  it 'accepts false (validation disabled)' do
+    config = Apartment::Config.new
+    config.tenant_strategy = :schema
+    config.tenants_provider = -> { [] }
+    config.tenant_validator = false
+    expect { config.validate! }.not_to(raise_error)
+  end
+
+  it 'accepts a callable' do
+    config = Apartment::Config.new
+    config.tenant_strategy = :schema
+    config.tenants_provider = -> { [] }
+    config.tenant_validator = ->(name) { name == 'acme' }
+    expect { config.validate! }.not_to(raise_error)
+  end
+
+  it 'rejects a non-callable, non-false value' do
+    config = Apartment::Config.new
+    config.tenant_strategy = :schema
+    config.tenants_provider = -> { [] }
+    config.tenant_validator = 'nope'
+    expect { config.validate! }
+      .to(raise_error(Apartment::ConfigurationError, /tenant_validator/))
+  end
+end
+
+describe '#tenant_not_found_handler' do
+  it 'rejects a non-callable value' do
+    config = Apartment::Config.new
+    config.tenant_strategy = :schema
+    config.tenants_provider = -> { [] }
+    config.tenant_not_found_handler = 'nope'
+    expect { config.validate! }
+      .to(raise_error(Apartment::ConfigurationError, /tenant_not_found_handler/))
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e tenant_validator -e tenant_not_found_handler`
+Expected: FAIL — `tenant_validator` is not a method; the validation specs do not raise.
+
+- [ ] **Step 3: Add the accessor and default**
+
+In `lib/apartment/config.rb`, add `:tenant_validator` to the `attr_accessor` list (alongside `:tenant_not_found_handler` on line 24):
+
+```ruby
+                  :tenant_not_found_handler, :tenant_validator,
+                  :active_record_log, :sql_query_tags,
+```
+
+In `initialize`, after `@tenant_not_found_handler = nil` (line 46):
+
+```ruby
+      @tenant_not_found_handler = nil
+      @tenant_validator = nil
+```
+
+- [ ] **Step 4: Add the validation**
+
+In `lib/apartment/config.rb`, in `validate!`, before the final `return if @shard_key_prefix...` block:
+
+```ruby
+      unless @tenant_validator.nil? || @tenant_validator == false || @tenant_validator.respond_to?(:call)
+        raise(ConfigurationError,
+              'tenant_validator must be nil, false, or a callable, ' \
+              "got: #{@tenant_validator.inspect}")
+      end
+
+      if @tenant_not_found_handler && !@tenant_not_found_handler.respond_to?(:call)
+        raise(ConfigurationError,
+              'tenant_not_found_handler must be nil or a callable, ' \
+              "got: #{@tenant_not_found_handler.inspect}")
+      end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb`
+Expected: PASS, all examples green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/apartment/config.rb spec/unit/config_spec.rb
+git commit -m "Add Config#tenant_validator; validate both elevator hooks"
+```
+
+---
+
+## Task 2: `TenantValidator` — core (positive set, rebuild-on-miss, TTL)
+
+**Files:**
+- Create: `lib/apartment/tenant_validator.rb`
+- Test: `spec/unit/tenant_validator_spec.rb`
+
+The validator reads tenant names from `Apartment.config.tenants_provider`. Specs configure Apartment with a provider they control.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `spec/unit/tenant_validator_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'apartment/tenant_validator'
+
+RSpec.describe(Apartment::TenantValidator) do
+  # Track validators built per example so notification subscriptions (added in
+  # Task 3) are torn down. The respond_to? guard keeps this forward-compatible:
+  # #shutdown does not exist until Task 3.
+  def build_validator(**opts)
+    validator = described_class.new(**opts)
+    (@built_validators ||= []) << validator
+    validator
+  end
+
+  after do
+    (@built_validators || []).each { |v| v.shutdown if v.respond_to?(:shutdown) }
+  end
+
+  def configure(provider)
+    Apartment.configure do |c|
+      c.tenant_strategy = :schema
+      c.default_tenant = 'public'
+      c.tenants_provider = provider
+    end
+  end
+
+  describe '#call' do
+    it 'returns true for a name the provider lists' do
+      configure(-> { %w[acme widgets] })
+      expect(build_validator.call('acme')).to(be(true))
+    end
+
+    it 'returns false for a name the provider does not list' do
+      configure(-> { %w[acme widgets] })
+      expect(build_validator.call('ghost')).to(be(false))
+    end
+
+    it 'does not call the provider on every request (memoizes)' do
+      calls = 0
+      configure(-> { calls += 1; %w[acme] })
+      validator = build_validator
+      5.times { validator.call('acme') }
+      expect(calls).to(eq(1))
+    end
+
+    it 'heals on a miss: a name added to the source becomes valid after a rebuild' do
+      names = %w[acme]
+      configure(-> { names })
+      validator = build_validator(rebuild_interval: 0)
+      expect(validator.call('widgets')).to(be(false))
+      names << 'widgets'
+      expect(validator.call('widgets')).to(be(true))
+    end
+
+    it 'rate-limits rebuilds: repeated misses inside the interval hit the source once' do
+      calls = 0
+      configure(-> { calls += 1; %w[acme] })
+      validator = build_validator(rebuild_interval: 3600)
+      10.times { validator.call('ghost') }
+      expect(calls).to(eq(1)) # one lazy build; further misses are rate-limited
+    end
+
+    it 'rebuilds after the positive-set TTL' do
+      names = %w[acme]
+      configure(-> { names })
+      validator = build_validator(positive_ttl: 0)
+      expect(validator.call('acme')).to(be(true))
+      names.replace(%w[widgets])
+      expect(validator.call('acme')).to(be(false))
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/tenant_validator_spec.rb`
+Expected: FAIL — `cannot load such file -- apartment/tenant_validator`.
+
+- [ ] **Step 3: Create the validator (core only)**
+
+Create `lib/apartment/tenant_validator.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'set'
+require 'concurrent'
+
+module Apartment
+  # In-process, memoized validator: answers "is this a real tenant name?".
+  # The positive set is sourced from config.tenants_provider, refreshed on a
+  # TTL and — rate-limited, single-flight — on a miss. Lifecycle invalidation
+  # and fail-open behavior are added in a later task.
+  class TenantValidator
+    DEFAULT_POSITIVE_TTL_SECONDS = 300
+    DEFAULT_REBUILD_INTERVAL_SECONDS = 5
+
+    def initialize(positive_ttl: DEFAULT_POSITIVE_TTL_SECONDS,
+                   rebuild_interval: DEFAULT_REBUILD_INTERVAL_SECONDS)
+      @positive_ttl = positive_ttl
+      @rebuild_interval = rebuild_interval
+      @names = Concurrent::Set.new
+      @mutex = Mutex.new
+      @built_at = nil
+      @last_rebuild_at = nil
+    end
+
+    # @return [Boolean] whether `name` is a known tenant.
+    def call(name)
+      name = name.to_s
+      rebuild if @built_at.nil? || stale?
+      return true if @names.include?(name)
+
+      rebuild_on_miss
+      @names.include?(name)
+    end
+    alias valid? call
+
+    private
+
+    def stale?
+      @built_at && (monotonic - @built_at) > @positive_ttl
+    end
+
+    def rebuild_on_miss
+      return if @last_rebuild_at && (monotonic - @last_rebuild_at) < @rebuild_interval
+
+      rebuild
+    end
+
+    # Single-flight: one thread rebuilds at a time; others skip and use the
+    # current set, rechecking on their next request.
+    def rebuild
+      return unless @mutex.try_lock
+
+      begin
+        @last_rebuild_at = monotonic
+        names = Array(Apartment.config.tenants_provider.call).map(&:to_s)
+        @names = Concurrent::Set.new(names)
+        @built_at = monotonic
+      ensure
+        @mutex.unlock
+      end
+    end
+
+    def monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/tenant_validator_spec.rb`
+Expected: PASS, all six examples green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/tenant_validator.rb spec/unit/tenant_validator_spec.rb
+git commit -m "Add TenantValidator: memoized set, rebuild-on-miss, TTL"
+```
+
+---
+
+## Task 3: `TenantValidator` — lifecycle invalidation, fail-open, shutdown
+
+**Files:**
+- Modify: `lib/apartment/tenant_validator.rb`
+- Test: `spec/unit/tenant_validator_spec.rb`
+
+`Apartment::Instrumentation` already emits `create.apartment` and `drop.apartment`
+notifications (payload includes `tenant:`). The validator subscribes to both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/unit/tenant_validator_spec.rb` inside the `RSpec.describe` block:
+
+```ruby
+describe 'lifecycle invalidation' do
+  it 'adds a tenant on a create.apartment notification' do
+    configure(-> { %w[acme] })
+    validator = build_validator
+    expect(validator.call('newco')).to(be(false))
+    ActiveSupport::Notifications.instrument('create.apartment', tenant: 'newco') {}
+    expect(validator.call('newco')).to(be(true))
+  end
+
+  it 'removes a tenant on a drop.apartment notification' do
+    configure(-> { %w[acme widgets] })
+    validator = build_validator
+    expect(validator.call('widgets')).to(be(true))
+    ActiveSupport::Notifications.instrument('drop.apartment', tenant: 'widgets') {}
+    expect(validator.call('widgets')).to(be(false))
+  end
+
+  it 'stops responding to notifications after #shutdown' do
+    configure(-> { %w[acme] })
+    validator = build_validator
+    validator.shutdown
+    ActiveSupport::Notifications.instrument('create.apartment', tenant: 'newco') {}
+    expect(validator.call('newco')).to(be(false))
+  end
+end
+
+describe 'fail-open on source error' do
+  it 'allows any name when tenants_provider raises' do
+    configure(-> { raise StandardError, 'provider down' })
+    expect(build_validator.call('anything')).to(be(true))
+  end
+end
+```
+
+The Task 2 specs continue to pass — `build_validator` and the `after`-shutdown
+hook are already in the file, and the new `#shutdown` makes the `respond_to?`
+guard active.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/tenant_validator_spec.rb -e lifecycle -e fail-open`
+Expected: FAIL — `#shutdown` undefined; notifications do not change the set; a raising provider raises instead of failing open.
+
+- [ ] **Step 3: Add lifecycle, fail-open, and shutdown**
+
+In `lib/apartment/tenant_validator.rb`, replace the `initialize` method and add the new behavior. New `initialize`:
+
+```ruby
+    def initialize(positive_ttl: DEFAULT_POSITIVE_TTL_SECONDS,
+                   rebuild_interval: DEFAULT_REBUILD_INTERVAL_SECONDS)
+      @positive_ttl = positive_ttl
+      @rebuild_interval = rebuild_interval
+      @names = Concurrent::Set.new
+      @mutex = Mutex.new
+      @built_at = nil
+      @last_rebuild_at = nil
+      @degraded = false
+      @subscribers = subscribe_to_lifecycle
+    end
+
+    # Remove the ActiveSupport::Notifications subscriptions. Call when
+    # discarding a validator (Apartment.clear_config) so subscriptions do
+    # not accumulate across a process's lifetime.
+    def shutdown
+      @subscribers.each { |s| ActiveSupport::Notifications.unsubscribe(s) }
+      @subscribers = []
+    end
+```
+
+Replace `call` so a degraded validator fails open:
+
+```ruby
+    def call(name)
+      name = name.to_s
+      rebuild if @built_at.nil? || stale?
+      return true if @degraded
+      return true if @names.include?(name)
+
+      rebuild_on_miss
+      @degraded || @names.include?(name)
+    end
+    alias valid? call
+```
+
+Replace `stale?` so a degraded validator retries on the (short) rebuild interval rather than the (long) TTL:
+
+```ruby
+    def stale?
+      return false unless @built_at
+
+      ttl = @degraded ? @rebuild_interval : @positive_ttl
+      (monotonic - @built_at) > ttl
+    end
+```
+
+Replace `rebuild` with a fail-open `rescue`:
+
+```ruby
+    def rebuild
+      return unless @mutex.try_lock
+
+      begin
+        @last_rebuild_at = monotonic
+        names = Array(Apartment.config.tenants_provider.call).map(&:to_s)
+        @names = Concurrent::Set.new(names)
+        @degraded = false
+        @built_at = monotonic
+      rescue StandardError => e
+        # Fail open: a broken tenants_provider must not blanket-404 the app.
+        @degraded = true
+        @built_at = monotonic
+        warn_degraded(e)
+      ensure
+        @mutex.unlock
+      end
+    end
+```
+
+Add the private helpers:
+
+```ruby
+    def subscribe_to_lifecycle
+      [
+        ActiveSupport::Notifications.subscribe('create.apartment') do |*args|
+          name = args.last[:tenant]
+          @names.add(name.to_s) if name
+        end,
+        ActiveSupport::Notifications.subscribe('drop.apartment') do |*args|
+          name = args.last[:tenant]
+          @names.delete(name.to_s) if name
+        end,
+      ]
+    end
+
+    def warn_degraded(error)
+      message = '[Apartment] tenant validation degraded: tenants_provider raised ' \
+                "#{error.class}: #{error.message}. Allowing all tenants until it recovers."
+      if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+        Rails.logger.error(message)
+      else
+        warn(message)
+      end
+    end
+```
+
+Add `require 'active_support/notifications'` to the top of the file.
+
+- [ ] **Step 4: Run the full validator spec to verify it passes**
+
+Run: `bundle exec rspec spec/unit/tenant_validator_spec.rb`
+Expected: PASS — all examples green, output clean (the fail-open spec logs an error line; that is expected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/tenant_validator.rb spec/unit/tenant_validator_spec.rb
+git commit -m "TenantValidator: lifecycle invalidation, fail-open, shutdown"
+```
+
+---
+
+## Task 4: `Apartment.tenant_validator` resolver
+
+**Files:**
+- Modify: `lib/apartment.rb`
+- Test: `spec/unit/apartment_spec.rb`
+
+`Apartment.tenant_validator` resolves `config.tenant_validator`: `false` → an
+always-true callable; `nil` → the process's built-in `TenantValidator` (memoized);
+a callable → returned as-is. The built-in is torn down on `clear_config`/`configure`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/unit/apartment_spec.rb`:
+
+```ruby
+describe '.tenant_validator' do
+  it 'returns an always-true callable when config.tenant_validator is false' do
+    described_class.configure do |c|
+      c.tenant_strategy = :schema
+      c.tenants_provider = -> { [] }
+      c.tenant_validator = false
+    end
+    expect(described_class.tenant_validator.call('anything')).to(be(true))
+  end
+
+  it 'returns the configured callable when one is set' do
+    custom = ->(name) { name == 'acme' }
+    described_class.configure do |c|
+      c.tenant_strategy = :schema
+      c.tenants_provider = -> { [] }
+      c.tenant_validator = custom
+    end
+    expect(described_class.tenant_validator).to(equal(custom))
+  end
+
+  it 'returns a built-in TenantValidator when unset, memoized per process' do
+    described_class.configure do |c|
+      c.tenant_strategy = :schema
+      c.tenants_provider = -> { [] }
+    end
+    first = described_class.tenant_validator
+    expect(first).to(be_a(Apartment::TenantValidator))
+    expect(described_class.tenant_validator).to(equal(first))
+  end
+
+  it 'discards the built-in validator on clear_config' do
+    described_class.configure do |c|
+      c.tenant_strategy = :schema
+      c.tenants_provider = -> { [] }
+    end
+    first = described_class.tenant_validator
+    described_class.clear_config
+    described_class.configure do |c|
+      c.tenant_strategy = :schema
+      c.tenants_provider = -> { [] }
+    end
+    expect(described_class.tenant_validator).not_to(equal(first))
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/apartment_spec.rb -e tenant_validator`
+Expected: FAIL — `tenant_validator` is not a method on `Apartment`.
+
+- [ ] **Step 3: Add the resolver and teardown**
+
+In `lib/apartment.rb`, add `require_relative 'apartment/tenant_validator'` with the other requires near the top of the file (next to the existing `require_relative` lines).
+
+Add a constant and the resolver method inside `module Apartment; class << self` (near `def adapter`):
+
+```ruby
+    # An always-valid validator, used when config.tenant_validator is false.
+    ALWAYS_VALID_TENANT = ->(_name) { true }
+
+    # Resolves config.tenant_validator to a callable: false -> always valid,
+    # nil -> the process's built-in TenantValidator (memoized), a callable ->
+    # itself.
+    def tenant_validator
+      case (configured = @config&.tenant_validator)
+      when false then ALWAYS_VALID_TENANT
+      when nil then (@built_in_tenant_validator ||= TenantValidator.new)
+      else configured
+      end
+    end
+```
+
+In `clear_config`, before `@config = nil`, add the built-in teardown:
+
+```ruby
+      @built_in_tenant_validator&.shutdown
+      @built_in_tenant_validator = nil
+```
+
+In `configure`, in the "tear down old state and swap in new" section (after `teardown_old_state`), add:
+
+```ruby
+      @built_in_tenant_validator&.shutdown
+      @built_in_tenant_validator = nil
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/apartment_spec.rb`
+Expected: PASS, all examples green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment.rb spec/unit/apartment_spec.rb
+git commit -m "Add Apartment.tenant_validator resolver with built-in teardown"
+```
+
+---
+
+## Task 5: `Generic#call` — validate before switch, route not-found
+
+**Files:**
+- Modify: `lib/apartment/elevators/generic.rb`
+- Test: `spec/unit/elevators/generic_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/unit/elevators/generic_spec.rb` a context for validation. Use a
+processor proc so no real request parsing is needed:
+
+```ruby
+describe 'tenant validation' do
+  let(:app) { ->(_env) { [200, {}, ['ok']] } }
+  let(:env) { Rack::MockRequest.env_for('http://acme.example.com/') }
+
+  before do
+    Apartment.configure do |c|
+      c.tenant_strategy = :schema
+      c.default_tenant = 'public'
+      c.tenants_provider = -> { %w[acme] }
+    end
+  end
+
+  it 'switches when the resolved tenant is valid' do
+    switched = nil
+    allow(Apartment::Tenant).to(receive(:switch)) { |name, &blk| switched = name; blk.call }
+    elevator = described_class.new(app, ->(_req) { 'acme' })
+    elevator.call(env)
+    expect(switched).to(eq('acme'))
+  end
+
+  it 'raises TenantNotFound when the resolved tenant is invalid and no handler is set' do
+    elevator = described_class.new(app, ->(_req) { 'ghost' })
+    expect { elevator.call(env) }.to(raise_error(Apartment::TenantNotFound, /ghost/))
+  end
+
+  it 'calls tenant_not_found_handler when configured, returning its Rack response' do
+    Apartment.configure do |c|
+      c.tenant_strategy = :schema
+      c.default_tenant = 'public'
+      c.tenants_provider = -> { %w[acme] }
+      c.tenant_not_found_handler = ->(tenant, _request) { [404, {}, ["no #{tenant}"]] }
+    end
+    elevator = described_class.new(app, ->(_req) { 'ghost' })
+    expect(elevator.call(env)).to(eq([404, {}, ['no ghost']]))
+  end
+
+  it 'does not validate when the processor returns nil (default tenant)' do
+    elevator = described_class.new(app, ->(_req) { nil })
+    expect(elevator.call(env)).to(eq([200, {}, ['ok']]))
+  end
+
+  it 'treats the default tenant as always valid' do
+    switched = nil
+    allow(Apartment::Tenant).to(receive(:switch)) { |name, &blk| switched = name; blk.call }
+    elevator = described_class.new(app, ->(_req) { 'public' })
+    elevator.call(env)
+    expect(switched).to(eq('public'))
+  end
+
+  it 'routes a TenantNotFound raised during resolution through the handler' do
+    Apartment.configure do |c|
+      c.tenant_strategy = :schema
+      c.default_tenant = 'public'
+      c.tenants_provider = -> { %w[acme] }
+      c.tenant_not_found_handler = ->(_tenant, _request) { [404, {}, ['routed']] }
+    end
+    processor = ->(_req) { raise Apartment::TenantNotFound, 'unmapped host' }
+    elevator = described_class.new(app, processor)
+    expect(elevator.call(env)).to(eq([404, {}, ['routed']]))
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/elevators/generic_spec.rb -e 'tenant validation'`
+Expected: FAIL — the elevator switches unconditionally; no validation, no handler.
+
+- [ ] **Step 3: Rewrite `Generic#call`**
+
+Replace the `call` method in `lib/apartment/elevators/generic.rb` and add private helpers:
+
+```ruby
+      def call(env)
+        request = Rack::Request.new(env)
+
+        begin
+          database = @processor.call(request)
+        rescue Apartment::TenantNotFound
+          # HostHash and similar raise during resolution; route through the
+          # same handler. The rescue is narrow — it does NOT wrap @app.call,
+          # so a TenantNotFound raised by the application is never swallowed.
+          return handle_tenant_not_found(request.host, request)
+        end
+
+        return @app.call(env) if database.nil?
+        return handle_tenant_not_found(database, request) unless tenant_valid?(database)
+
+        Apartment::Tenant.switch(database) { @app.call(env) }
+      end
+
+      def parse_tenant_name(_request)
+        raise(NotImplementedError, "#{self.class}#parse_tenant_name must be implemented")
+      end
+
+      private
+
+      def tenant_valid?(database)
+        return true if database.to_s == Apartment.config.default_tenant.to_s
+
+        Apartment.tenant_validator.call(database)
+      end
+
+      def handle_tenant_not_found(tenant, request)
+        handler = Apartment.config&.tenant_not_found_handler
+        return handler.call(tenant, request) if handler
+
+        raise(Apartment::TenantNotFound, "No tenant found for #{tenant.inspect}")
+      end
+```
+
+`require 'apartment/errors'` is already pulled in via `apartment/tenant`; no new require needed.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/elevators/generic_spec.rb`
+Expected: PASS — the new validation context plus the pre-existing `Generic` specs.
+
+- [ ] **Step 5: Run the full elevator suite for regressions**
+
+Run: `bundle exec rspec spec/unit/elevators/`
+Expected: PASS — `Subdomain`, `Domain`, `Host`, `FirstSubdomain`, `Header`, `HostHash` all inherit `call`; confirm none regressed. If a `HostHash` spec asserted a raw `TenantNotFound` raise, update it to expect the handler path when a handler is configured (the raise still happens when none is).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/apartment/elevators/generic.rb spec/unit/elevators/generic_spec.rb
+git commit -m "Generic elevator: validate tenant before switch, route not-found"
+```
+
+---
+
+## Task 6: Railtie — map `TenantNotFound` to `:not_found`
+
+**Files:**
+- Modify: `lib/apartment/railtie.rb`
+- Test: `spec/unit/railtie_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `spec/unit/railtie_spec.rb`:
+
+```ruby
+describe 'TenantNotFound rescue_responses mapping' do
+  it 'maps Apartment::TenantNotFound to :not_found' do
+    require 'action_dispatch'
+    # The railtie initializer registers the mapping at boot.
+    expect(ActionDispatch::ExceptionWrapper.rescue_responses['Apartment::TenantNotFound'])
+      .to(eq(:not_found))
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bundle exec rspec spec/unit/railtie_spec.rb -e rescue_responses`
+Expected: FAIL — the key is unset (`nil`).
+
+- [ ] **Step 3: Add the railtie initializer**
+
+In `lib/apartment/railtie.rb`, inside the `class Railtie`, add a new initializer
+(after the `'apartment.middleware'` initializer block, before `if Rails.env.test?`):
+
+```ruby
+    # Map Apartment::TenantNotFound to a 404 so an unknown tenant renders the
+    # application's own 404 page when no tenant_not_found_handler is configured.
+    # `||=` so an app that sets its own mapping is not overridden.
+    initializer 'apartment.rescue_responses' do
+      require 'action_dispatch'
+      ActionDispatch::ExceptionWrapper.rescue_responses['Apartment::TenantNotFound'] ||= :not_found
+    end
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bundle exec rspec spec/unit/railtie_spec.rb`
+Expected: PASS. (If `railtie_spec.rb` boots the railtie via a dummy app, the mapping is registered; if it tests initializers in isolation, run the initializer block directly in the spec setup — match the file's existing pattern.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/railtie.rb spec/unit/railtie_spec.rb
+git commit -m "Railtie: map Apartment::TenantNotFound to :not_found"
+```
+
+---
+
+## Task 7: Documentation — resolve the contradiction, CHANGELOG
+
+**Files:**
+- Modify: `docs/designs/v4-elevators.md`
+- Modify: `docs/designs/apartment-v4.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Rewrite the v4-elevators.md "Error Handling" section**
+
+In `docs/designs/v4-elevators.md`, replace the "Error Handling" section (the one
+stating Generic does not rescue and `tenant_not_found_handler` is "an
+adapter-level hook"). New content:
+
+```markdown
+## Error Handling
+
+`Generic#call` validates the resolved tenant name before switching, via
+`config.tenant_validator` (a built-in in-process validator by default). An
+unknown tenant is routed through `config.tenant_not_found_handler` if one is
+configured (it returns a Rack response), otherwise `Apartment::TenantNotFound`
+is raised. The railtie maps that exception to `:not_found`.
+
+A `TenantNotFound` raised during resolution itself — e.g. `HostHash` on an
+unmapped host — is caught narrowly around the processor call and routed through
+the same handler. The rescue does not wrap `@app.call`, so an application's own
+`TenantNotFound` is never swallowed.
+
+See `docs/designs/elevator-tenant-validation.md` for the full design.
+```
+
+- [ ] **Step 2: Reconcile apartment-v4.md**
+
+In `docs/designs/apartment-v4.md`, find the "Tenant not found" line (the one near
+the `tenant_not_found_handler` example) and ensure it reads as elevator-level and
+points at the new design doc. Change any "adapter-level" phrasing to elevator-level.
+Add, next to the `tenant_not_found_handler` config example, a one-line cross-reference:
+`# See docs/designs/elevator-tenant-validation.md`.
+
+- [ ] **Step 3: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, under the current unreleased/alpha section, add:
+
+```markdown
+- **Breaking (alpha):** elevators now validate the resolved tenant before
+  switching. An unknown subdomain raises `Apartment::TenantNotFound` (mapped to
+  a 404) instead of failing deep in the first query with an opaque 500.
+  Validation runs by default via a built-in in-process validator; disable with
+  `config.tenant_validator = false`, or customize with a callable. Configure
+  `config.tenant_not_found_handler` for a custom response.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/designs/v4-elevators.md docs/designs/apartment-v4.md CHANGELOG.md
+git commit -m "Docs: elevator-level tenant-not-found handling; CHANGELOG"
+```
+
+---
+
+## Task 8: Integration test — unknown subdomain returns 404
+
+**Files:**
+- Modify: `spec/integration/v4/request_lifecycle_spec.rb`
+
+The dummy app already boots with the `:subdomain` elevator and a
+`tenants_provider`. An unknown subdomain should now fail closed.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `spec/integration/v4/request_lifecycle_spec.rb`, inside the existing
+`describe 'v4 Request lifecycle'` block:
+
+```ruby
+it 'returns 404 for an unknown subdomain instead of a 500' do
+  header 'Host', 'ghost.example.com'
+  get '/tenant_info'
+  expect(last_response.status).to(eq(404))
+end
+
+it 'switches normally for a known tenant (validation does not block valid tenants)' do
+  header 'Host', 'acme.example.com'
+  get '/tenant_info'
+  expect(last_response).to(be_ok)
+  expect(JSON.parse(last_response.body)['tenant']).to(eq('acme'))
+end
+```
+
+The dummy app's `tenants_provider` must list the test tenants for the built-in
+validator to accept them. Confirm `spec/dummy/config/initializers/apartment.rb`'s
+`tenants_provider` returns `acme`/`widgets` during the spec (the `before` hook
+creates those tenants); if it sources from an empty `Company` table, set the
+dummy `tenants_provider` to `-> { %w[public acme widgets] }` or have the `before`
+hook populate `Company`. The unknown-subdomain raise relies on the railtie's
+`rescue_responses` mapping; the dummy app must boot the railtie (it does — see
+the explicit `require 'apartment/railtie'` in `spec/dummy/config/application.rb`).
+
+- [ ] **Step 2: Run the test to verify it fails (then passes)**
+
+Run: `RAILS_ENV=test DATABASE_ENGINE=postgresql REQUEST_LIFECYCLE_REQUIRED=1 BUNDLE_GEMFILE=gemfiles/rails_8.1_postgresql.gemfile bundle exec rspec spec/integration/v4/request_lifecycle_spec.rb`
+Expected: with the validation code from Tasks 1–6 in place, the 404 test PASSES and the known-tenant test PASSES. If the 404 test errors with a 500, inspect whether the dummy `tenants_provider` lists the valid tenants and whether `rescue_responses` is registered.
+
+- [ ] **Step 3: Run the full integration suite for regressions**
+
+Run: `RAILS_ENV=test DATABASE_ENGINE=postgresql REQUEST_LIFECYCLE_REQUIRED=1 BUNDLE_GEMFILE=gemfiles/rails_8.1_postgresql.gemfile bundle exec rspec spec/integration/v4/`
+Expected: PASS — no regressions; the request_lifecycle examples that switch to real tenants still pass (their tenants are valid).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec/integration/v4/request_lifecycle_spec.rb spec/dummy/config/initializers/apartment.rb
+git commit -m "Integration: unknown subdomain returns 404"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full unit suite: `bundle exec rspec spec/unit/` — expect 0 failures.
+- [ ] Run rubocop on every changed file: `bundle exec rubocop <files>` — expect 0 offenses.
+- [ ] Run the integration suite on PostgreSQL (command in Task 8 Step 3) — expect 0 failures.
+- [ ] Open the PR; CHANGELOG entry present; design doc linked.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Two seams (Tasks 1, 4, 5); built-in validator with set / rebuild-on-miss / rate-limit / single-flight / TTL / lifecycle / fail-open (Tasks 2, 3); railtie mapping (Task 6); doc-contradiction resolution (Task 7); on-by-default + breaking-change note (Task 7 CHANGELOG); edge cases — `nil` name, `default_tenant` always valid, `HostHash` routing (Task 5 tests). Multi-process behavior is a property of the validator (Tasks 2–3), not separate code.
+- **Out of scope (per spec):** programmatic `Tenant.switch` validation, distributed cache, multi-source resolution — no tasks, intentionally.
+- **Naming consistency:** `Apartment.tenant_validator` (resolver), `Apartment::TenantValidator` (class), `config.tenant_validator` / `config.tenant_not_found_handler` (config), `#shutdown` (teardown) — used consistently across Tasks 2–6.
+- **Known follow-up for the executor:** the built-in `TenantValidator` is process-global; if any new count-sensitive spec exercises it, isolate its state per example (see the pinned-model registry note in `spec/CLAUDE.md`).

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -129,6 +129,21 @@ end
 
 Available elevators: `:subdomain`, `:first_subdomain`, `:domain`, `:host`, `:host_hash`, `:header`, `:generic`.
 
+### Elevator Tenant Validation
+
+Elevators now validate the resolved tenant before switching. An unknown subdomain (or any other unresolved tenant) raises `Apartment::TenantNotFound` — which the Railtie maps to a 404 — instead of failing deep in the first query with an opaque 500.
+
+Validation runs by default via a built-in in-process validator. To disable it, or to supply your own:
+
+```ruby
+Apartment.configure do |config|
+  config.tenant_validator = false              # disable validation
+  # config.tenant_validator = ->(name) { ... } # or supply a custom callable
+end
+```
+
+Configure `config.tenant_not_found_handler` for a custom not-found response instead of the default 404. See `docs/designs/elevator-tenant-validation.md` for the full design.
+
 ### Connection Model
 
 v4 uses pool-per-tenant instead of thread-local switching. Each tenant gets a dedicated `ActiveRecord::ConnectionAdapters::ConnectionPool` managed by `Apartment::PoolManager`.

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -144,6 +144,8 @@ end
 
 Configure `config.tenant_not_found_handler` for a custom not-found response instead of the default 404. See `docs/designs/elevator-tenant-validation.md` for the full design.
 
+If you provision tenants outside `Apartment::Tenant.create` / `.drop` (raw `psql`, `pg_restore`, a separate schema-cloning job), call `Apartment::Lifecycle.notify_created(name)` / `notify_dropped(name)` after the schema is live. The lifecycle calls publish the `create.apartment` / `drop.apartment` notifications the validator subscribes to, so the new tenant is valid on the very next request instead of waiting for rebuild-on-miss. In-process only — multi-process propagation needs a custom validator (see the design doc's *Multi-process deployments* section).
+
 ### Connection Model
 
 v4 uses pool-per-tenant instead of thread-local switching. Each tenant gets a dedicated `ActiveRecord::ConnectionAdapters::ConnectionPool` managed by `Apartment::PoolManager`.

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -144,6 +144,8 @@ end
 
 Configure `config.tenant_not_found_handler` for a custom not-found response instead of the default 404. See `docs/designs/elevator-tenant-validation.md` for the full design.
 
+If your elevator subclass already rejects unknown tenants in `parse_tenant_name` (e.g., filtering against a shared cache of valid names), the validator is structurally redundant — set `config.tenant_validator = false`. See the design doc's *When to disable validation* section.
+
 If you provision tenants outside `Apartment::Tenant.create` / `.drop` (raw `psql`, `pg_restore`, a separate schema-cloning job), call `Apartment::Lifecycle.notify_created(name)` / `notify_dropped(name)` after the schema is live. The lifecycle calls publish the `create.apartment` / `drop.apartment` notifications the validator subscribes to, so the new tenant is valid on the very next request instead of waiting for rebuild-on-miss. In-process only — multi-process propagation needs a custom validator (see the design doc's *Multi-process deployments* section).
 
 ### Connection Model

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -49,13 +49,17 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     # An always-valid validator, used when config.tenant_validator is false.
     ALWAYS_VALID_TENANT = ->(_name) { true }
 
+    # Guards lazy construction of the built-in validator. A constant (not an
+    # ivar) so it survives clear_config, which nils @built_in_tenant_validator.
+    BUILT_IN_VALIDATOR_MUTEX = Mutex.new
+
     # Resolves config.tenant_validator to a callable: false -> always valid,
     # nil -> the process's built-in TenantValidator (memoized), a callable ->
     # itself.
     def tenant_validator
       case (configured = @config&.tenant_validator)
       when false then ALWAYS_VALID_TENANT
-      when nil then (@built_in_tenant_validator ||= TenantValidator.new)
+      when nil then built_in_tenant_validator
       else configured
       end
     end
@@ -243,6 +247,15 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     end
 
     private
+
+    # Double-checked locking: the common path (already built) skips the mutex;
+    # concurrent first callers serialize so exactly one validator is built.
+    # TenantValidator.new subscribes to ActiveSupport::Notifications, so a
+    # discarded duplicate would leak its subscription.
+    def built_in_tenant_validator
+      @built_in_tenant_validator ||
+        BUILT_IN_VALIDATOR_MUTEX.synchronize { @built_in_tenant_validator ||= TenantValidator.new }
+    end
 
     # Safely tear down old state. Stops the reaper first (so it doesn't
     # evict mid-cleanup), then deregisters tenant pools from AR's

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -33,6 +33,7 @@ loader.collapse("#{__dir__}/apartment/concerns")
 loader.setup
 
 require_relative 'apartment/errors'
+require_relative 'apartment/tenant_validator'
 
 module Apartment # rubocop:disable Metrics/ModuleLength
   class << self # rubocop:disable Metrics/ClassLength
@@ -43,6 +44,20 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     # Can be set manually (e.g., in tests) via Apartment.adapter=.
     def adapter
       @adapter ||= build_adapter
+    end
+
+    # An always-valid validator, used when config.tenant_validator is false.
+    ALWAYS_VALID_TENANT = ->(_name) { true }
+
+    # Resolves config.tenant_validator to a callable: false -> always valid,
+    # nil -> the process's built-in TenantValidator (memoized), a callable ->
+    # itself.
+    def tenant_validator
+      case (configured = @config&.tenant_validator)
+      when false then ALWAYS_VALID_TENANT
+      when nil then (@built_in_tenant_validator ||= TenantValidator.new)
+      else configured
+      end
     end
 
     # Registry of models that declared pin_tenant.
@@ -130,6 +145,8 @@ module Apartment # rubocop:disable Metrics/ModuleLength
 
       # Validation passed — tear down old state and swap in new.
       teardown_old_state
+      @built_in_tenant_validator&.shutdown
+      @built_in_tenant_validator = nil
       @config = new_config
       @pool_manager = PoolManager.new
       @pool_reaper = PoolReaper.new(
@@ -155,6 +172,8 @@ module Apartment # rubocop:disable Metrics/ModuleLength
       # constants); a test process that pins anonymous classes accumulates them
       # here — acceptable, but count-sensitive specs must isolate it themselves.
       @pinned_models&.each { |klass| klass.apartment_restore! if klass.respond_to?(:apartment_restore!) }
+      @built_in_tenant_validator&.shutdown
+      @built_in_tenant_validator = nil
       @config = nil
       @pool_manager = nil
       @pool_reaper = nil

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -7,7 +7,7 @@ require_relative 'configs/mysql_config'
 module Apartment
   # Configuration object for Apartment v4.
   # Created via Apartment.configure block; validated after the block yields.
-  class Config
+  class Config # rubocop:disable Metrics/ClassLength
     VALID_STRATEGIES = %i[schema database_name shard database_config].freeze
     VALID_ENVIRONMENTIFY_STRATEGIES = [nil, :prepend, :append].freeze
 
@@ -21,7 +21,8 @@ module Apartment
                   :schema_load_strategy, :schema_file,
                   :parallel_migration_threads,
                   :elevator, :elevator_options,
-                  :tenant_not_found_handler, :active_record_log, :sql_query_tags,
+                  :tenant_not_found_handler, :tenant_validator,
+                  :active_record_log, :sql_query_tags,
                   :shard_key_prefix,
                   :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
                   :force_separate_pinned_pool, :test_fixture_cleanup
@@ -44,6 +45,7 @@ module Apartment
       @elevator = nil
       @elevator_options = {}
       @tenant_not_found_handler = nil
+      @tenant_validator = nil
       @active_record_log = false
       @sql_query_tags = false
       @postgres_config = nil
@@ -186,6 +188,18 @@ module Apartment
       unless [true, false].include?(@test_fixture_cleanup)
         raise(ConfigurationError,
               "test_fixture_cleanup must be true or false, got: #{@test_fixture_cleanup.inspect}")
+      end
+
+      unless @tenant_validator.nil? || @tenant_validator == false || @tenant_validator.respond_to?(:call)
+        raise(ConfigurationError,
+              'tenant_validator must be nil, false, or a callable, ' \
+              "got: #{@tenant_validator.inspect}")
+      end
+
+      if @tenant_not_found_handler && !@tenant_not_found_handler.respond_to?(:call)
+        raise(ConfigurationError,
+              'tenant_not_found_handler must be nil or a callable, ' \
+              "got: #{@tenant_not_found_handler.inspect}")
       end
 
       return if @shard_key_prefix.is_a?(String) && @shard_key_prefix.match?(/\A[a-z_][a-z0-9_]*\z/)

--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -18,11 +18,12 @@ module Apartment
 
         begin
           database = @processor.call(request)
-        rescue Apartment::TenantNotFound
+        rescue Apartment::TenantNotFound => e
           # HostHash and similar raise during resolution; route through the
           # same handler. The rescue is narrow — it does NOT wrap @app.call,
           # so a TenantNotFound raised by the application is never swallowed.
-          return handle_tenant_not_found(request.host, request)
+          # Prefer the exception's own tenant; fall back to the host.
+          return handle_tenant_not_found(e.tenant || request.host, request)
         end
 
         return @app.call(env) if database.nil?
@@ -54,7 +55,9 @@ module Apartment
         handler = Apartment.config&.tenant_not_found_handler
         return handler.call(tenant, request) if handler
 
-        raise(Apartment::TenantNotFound, "No tenant found for #{tenant.inspect}")
+        # TenantNotFound.new's argument is the tenant name — it builds its own
+        # message. Pass the bare name so #tenant and #message stay correct.
+        raise(Apartment::TenantNotFound, tenant)
       end
     end
   end

--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -16,17 +16,45 @@ module Apartment
       def call(env)
         request = Rack::Request.new(env)
 
-        database = @processor.call(request)
-
-        if database
-          Apartment::Tenant.switch(database) { @app.call(env) }
-        else
-          @app.call(env)
+        begin
+          database = @processor.call(request)
+        rescue Apartment::TenantNotFound
+          # HostHash and similar raise during resolution; route through the
+          # same handler. The rescue is narrow — it does NOT wrap @app.call,
+          # so a TenantNotFound raised by the application is never swallowed.
+          return handle_tenant_not_found(request.host, request)
         end
+
+        return @app.call(env) if database.nil?
+        return handle_tenant_not_found(database, request) unless tenant_valid?(database)
+
+        Apartment::Tenant.switch(database) { @app.call(env) }
       end
 
       def parse_tenant_name(_request)
         raise(NotImplementedError, "#{self.class}#parse_tenant_name must be implemented")
+      end
+
+      private
+
+      # Whether `database` resolves to a real tenant. The default tenant is
+      # always valid; an unconfigured Apartment skips validation entirely
+      # (there is no tenant source to validate against).
+      def tenant_valid?(database)
+        config = Apartment.config
+        return true unless config
+        return true if database.to_s == config.default_tenant.to_s
+
+        Apartment.tenant_validator.call(database)
+      end
+
+      # Route an unknown tenant through config.tenant_not_found_handler when
+      # one is set; otherwise raise TenantNotFound (the railtie maps it to 404).
+      def handle_tenant_not_found(tenant, request)
+        handler = Apartment.config&.tenant_not_found_handler
+        return handler.call(tenant, request) if handler
+
+        raise(Apartment::TenantNotFound, "No tenant found for #{tenant.inspect}")
       end
     end
   end

--- a/lib/apartment/lifecycle.rb
+++ b/lib/apartment/lifecycle.rb
@@ -16,8 +16,10 @@ module Apartment
   #   Apartment::Lifecycle.notify_created('acme')
   #   Apartment::Lifecycle.notify_dropped('acme')
   #
-  # Cross-process propagation is not in scope here — see
-  # docs/designs/elevator-tenant-validation.md (Multi-process deployments).
+  # Updates only the calling Ruby process's validator. A worker-tier job that
+  # provisions a schema and notifies here will not reach a separate web-tier
+  # process — see docs/designs/elevator-tenant-validation.md (Multi-process
+  # deployments) and the cross-process invalidation tracking issue.
   module Lifecycle
     def self.notify_created(tenant)
       Instrumentation.instrument(:create, tenant: tenant)

--- a/lib/apartment/lifecycle.rb
+++ b/lib/apartment/lifecycle.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative 'instrumentation'
+
+module Apartment
+  # Public hooks for telling Apartment that a tenant was created or dropped
+  # outside the gem's own lifecycle path (e.g., a schema provisioned by raw
+  # psql, pg_restore, or a separate migration job).
+  #
+  # Apartment::Tenant.create / .drop already publish these events; call these
+  # helpers only when the lifecycle happens through some other path. The
+  # in-process TenantValidator subscribes to both events and updates its
+  # positive set, so the next request for that tenant doesn't pay a
+  # rebuild-on-miss.
+  #
+  #   Apartment::Lifecycle.notify_created('acme')
+  #   Apartment::Lifecycle.notify_dropped('acme')
+  #
+  # Cross-process propagation is not in scope here — see
+  # docs/designs/elevator-tenant-validation.md (Multi-process deployments).
+  module Lifecycle
+    def self.notify_created(tenant)
+      Instrumentation.instrument(:create, tenant: tenant)
+    end
+
+    def self.notify_dropped(tenant)
+      Instrumentation.instrument(:drop, tenant: tenant)
+    end
+  end
+end

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -58,6 +58,16 @@ module Apartment
       Apartment::Railtie.insert_elevator_middleware(app.middleware, elevator_class, **opts)
     end
 
+    # Map Apartment::TenantNotFound to a 404 so an unknown tenant renders the
+    # application's own 404 page when no tenant_not_found_handler is configured.
+    # rescue_responses has a non-nil default (:internal_server_error), so a
+    # key? check — not ||= — is what skips an app's own explicit mapping.
+    initializer 'apartment.rescue_responses' do
+      require 'action_dispatch'
+      responses = ActionDispatch::ExceptionWrapper.rescue_responses
+      responses['Apartment::TenantNotFound'] = :not_found unless responses.key?('Apartment::TenantNotFound')
+    end
+
     # In test environments, clean up apartment's tenant pools before Rails'
     # fixture setup iterates shards. See docs/designs/v4-test-fixtures-compatibility.md.
     if Rails.env.test?

--- a/lib/apartment/tenant_validator.rb
+++ b/lib/apartment/tenant_validator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'concurrent'
+require 'active_support/notifications'
 
 module Apartment
   # In-process, memoized validator: answers "is this a real tenant name?".
   # The positive set is sourced from config.tenants_provider, refreshed on a
-  # TTL and — rate-limited, single-flight — on a miss. Lifecycle invalidation
-  # and fail-open behavior are added in a later task.
+  # TTL and — rate-limited, single-flight — on a miss. Lifecycle notifications
+  # (create.apartment / drop.apartment) keep the set current between rebuilds;
+  # a tenants_provider error makes the validator fail open (allow all names).
   class TenantValidator
     DEFAULT_POSITIVE_TTL_SECONDS = 300
     DEFAULT_REBUILD_INTERVAL_SECONDS = 5
@@ -19,23 +21,37 @@ module Apartment
       @mutex = Mutex.new
       @built_at = nil
       @last_rebuild_at = nil
+      @degraded = false
+      @subscribers = subscribe_to_lifecycle
+    end
+
+    # Remove the ActiveSupport::Notifications subscriptions. Call when
+    # discarding a validator (Apartment.clear_config) so subscriptions do
+    # not accumulate across a process's lifetime.
+    def shutdown
+      @subscribers.each { |s| ActiveSupport::Notifications.unsubscribe(s) }
+      @subscribers = []
     end
 
     # @return [Boolean] whether `name` is a known tenant.
     def call(name)
       name = name.to_s
       rebuild if @built_at.nil? || stale?
+      return true if @degraded
       return true if @names.include?(name)
 
       rebuild_on_miss
-      @names.include?(name)
+      @degraded || @names.include?(name)
     end
     alias valid? call
 
     private
 
     def stale?
-      @built_at && (monotonic - @built_at) > @positive_ttl
+      return false unless @built_at
+
+      ttl = @degraded ? @rebuild_interval : @positive_ttl
+      (monotonic - @built_at) > ttl
     end
 
     def rebuild_on_miss
@@ -53,7 +69,13 @@ module Apartment
         @last_rebuild_at = monotonic
         names = Array(Apartment.config.tenants_provider.call).map(&:to_s)
         @names = Concurrent::Set.new(names)
+        @degraded = false
         @built_at = monotonic
+      rescue StandardError => e
+        # Fail open: a broken tenants_provider must not blanket-404 the app.
+        @degraded = true
+        @built_at = monotonic
+        warn_degraded(e)
       ensure
         @mutex.unlock
       end
@@ -61,6 +83,29 @@ module Apartment
 
     def monotonic
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def subscribe_to_lifecycle
+      [
+        ActiveSupport::Notifications.subscribe('create.apartment') do |*args|
+          name = args.last[:tenant]
+          @names.add(name.to_s) if name
+        end,
+        ActiveSupport::Notifications.subscribe('drop.apartment') do |*args|
+          name = args.last[:tenant]
+          @names.delete(name.to_s) if name
+        end,
+      ]
+    end
+
+    def warn_degraded(error)
+      message = '[Apartment] tenant validation degraded: tenants_provider raised ' \
+                "#{error.class}: #{error.message}. Allowing all tenants until it recovers."
+      if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+        Rails.logger.error(message)
+      else
+        warn(message)
+      end
     end
   end
 end

--- a/lib/apartment/tenant_validator.rb
+++ b/lib/apartment/tenant_validator.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+
+module Apartment
+  # In-process, memoized validator: answers "is this a real tenant name?".
+  # The positive set is sourced from config.tenants_provider, refreshed on a
+  # TTL and — rate-limited, single-flight — on a miss. Lifecycle invalidation
+  # and fail-open behavior are added in a later task.
+  class TenantValidator
+    DEFAULT_POSITIVE_TTL_SECONDS = 300
+    DEFAULT_REBUILD_INTERVAL_SECONDS = 5
+
+    def initialize(positive_ttl: DEFAULT_POSITIVE_TTL_SECONDS,
+                   rebuild_interval: DEFAULT_REBUILD_INTERVAL_SECONDS)
+      @positive_ttl = positive_ttl
+      @rebuild_interval = rebuild_interval
+      @names = Concurrent::Set.new
+      @mutex = Mutex.new
+      @built_at = nil
+      @last_rebuild_at = nil
+    end
+
+    # @return [Boolean] whether `name` is a known tenant.
+    def call(name)
+      name = name.to_s
+      rebuild if @built_at.nil? || stale?
+      return true if @names.include?(name)
+
+      rebuild_on_miss
+      @names.include?(name)
+    end
+    alias valid? call
+
+    private
+
+    def stale?
+      @built_at && (monotonic - @built_at) > @positive_ttl
+    end
+
+    def rebuild_on_miss
+      return if @last_rebuild_at && (monotonic - @last_rebuild_at) < @rebuild_interval
+
+      rebuild
+    end
+
+    # Single-flight: one thread rebuilds at a time; others skip and use the
+    # current set, rechecking on their next request.
+    def rebuild
+      return unless @mutex.try_lock
+
+      begin
+        @last_rebuild_at = monotonic
+        names = Array(Apartment.config.tenants_provider.call).map(&:to_s)
+        @names = Concurrent::Set.new(names)
+        @built_at = monotonic
+      ensure
+        @mutex.unlock
+      end
+    end
+
+    def monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/apartment/tenant_validator.rb
+++ b/lib/apartment/tenant_validator.rb
@@ -18,7 +18,9 @@ module Apartment
       @positive_ttl = positive_ttl
       @rebuild_interval = rebuild_interval
       @names = Concurrent::Set.new
-      @mutex = Mutex.new
+      @rebuild_mutex = Mutex.new # single-flight guard: one rebuild at a time
+      @state_mutex = Mutex.new   # guards the @names swap vs lifecycle deltas
+      @pending_deltas = nil      # non-nil Array while a rebuild is in flight
       @built_at = nil
       @last_rebuild_at = nil
       @degraded = false
@@ -36,7 +38,11 @@ module Apartment
     # @return [Boolean] whether `name` is a known tenant.
     def call(name)
       name = name.to_s
-      rebuild if @built_at.nil? || stale?
+      if @built_at.nil?
+        rebuild(blocking: true) # cold start: every caller waits for the first build
+      elsif stale?
+        rebuild                 # refresh: single-flight, non-blocking
+      end
       return true if @degraded
       return true if @names.include?(name)
 
@@ -60,24 +66,69 @@ module Apartment
       rebuild
     end
 
-    # Single-flight: one thread rebuilds at a time; others skip and use the
-    # current set, rechecking on their next request.
-    def rebuild
-      return unless @mutex.try_lock
+    # Single-flight. The first build is +blocking+ — concurrent callers wait
+    # for it rather than evaluating against the empty initial set, which would
+    # 404 a valid tenant. Refreshes are non-blocking: a caller that loses the
+    # lock uses the still-valid current set and rechecks on its next request.
+    def rebuild(blocking: false)
+      if blocking
+        @rebuild_mutex.synchronize { perform_rebuild if @built_at.nil? }
+      else
+        return unless @rebuild_mutex.try_lock
 
-      begin
-        @last_rebuild_at = monotonic
-        names = Array(Apartment.config.tenants_provider.call).map(&:to_s)
-        @names = Concurrent::Set.new(names)
+        begin
+          perform_rebuild
+        ensure
+          @rebuild_mutex.unlock
+        end
+      end
+    end
+
+    # Rebuilds the positive set from the source. The slow provider call runs
+    # without @state_mutex held, so lifecycle notifications never block on it;
+    # deltas that arrive during the call are captured and re-applied to the
+    # new set, so the whole-set swap cannot lose a concurrent create/drop.
+    def perform_rebuild
+      @last_rebuild_at = monotonic
+      @state_mutex.synchronize { @pending_deltas = [] }
+      fresh = Array(Apartment.config.tenants_provider.call).map(&:to_s)
+      commit_rebuild(Concurrent::Set.new(fresh))
+    rescue StandardError => e
+      # Fail open: a broken tenants_provider must not blanket-404 the app.
+      mark_degraded
+      warn_degraded(e)
+    end
+
+    # Swap in the freshly built set, re-applying any lifecycle deltas that
+    # arrived during the (unlocked) provider call so the swap loses nothing.
+    def commit_rebuild(new_set)
+      @state_mutex.synchronize do
+        @pending_deltas.each { |op, name| op == :add ? new_set.add(name) : new_set.delete(name) }
+        @pending_deltas = nil
+        @names = new_set
         @degraded = false
         @built_at = monotonic
-      rescue StandardError => e
-        # Fail open: a broken tenants_provider must not blanket-404 the app.
+      end
+    end
+
+    def mark_degraded
+      @state_mutex.synchronize do
+        @pending_deltas = nil
         @degraded = true
         @built_at = monotonic
-        warn_degraded(e)
-      ensure
-        @mutex.unlock
+      end
+    end
+
+    # Apply a lifecycle change to the live set. While a rebuild is in flight
+    # the delta is also recorded, so perform_rebuild re-applies it after the
+    # whole-set swap rather than discarding it.
+    def apply_lifecycle(operation, name)
+      return unless name
+
+      name = name.to_s
+      @state_mutex.synchronize do
+        operation == :add ? @names.add(name) : @names.delete(name)
+        @pending_deltas << [operation, name] if @pending_deltas
       end
     end
 
@@ -88,12 +139,10 @@ module Apartment
     def subscribe_to_lifecycle
       [
         ActiveSupport::Notifications.subscribe('create.apartment') do |*args|
-          name = args.last[:tenant]
-          @names.add(name.to_s) if name
+          apply_lifecycle(:add, args.last[:tenant])
         end,
         ActiveSupport::Notifications.subscribe('drop.apartment') do |*args|
-          name = args.last[:tenant]
-          @names.delete(name.to_s) if name
+          apply_lifecycle(:remove, args.last[:tenant])
         end,
       ]
     end
@@ -106,6 +155,9 @@ module Apartment
       else
         warn(message)
       end
+    rescue StandardError
+      # Logging must never break the request path.
+      nil
     end
   end
 end

--- a/lib/apartment/tenant_validator.rb
+++ b/lib/apartment/tenant_validator.rb
@@ -91,8 +91,7 @@ module Apartment
     def perform_rebuild
       @last_rebuild_at = monotonic
       @state_mutex.synchronize { @pending_deltas = [] }
-      fresh = Array(Apartment.config.tenants_provider.call).map(&:to_s)
-      commit_rebuild(Concurrent::Set.new(fresh))
+      commit_rebuild(Concurrent::Set.new(fetch_tenant_names))
     rescue StandardError => e
       # Fail open: a broken tenants_provider must not blanket-404 the app.
       mark_degraded
@@ -117,6 +116,20 @@ module Apartment
         @degraded = true
         @built_at = monotonic
       end
+    end
+
+    # Reads the configured tenant source. A non-Enumerable return — nil from a
+    # misconfigured provider, or a stray scalar — is a provider failure, not
+    # "zero tenants": it raises, so perform_rebuild's rescue fails open and logs,
+    # the same as a provider that raised. An empty Enumerable is legitimate (a
+    # fresh install with no tenants) and is left to 404 unknown names.
+    def fetch_tenant_names
+      raw = Apartment.config.tenants_provider.call
+      unless raw.respond_to?(:each)
+        raise(ConfigurationError, "tenants_provider must return an Enumerable, got #{raw.class}")
+      end
+
+      Array(raw).map(&:to_s)
     end
 
     # Apply a lifecycle change to the live set. While a rebuild is in flight
@@ -148,7 +161,7 @@ module Apartment
     end
 
     def warn_degraded(error)
-      message = '[Apartment] tenant validation degraded: tenants_provider raised ' \
+      message = '[Apartment] tenant validation degraded: ' \
                 "#{error.class}: #{error.message}. Allowing all tenants until it recovers."
       if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
         Rails.logger.error(message)

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -5,6 +5,9 @@ Dummy::Application.configure do
   config.eager_load = false
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.action_dispatch.show_exceptions = :none
+  # :rescuable (the modern Rails test-env default) renders exceptions listed
+  # in rescue_responses as their mapped status — so Apartment::TenantNotFound
+  # surfaces as a real 404 — while still re-raising anything unexpected.
+  config.action_dispatch.show_exceptions = :rescuable
   config.active_support.deprecation = :stderr
 end

--- a/spec/dummy/config/initializers/apartment.rb
+++ b/spec/dummy/config/initializers/apartment.rb
@@ -2,7 +2,10 @@
 
 Apartment.configure do |config|
   config.tenant_strategy = :schema
-  config.tenants_provider = -> { Company.pluck(:database) }
+  # Static tenant list for the dummy app: the request-lifecycle spec creates
+  # exactly these tenants, and the elevator validates resolved subdomains
+  # against this list before switching.
+  config.tenants_provider = -> { %w[public acme widgets] }
   config.default_tenant = 'public'
   config.elevator = :subdomain
   config.schema_load_strategy = nil # dummy app manages its own schema

--- a/spec/integration/v4/request_lifecycle_spec.rb
+++ b/spec/integration/v4/request_lifecycle_spec.rb
@@ -144,4 +144,17 @@ RSpec.describe(
     body = JSON.parse(last_response.body)
     expect(body['tenant']).to(eq('public'))
   end
+
+  it 'returns 404 for an unknown subdomain instead of a 500' do
+    header 'Host', 'ghost.example.com'
+    get '/tenant_info'
+    expect(last_response.status).to(eq(404))
+  end
+
+  it 'switches normally for a known tenant (validation does not block valid tenants)' do
+    header 'Host', 'acme.example.com'
+    get '/tenant_info'
+    expect(last_response).to(be_ok)
+    expect(JSON.parse(last_response.body)['tenant']).to(eq('acme'))
+  end
 end

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -477,4 +477,49 @@ RSpec.describe(Apartment) do
       expect(result).to(eq('postgresql'))
     end
   end
+
+  describe '.tenant_validator' do
+    it 'returns an always-true callable when config.tenant_validator is false' do
+      described_class.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+        c.tenant_validator = false
+      end
+      expect(described_class.tenant_validator.call('anything')).to(be(true))
+    end
+
+    it 'returns the configured callable when one is set' do
+      custom = ->(name) { name == 'acme' }
+      described_class.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+        c.tenant_validator = custom
+      end
+      expect(described_class.tenant_validator).to(equal(custom))
+    end
+
+    it 'returns a built-in TenantValidator when unset, memoized per process' do
+      described_class.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+      end
+      first = described_class.tenant_validator
+      expect(first).to(be_a(Apartment::TenantValidator))
+      expect(described_class.tenant_validator).to(equal(first))
+    end
+
+    it 'discards the built-in validator on clear_config' do
+      described_class.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+      end
+      first = described_class.tenant_validator
+      described_class.clear_config
+      described_class.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+      end
+      expect(described_class.tenant_validator).not_to(equal(first))
+    end
+  end
 end

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -521,5 +521,23 @@ RSpec.describe(Apartment) do
       end
       expect(described_class.tenant_validator).not_to(equal(first))
     end
+
+    it 'builds the built-in validator once under concurrent first access' do
+      described_class.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+      end
+      call_count = Concurrent::AtomicFixnum.new(0)
+      original = Apartment::TenantValidator.method(:new)
+      allow(Apartment::TenantValidator).to(receive(:new)) do
+        call_count.increment
+        sleep(0.02) # widen the race window so an unsynchronized ||= is caught
+        original.call
+      end
+
+      Array.new(20) { Thread.new { described_class.tenant_validator } }.each(&:join)
+
+      expect(call_count.value).to(eq(1))
+    end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -558,6 +558,48 @@ RSpec.describe(Apartment::Config) do
       expect(config.rails_env_name).to(eq('default_env'))
     end
   end
+
+  describe '#tenant_validator' do
+    it 'defaults to nil' do
+      expect(described_class.new.tenant_validator).to(be_nil)
+    end
+
+    it 'accepts false (validation disabled)' do
+      config = described_class.new
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_validator = false
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'accepts a callable' do
+      config = described_class.new
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_validator = ->(name) { name == 'acme' }
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'rejects a non-callable, non-false value' do
+      config = described_class.new
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_validator = 'nope'
+      expect { config.validate! }
+        .to(raise_error(Apartment::ConfigurationError, /tenant_validator/))
+    end
+  end
+
+  describe '#tenant_not_found_handler' do
+    it 'rejects a non-callable value' do
+      config = described_class.new
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_not_found_handler = 'nope'
+      expect { config.validate! }
+        .to(raise_error(Apartment::ConfigurationError, /tenant_not_found_handler/))
+    end
+  end
 end
 
 RSpec.describe('Apartment.configure') do

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -141,5 +141,29 @@ RSpec.describe(Apartment::Elevators::Generic) do
       elevator = described_class.new(app, processor)
       expect(elevator.call(env)).to(eq([404, {}, ['routed']]))
     end
+
+    it 'raises TenantNotFound with the tenant name intact, not a nested message' do
+      elevator = described_class.new(app, ->(_req) { 'ghost' })
+      expect { elevator.call(env) }.to(raise_error(Apartment::TenantNotFound) do |error|
+        expect(error.tenant).to(eq('ghost'))
+        expect(error.message).to(eq("Tenant 'ghost' not found"))
+      end)
+    end
+
+    it 'passes the resolved tenant, not the host, when resolution raises TenantNotFound' do
+      received = nil
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.default_tenant = 'public'
+        c.tenants_provider = -> { %w[acme] }
+        c.tenant_not_found_handler = lambda { |tenant, _request|
+          received = tenant
+          [404, {}, []]
+        }
+      end
+      processor = ->(_req) { raise(Apartment::TenantNotFound, 'resolved-name') }
+      described_class.new(app, processor).call(env)
+      expect(received).to(eq('resolved-name'))
+    end
   end
 end

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -74,4 +74,72 @@ RSpec.describe(Apartment::Elevators::Generic) do
         .to(raise_error(NotImplementedError, /parse_tenant_name must be implemented/))
     end
   end
+
+  describe 'tenant validation' do
+    let(:app) { ->(_env) { [200, {}, ['ok']] } }
+    let(:env) { Rack::MockRequest.env_for('http://acme.example.com/') }
+
+    before do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.default_tenant = 'public'
+        c.tenants_provider = -> { %w[acme] }
+      end
+    end
+
+    it 'switches when the resolved tenant is valid' do
+      switched = nil
+      allow(Apartment::Tenant).to(receive(:switch)) do |name, &blk|
+        switched = name
+        blk.call
+      end
+      elevator = described_class.new(app, ->(_req) { 'acme' })
+      elevator.call(env)
+      expect(switched).to(eq('acme'))
+    end
+
+    it 'raises TenantNotFound when the resolved tenant is invalid and no handler is set' do
+      elevator = described_class.new(app, ->(_req) { 'ghost' })
+      expect { elevator.call(env) }.to(raise_error(Apartment::TenantNotFound, /ghost/))
+    end
+
+    it 'calls tenant_not_found_handler when configured, returning its Rack response' do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.default_tenant = 'public'
+        c.tenants_provider = -> { %w[acme] }
+        c.tenant_not_found_handler = ->(tenant, _request) { [404, {}, ["no #{tenant}"]] }
+      end
+      elevator = described_class.new(app, ->(_req) { 'ghost' })
+      expect(elevator.call(env)).to(eq([404, {}, ['no ghost']]))
+    end
+
+    it 'does not validate when the processor returns nil (default tenant)' do
+      elevator = described_class.new(app, ->(_req) {})
+      expect(elevator.call(env)).to(eq([200, {}, ['ok']]))
+    end
+
+    it 'treats the default tenant as always valid' do
+      switched = nil
+      allow(Apartment::Tenant).to(receive(:switch)) do |name, &blk|
+        switched = name
+        blk.call
+      end
+      elevator = described_class.new(app, ->(_req) { 'public' })
+      elevator.call(env)
+      expect(switched).to(eq('public'))
+    end
+
+    it 'routes a TenantNotFound raised during resolution through the handler' do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.default_tenant = 'public'
+        c.tenants_provider = -> { %w[acme] }
+        c.tenant_not_found_handler = ->(_tenant, _request) { [404, {}, ['routed']] }
+      end
+      processor = ->(_req) { raise(Apartment::TenantNotFound, 'unmapped host') }
+      elevator = described_class.new(app, processor)
+      expect(elevator.call(env)).to(eq([404, {}, ['routed']]))
+    end
+  end
 end

--- a/spec/unit/lifecycle_spec.rb
+++ b/spec/unit/lifecycle_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Apartment::Lifecycle) do
+  describe '.notify_created' do
+    it 'publishes a create.apartment event carrying the tenant name' do
+      events = []
+      ActiveSupport::Notifications.subscribe('create.apartment') { |event| events << event }
+
+      described_class.notify_created('acme')
+
+      expect(events.size).to(eq(1))
+      expect(events.first.payload).to(include(tenant: 'acme'))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('create.apartment')
+    end
+  end
+
+  describe '.notify_dropped' do
+    it 'publishes a drop.apartment event carrying the tenant name' do
+      events = []
+      ActiveSupport::Notifications.subscribe('drop.apartment') { |event| events << event }
+
+      described_class.notify_dropped('acme')
+
+      expect(events.size).to(eq(1))
+      expect(events.first.payload).to(include(tenant: 'acme'))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('drop.apartment')
+    end
+  end
+end

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -139,4 +139,19 @@ RSpec.describe('Apartment::Railtie') do
       expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
     end
   end
+
+  describe 'TenantNotFound rescue_responses mapping' do
+    # Unit specs do not boot a Rails::Application, so railtie initializers
+    # never run on their own — invoke the initializer block directly.
+    it 'maps Apartment::TenantNotFound to :not_found' do
+      require 'action_dispatch'
+      initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.rescue_responses' }
+      expect(initializer).not_to(be_nil)
+
+      initializer.run
+
+      expect(ActionDispatch::ExceptionWrapper.rescue_responses['Apartment::TenantNotFound'])
+        .to(eq(:not_found))
+    end
+  end
 end

--- a/spec/unit/tenant_validator_spec.rb
+++ b/spec/unit/tenant_validator_spec.rb
@@ -76,4 +76,37 @@ RSpec.describe(Apartment::TenantValidator) do
       expect(validator.call('acme')).to(be(false))
     end
   end
+
+  describe 'lifecycle invalidation' do
+    it 'adds a tenant on a create.apartment notification' do
+      configure(-> { %w[acme] })
+      validator = build_validator
+      expect(validator.call('newco')).to(be(false))
+      ActiveSupport::Notifications.instrument('create.apartment', tenant: 'newco') {}
+      expect(validator.call('newco')).to(be(true))
+    end
+
+    it 'removes a tenant on a drop.apartment notification' do
+      configure(-> { %w[acme widgets] })
+      validator = build_validator
+      expect(validator.call('widgets')).to(be(true))
+      ActiveSupport::Notifications.instrument('drop.apartment', tenant: 'widgets') {}
+      expect(validator.call('widgets')).to(be(false))
+    end
+
+    it 'stops responding to notifications after #shutdown' do
+      configure(-> { %w[acme] })
+      validator = build_validator
+      validator.shutdown
+      ActiveSupport::Notifications.instrument('create.apartment', tenant: 'newco') {}
+      expect(validator.call('newco')).to(be(false))
+    end
+  end
+
+  describe 'fail-open on source error' do
+    it 'allows any name when tenants_provider raises' do
+      configure(-> { raise(StandardError, 'provider down') })
+      expect(build_validator.call('anything')).to(be(true))
+    end
+  end
 end

--- a/spec/unit/tenant_validator_spec.rb
+++ b/spec/unit/tenant_validator_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'apartment/tenant_validator'
+
+RSpec.describe(Apartment::TenantValidator) do
+  # Track validators built per example so notification subscriptions (added in
+  # Task 3) are torn down. The respond_to? guard keeps this forward-compatible:
+  # #shutdown does not exist until Task 3.
+  def build_validator(**opts)
+    validator = described_class.new(**opts)
+    (@built_validators ||= []) << validator
+    validator
+  end
+
+  after do
+    (@built_validators || []).each { |v| v.shutdown if v.respond_to?(:shutdown) }
+  end
+
+  def configure(provider)
+    Apartment.configure do |c|
+      c.tenant_strategy = :schema
+      c.default_tenant = 'public'
+      c.tenants_provider = provider
+    end
+  end
+
+  describe '#call' do
+    it 'returns true for a name the provider lists' do
+      configure(-> { %w[acme widgets] })
+      expect(build_validator.call('acme')).to(be(true))
+    end
+
+    it 'returns false for a name the provider does not list' do
+      configure(-> { %w[acme widgets] })
+      expect(build_validator.call('ghost')).to(be(false))
+    end
+
+    it 'does not call the provider on every request (memoizes)' do
+      calls = 0
+      configure(lambda {
+        calls += 1
+        %w[acme]
+      })
+      validator = build_validator
+      5.times { validator.call('acme') }
+      expect(calls).to(eq(1))
+    end
+
+    it 'heals on a miss: a name added to the source becomes valid after a rebuild' do
+      names = %w[acme]
+      configure(-> { names })
+      validator = build_validator(rebuild_interval: 0)
+      expect(validator.call('widgets')).to(be(false))
+      names << 'widgets'
+      expect(validator.call('widgets')).to(be(true))
+    end
+
+    it 'rate-limits rebuilds: repeated misses inside the interval hit the source once' do
+      calls = 0
+      configure(lambda {
+        calls += 1
+        %w[acme]
+      })
+      validator = build_validator(rebuild_interval: 3600)
+      10.times { validator.call('ghost') }
+      expect(calls).to(eq(1)) # one lazy build; further misses are rate-limited
+    end
+
+    it 'rebuilds after the positive-set TTL' do
+      names = %w[acme]
+      configure(-> { names })
+      validator = build_validator(positive_ttl: 0)
+      expect(validator.call('acme')).to(be(true))
+      names.replace(%w[widgets])
+      expect(validator.call('acme')).to(be(false))
+    end
+  end
+end

--- a/spec/unit/tenant_validator_spec.rb
+++ b/spec/unit/tenant_validator_spec.rb
@@ -101,6 +101,22 @@ RSpec.describe(Apartment::TenantValidator) do
       ActiveSupport::Notifications.instrument('create.apartment', tenant: 'newco') {}
       expect(validator.call('newco')).to(be(false))
     end
+
+    it 'evicts a tenant added via Apartment::Lifecycle.notify_created' do
+      configure(-> { %w[acme] })
+      validator = build_validator
+      expect(validator.call('newco')).to(be(false))
+      Apartment::Lifecycle.notify_created('newco')
+      expect(validator.call('newco')).to(be(true))
+    end
+
+    it 'evicts a tenant removed via Apartment::Lifecycle.notify_dropped' do
+      configure(-> { %w[acme widgets] })
+      validator = build_validator
+      expect(validator.call('widgets')).to(be(true))
+      Apartment::Lifecycle.notify_dropped('widgets')
+      expect(validator.call('widgets')).to(be(false))
+    end
   end
 
   describe 'fail-open on source error' do

--- a/spec/unit/tenant_validator_spec.rb
+++ b/spec/unit/tenant_validator_spec.rb
@@ -117,6 +117,21 @@ RSpec.describe(Apartment::TenantValidator) do
 
       expect(build_validator.call('anything')).to(be(true))
     end
+
+    it 'fails open when tenants_provider returns nil' do
+      configure(-> {}) # an empty lambda returns nil
+      expect(build_validator.call('anything')).to(be(true))
+    end
+
+    it 'fails open when tenants_provider returns a non-Enumerable' do
+      configure(-> { 'acme' }) # a stray scalar, not a list of names
+      expect(build_validator.call('widgets')).to(be(true))
+    end
+
+    it 'treats an empty list as zero tenants (404s unknown names), not a source error' do
+      configure(-> { [] })
+      expect(build_validator.call('anything')).to(be(false))
+    end
   end
 
   describe 'concurrency' do

--- a/spec/unit/tenant_validator_spec.rb
+++ b/spec/unit/tenant_validator_spec.rb
@@ -108,5 +108,55 @@ RSpec.describe(Apartment::TenantValidator) do
       configure(-> { raise(StandardError, 'provider down') })
       expect(build_validator.call('anything')).to(be(true))
     end
+
+    it 'does not let a logging failure escape into the request path' do
+      configure(-> { raise(StandardError, 'provider down') })
+      broken_logger = double('logger')
+      allow(broken_logger).to(receive(:error).and_raise(IOError, 'log stream closed'))
+      stub_const('Rails', double(logger: broken_logger))
+
+      expect(build_validator.call('anything')).to(be(true))
+    end
+  end
+
+  describe 'concurrency' do
+    it 'does not false-404 a valid tenant while the first build is in progress' do
+      provider_running = Queue.new
+      finish_provider = Queue.new
+      configure(lambda {
+        provider_running << true
+        finish_provider.pop
+        %w[acme]
+      })
+      validator = build_validator
+      results = Concurrent::Hash.new
+
+      t1 = Thread.new { results[:t1] = validator.call('acme') }
+      provider_running.pop          # t1 is blocked inside the first build's provider call
+      t2 = Thread.new { results[:t2] = validator.call('acme') }
+      sleep(0.05)                   # give t2 time to reach the (blocking) rebuild
+      finish_provider << true       # release the provider
+      [t1, t2].each(&:join)
+
+      expect(results).to(eq(t1: true, t2: true))
+    end
+
+    it 'preserves a create.apartment notification that lands mid-rebuild' do
+      provider_running = Queue.new
+      finish_provider = Queue.new
+      configure(lambda {
+        provider_running << true
+        finish_provider.pop
+        %w[acme]                    # the provider snapshot excludes newco
+      })
+      validator = build_validator
+      builder = Thread.new { validator.call('acme') }
+      provider_running.pop          # the rebuild is inside provider.call
+      ActiveSupport::Notifications.instrument('create.apartment', tenant: 'newco') {}
+      finish_provider << true
+      builder.join
+
+      expect(validator.call('newco')).to(be(true))
+    end
   end
 end


### PR DESCRIPTION
## Summary

Elevators now validate the resolved tenant name before switching, so an unknown subdomain returns a clean 404 instead of an opaque 500 from a non-existent schema.

Two pluggable seams in `Generic#call`:
- **`config.tenant_validator`** (`name -> bool`) — runs by default via a built-in in-process `TenantValidator`: a memoized `Set` of valid names, rate-limited single-flight rebuild-on-miss, TTL backstop, lifecycle invalidation via `create.apartment`/`drop.apartment` notifications, fail-open on source error. Disable with `config.tenant_validator = false`, or pass a custom callable.
- **`config.tenant_not_found_handler`** (`(tenant, request) -> Rack response`) — routes an unknown tenant (or a `TenantNotFound` raised during resolution, e.g. `HostHash` on an unmapped host) through a custom response.

When no handler is set, `Generic#call` raises `Apartment::TenantNotFound`; a new railtie initializer maps that exception to `:not_found` so an unconfigured app renders its own 404.

For tenants provisioned outside `Apartment::Tenant.create` / `.drop` (raw `psql`, `pg_restore`, a separate schema-cloning job), `Apartment::Lifecycle.notify_created(name)` / `notify_dropped(name)` publish the events the validator already subscribes to — closing the rebuild-on-miss / TTL gap on the new tenant's first request without leaking the event-name contract into caller code.

Design: `docs/designs/elevator-tenant-validation.md` · Plan: `docs/plans/elevator-tenant-validation/implementation.md`

## Changes

- `Config#tenant_validator` accessor + validation of both elevator hooks
- New `Apartment::TenantValidator` (in-process validator) + `Apartment.tenant_validator` resolver, torn down on `clear_config`/`configure`
- New `Apartment::Lifecycle.notify_created` / `notify_dropped` — thin wrappers over `Instrumentation.instrument(:create|:drop, tenant:)` for external provisioners
- `Generic#call` rewritten: validate before switch, narrow rescue routes resolution-time `TenantNotFound` through the handler without wrapping `@app.call`
- Railtie `apartment.rescue_responses` initializer: `TenantNotFound -> :not_found`
- Docs: rewrote the v4-elevators "Error Handling" section (was "Generic does not rescue; adapter-level hook"), added an "External schema provisioning" subsection to the design doc, breaking-change + lifecycle-helper notes in `docs/upgrading-to-v4.md`

### Notes / deviations from the plan
- `tenant_valid?` guards a nil `Apartment.config` (the plan's verbatim code would `NoMethodError` on pre-existing elevator unit tests).
- Railtie uses a `key?` check, not `||=` — `rescue_responses` defaults missing keys to `:internal_server_error`, so `||=` would never assign.
- The repo has no top-level `CHANGELOG.md`; the breaking-change entry went into the v4 upgrade guide. The dummy app's `tenants_provider` (previously an unseeded `Company` table, always `[]`) and `show_exceptions = :none` were also adjusted so the integration test exercises the real 404 path.
- Pre-existing, unrelated: `railtie_spec.rb` `.header_trust_warning?` fails under `-r rails` (`Subdomain <= Header` is `nil`) — not addressed here.

## Code review

A multi-model review (Codex, Gemini, Cursor, Mistral) plus self-review surfaced concurrency bugs in `TenantValidator` and one silent-outage hole. All addressed:

- **Cold-start single-flight false-404** — a thread losing the `try_lock` race on the *first* build evaluated against the empty initial set and 404'd a valid tenant. The first build is now blocking; refreshes stay non-blocking.
- **Lost lifecycle update** — the whole-set swap on rebuild discarded a `create`/`drop` notification that landed during the provider call. Deltas are captured during the rebuild and re-applied to the new set.
- **Built-in validator memoization leak** — `Apartment.tenant_validator`'s unsynchronized `||=` could construct multiple validators under concurrent first access, orphaning all but one with a live notification subscription. Guarded with double-checked locking.
- **`TenantNotFound` construction** — `raise(TenantNotFound, "No tenant found for …")` put the whole sentence into `#tenant` (its initializer treats the arg as the tenant name). Pass the bare name; the resolution-time rescue also preserves the exception's own `#tenant`.
- **`warn_degraded`** — a failing logger raised out of the rebuild into the request path; logging failures are now swallowed.
- **Silent outage on a non-Enumerable `tenants_provider` return** — `Array(provider.call)` collapsed `nil` (a one-line provider misconfig) to `[]`, leaving `@degraded` false: every tenant 404'd, no exception, no log. `fetch_tenant_names` now requires the return to respond to `:each` — the same contract `Apartment.tenant_names` already enforces — and a non-Enumerable raises `ConfigurationError` into the existing rescue, failing open with a log. An empty `[]` is still a legitimate "zero tenants" and 404s unknown names; the `nil`/`[]` asymmetry is the design line.

A separate review on a real v4 deployment surfaced one general-class follow-up: schemas provisioned outside `Apartment::Tenant.create` (raw `psql`, `pg_restore`, separate cloning job) skip the `create.apartment` notification and live on rebuild-on-miss. Added `Apartment::Lifecycle.notify_created(name)` / `notify_dropped(name)` as the public API for that path; tracked the related cross-process invalidation work in #414.

Specs for each fix: latch-driven for the concurrency races (cold-start, notification-during-rebuild, concurrent memoization), plain assertions for the rest. `Apartment::Lifecycle` ships with a dedicated unit spec plus two contract examples in `tenant_validator_spec` proving the helper actually moves the validator's positive set.

Out of scope (review findings not addressed): non-MRI memory visibility of plain ivars (off apartment's CRuby-only CI matrix); `warn_degraded` log cadence while degraded; the inherent TOCTOU between validate and switch; cross-process invalidation (tracked in #414).

## Concurrency & fiber-safety

`TenantValidator`'s registry is process-global shared state, safe under both threads and fibers — which matters because v4 is fiber-first (`isolation_level = :fiber`).

- The positive set is a `concurrent-ruby` set; a rebuild swaps a whole new set under a state mutex, re-applying lifecycle deltas captured during the (unlocked) provider call.
- Single-flight is a `Mutex`, owned per-*fiber* on Ruby 3.0+ (apartment requires ≥ 3.3): a second fiber on the same thread blocks rather than re-entering, and every lock is released by the fiber that took it. Single-flight holds under a fiber scheduler, not just under threads.
- The registry is deliberately **not** an `ActiveSupport::CurrentAttributes`: that is request-scoped (reset before and after every request), so it would wipe the valid-tenant set each request and collapse the memoized cache into a per-request DB query. `CurrentAttributes` is for the *current tenant* (`Apartment::Current` — per-request context); the *set of all valid tenants* is shared global data, the opposite kind of state.

The rationale for every non-obvious choice — on-by-default validation, raise + `rescue_responses` over a gem-rendered 404, name-only validator, no negative cache, blocking first build, fail-open on a provider error or non-Enumerable return, and the `CurrentAttributes` rejection — is recorded in `docs/designs/elevator-tenant-validation.md` (sections "Built-in validator", "External schema provisioning", and "Alternatives considered").

## Test Plan

- [x] `bundle exec rspec spec/unit/` — 799 examples, 0 failures
- [x] `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/` — 0 failures
- [x] `railtie_spec.rb` under appraisal with `-r rails` — rescue_responses mapping verified
- [x] `DATABASE_ENGINE=postgresql ... rspec spec/integration/v4/ --exclude-pattern "**/request_lifecycle_spec.rb"` — 132 examples, 0 failures
- [x] `DATABASE_ENGINE=postgresql ... rspec spec/integration/v4/request_lifecycle_spec.rb` — 7 examples, 0 failures (unknown subdomain -> 404, known tenant still switches)
- [x] Concurrency specs stable across repeated seeds
- [x] `rubocop` on all changed Ruby files — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)