### PR TITLE
Fix: propagate tenant context into ActionController::Live threads

### DIFF
--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -10,7 +10,7 @@ module Apartment
     # resolved by the adapter using the current role's base config.
     module ConnectionHandling
       def connection_pool # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        tenant = Apartment::Current.tenant
+        tenant = Apartment::Current.tenant || Thread.current.thread_variable_get(:apartment_current_tenant)
         cfg = Apartment.config
 
         return super if tenant.nil? || cfg.nil?

--- a/lib/apartment/patches/live_tenant_propagation.rb
+++ b/lib/apartment/patches/live_tenant_propagation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Apartment
+  module Patches
+    # Prepended on ActionController::Live to propagate tenant context
+    # into the thread spawned for streaming responses.
+    #
+    # ActionController::Live#new_controller_thread spawns a new thread (Thread B)
+    # for the controller action. Under :fiber isolation, child fibers within
+    # Thread B do not inherit CurrentAttributes from the parent fiber.
+    # We store the tenant via thread_variable_set so the ConnectionHandling
+    # fallback can resolve tenant context regardless of which fiber the query
+    # runs on. (Thread#[] is fiber-local in Ruby 3.2+; thread_variable_set/get
+    # is truly thread-scoped and visible across all fibers.)
+    module LiveTenantPropagation
+      def new_controller_thread
+        tenant = Apartment::Current.tenant
+        super do
+          Thread.current.thread_variable_set(:apartment_current_tenant, tenant)
+          yield
+        ensure
+          Thread.current.thread_variable_set(:apartment_current_tenant, nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -28,6 +28,7 @@ module Apartment
         warn '[Apartment] Database not found during init — skipping. Run db:create first.'
       end
 
+      Apartment::Railtie.apply_live_tenant_propagation!
       Apartment::Railtie.deactivate_pool_reaper_in_test_env!
     end
 
@@ -128,6 +129,15 @@ module Apartment
 
       Apartment.pool_reaper.stop
       Apartment::Instrumentation.instrument(:reaper_stopped, reason: :test_env)
+    end
+
+    # Prepend LiveTenantPropagation on ActionController::Live so tenant
+    # context is automatically copied into the streaming thread.
+    def self.apply_live_tenant_propagation!
+      return unless defined?(ActionController::Live)
+
+      require('apartment/patches/live_tenant_propagation')
+      ActionController::Live.prepend(Apartment::Patches::LiveTenantPropagation)
     end
 
     # Resolve an elevator symbol/string to its class. Class method for testability.

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -180,6 +180,22 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
       end
     end
 
+    context 'when Current.tenant is nil (e.g. child fiber in ActionController::Live thread)' do
+      after { Thread.current.thread_variable_set(:apartment_current_tenant, nil) }
+
+      it 'falls back to thread variable for tenant resolution' do
+        Apartment::Current.tenant = nil
+        role = ActiveRecord::Base.current_role
+
+        ActiveRecord::Base.connection_pool
+        expect(Apartment.pool_manager.tracked?("acme:#{role}")).to(be(false))
+
+        Thread.current.thread_variable_set(:apartment_current_tenant, 'acme')
+        ActiveRecord::Base.connection_pool
+        expect(Apartment.pool_manager.tracked?("acme:#{role}")).to(be(true))
+      end
+    end
+
     context 'when pool_manager is nil (unconfigured)' do
       it 'returns the default pool without raising' do
         Apartment.clear_config

--- a/spec/unit/patches/live_tenant_propagation_spec.rb
+++ b/spec/unit/patches/live_tenant_propagation_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'apartment/patches/live_tenant_propagation'
+
+RSpec.describe(Apartment::Patches::LiveTenantPropagation) do
+  let(:controller) do
+    Class.new do
+      def new_controller_thread
+        yield
+      end
+
+      prepend Apartment::Patches::LiveTenantPropagation
+    end.new
+  end
+
+  after { Apartment::Current.reset }
+
+  it 'sets tenant thread variable during block execution' do
+    Apartment::Current.tenant = 'acme'
+
+    tenant_during = nil
+    controller.new_controller_thread do
+      tenant_during = Thread.current.thread_variable_get(:apartment_current_tenant)
+    end
+
+    expect(tenant_during).to(eq('acme'))
+  end
+
+  it 'clears tenant thread variable after completion' do
+    Apartment::Current.tenant = 'acme'
+
+    controller.new_controller_thread {}
+
+    expect(Thread.current.thread_variable_get(:apartment_current_tenant)).to(be_nil)
+  end
+end

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -145,6 +145,23 @@ if railtie_loaded
       end
     end
 
+    describe '.apply_live_tenant_propagation!' do
+      it 'prepends LiveTenantPropagation on ActionController::Live when defined' do
+        live_module = Module.new
+        stub_const('ActionController::Live', live_module)
+
+        Apartment::Railtie.apply_live_tenant_propagation!
+
+        expect(live_module.ancestors).to(include(Apartment::Patches::LiveTenantPropagation))
+      end
+
+      it 'is a no-op when ActionController::Live is not defined' do
+        hide_const('ActionController::Live') if defined?(ActionController::Live)
+
+        expect { Apartment::Railtie.apply_live_tenant_propagation! }.not_to(raise_error)
+      end
+    end
+
     describe '.deactivate_pool_reaper_in_test_env!' do
       it 'stops Apartment.pool_reaper when Rails.env.test? is true' do
         reaper = instance_double(Apartment::PoolReaper, stop: nil)


### PR DESCRIPTION
When using SSE (Server-Sent Events), Rails spawns a new thread via
ActionController::Live to execute the controller action.                                                                        
The tenant context set on the original thread is not carried over                                                                                                                      
to the new thread, causing queries to route to the wrong tenant.                                                                                                                       
                                                                                                                                                                                       
To fix this, we copy the tenant into a thread variable at the point                                                                                                                    
the new thread is created, and added a fallback read in ConnectionHandling.                                                                                                            
This is auto-applied via Railtie — no user code changes required.                                                                                                                      
 
This is admittedly a bit of magic — it works by prepending around                                                                                                                      
Rails' internal method (`new_controller_thread`), so it may need                                                                                                                     
review when upgrading Rails versions.                                                                                                                                                  