### PR TITLE
Test: stop hiding railtie_spec behind a silent skip; fix the bug it was masking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ on:
 
 jobs:
   # ── Unit tests (no database required) ──────────────────────────────
-  # Also runs spec/unit/rspec_rails_lifecycle_spec.rb across the full matrix —
-  # it needs rspec-rails, which the appraisal gemfiles carry. RSPEC_RAILS_REQUIRED
-  # turns a missing rspec-rails into a hard failure rather than a silent skip.
+  # Also runs spec/unit/rspec_rails_lifecycle_spec.rb and spec/unit/railtie_spec.rb
+  # across the full matrix — both self-require heavy deps (rspec-rails, rails)
+  # because spec_helper.rb stays Rails-free. The appraisal gemfiles carry the
+  # deps. {RSPEC_RAILS,RAILTIE_SPEC}_REQUIRED turn a missing dep into a hard
+  # failure rather than a silent skip (railtie_spec silently pended for months
+  # without it, masking a real bug in header_trust_warning?).
   unit:
     name: Unit · Ruby ${{ matrix.ruby }} · Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
@@ -44,6 +47,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_${{ matrix.rails }}_sqlite3.gemfile
       RSPEC_RAILS_REQUIRED: '1'
+      RAILTIE_SPEC_REQUIRED: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -107,7 +107,12 @@ module Apartment
 
     # Whether the Header elevator trust warning should fire. Class method for testability.
     def self.header_trust_warning?(elevator_class, opts)
-      elevator_class <= Apartment::Elevators::Header && !opts[:trusted]
+      # Module#<= returns nil (not false) for unrelated classes, so a bare
+      # `&&` would let unrelated elevators slip through as nil — coerce via
+      # an explicit guard so non-Header elevators report false.
+      return false unless elevator_class <= Apartment::Elevators::Header
+
+      !opts[:trusted]
     end
 
     # In test environments the reaper is more liability than asset: suites

--- a/spec/CLAUDE.md
+++ b/spec/CLAUDE.md
@@ -125,6 +125,16 @@ Opt-in via `COVERAGE=1 bundle exec rspec spec/unit/`. Reports to `coverage/` (gi
 
 **Selection**: Via `DB` environment variable (`DB=postgresql`, `DB=mysql`, `DB=sqlite3`)
 
+### CI hard-fail flags for self-required deps
+
+Some specs self-require a heavy dep in a `begin/rescue LoadError` so they skip gracefully when the dep isn't loadable. The risk: if the targeted CI job's bundle silently loses the dep, the spec keeps skipping and covers nothing. Three `*_REQUIRED` env vars turn that skip into a hard failure in the job that's *supposed* to load the dep:
+
+- `RSPEC_RAILS_REQUIRED=1` — `spec/unit/rspec_rails_lifecycle_spec.rb` (needs rspec-rails)
+- `RAILTIE_SPEC_REQUIRED=1` — `spec/unit/railtie_spec.rb` (needs rails + apartment/railtie)
+- `REQUEST_LIFECYCLE_REQUIRED=1` — `spec/integration/v4/request_lifecycle_spec.rb` (needs the dummy app)
+
+Pattern: `begin require('<dep>'); rescue LoadError => e; raise if ENV['<FLAG>']; warn '...'; ... end`. CI's relevant job sets the flag; everywhere else the skip remains graceful. When adding a new self-required spec, mirror this idiom and add the flag here so the convention stays discoverable.
+
 ## Shared Examples (spec/examples/)
 
 **Why shared examples?**: Apartment promises a unified API regardless of database. Without shared examples, behavior could diverge between PostgreSQL and MySQL implementations.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# Default RAILS_ENV to 'test' before any spec loads. The rails_stub hardcodes
+# Rails.env to 'test' (see spec/support/rails_stub.rb); specs that load real
+# Rails (railtie_spec.rb) would otherwise get Rails' own default of
+# 'development', diverging from the stubbed contract and breaking adapter
+# specs that compute environmentified names from Rails.env.
+ENV['RAILS_ENV'] ||= 'test'
+
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start do

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -2,156 +2,176 @@
 
 require 'spec_helper'
 
-# Railtie loads automatically when Rails is present (via lib/apartment.rb).
-# Without Rails, Apartment::Railtie is not defined — skip gracefully.
-RSpec.describe('Apartment::Railtie') do
-  before do
-    skip 'requires Rails (run via appraisal)' unless defined?(Apartment::Railtie)
+# spec_helper.rb deliberately does not load Rails — the gem suite is
+# Rails-free (see spec/support/rails_stub.rb). This spec self-requires
+# Rails and the Railtie so it actually runs; without that, every example
+# silently pended under `bundle exec rspec spec/unit/`. When Rails is
+# absent the spec still skips gracefully; RAILTIE_SPEC_REQUIRED turns
+# the skip into a hard failure in CI, where the Rails bundle must be
+# present. Same idiom as spec/unit/rspec_rails_lifecycle_spec.rb and
+# REQUEST_LIFECYCLE_REQUIRED.
+railtie_loaded =
+  begin
+    require('rails')
+    require('apartment/railtie')
+    true
+  rescue LoadError => e
+    raise if ENV['RAILTIE_SPEC_REQUIRED']
+
+    warn "[railtie_spec] skipping: #{e.message}"
+    false
   end
 
-  describe '.resolve_elevator_class' do
-    it 'resolves :subdomain to Apartment::Elevators::Subdomain' do
-      klass = Apartment::Railtie.resolve_elevator_class(:subdomain)
-      expect(klass).to(eq(Apartment::Elevators::Subdomain))
-    end
+if railtie_loaded
+  RSpec.describe('Apartment::Railtie') do
+    describe '.resolve_elevator_class' do
+      it 'resolves :subdomain to Apartment::Elevators::Subdomain' do
+        klass = Apartment::Railtie.resolve_elevator_class(:subdomain)
+        expect(klass).to(eq(Apartment::Elevators::Subdomain))
+      end
 
-    it 'resolves :domain to Apartment::Elevators::Domain' do
-      klass = Apartment::Railtie.resolve_elevator_class(:domain)
-      expect(klass).to(eq(Apartment::Elevators::Domain))
-    end
+      it 'resolves :domain to Apartment::Elevators::Domain' do
+        klass = Apartment::Railtie.resolve_elevator_class(:domain)
+        expect(klass).to(eq(Apartment::Elevators::Domain))
+      end
 
-    it 'resolves :host to Apartment::Elevators::Host' do
-      klass = Apartment::Railtie.resolve_elevator_class(:host)
-      expect(klass).to(eq(Apartment::Elevators::Host))
-    end
+      it 'resolves :host to Apartment::Elevators::Host' do
+        klass = Apartment::Railtie.resolve_elevator_class(:host)
+        expect(klass).to(eq(Apartment::Elevators::Host))
+      end
 
-    it 'raises ConfigurationError for unknown elevator' do
-      expect { Apartment::Railtie.resolve_elevator_class(:nonexistent) }
-        .to(raise_error(Apartment::ConfigurationError, /Unknown elevator.*nonexistent/))
-    end
+      it 'raises ConfigurationError for unknown elevator' do
+        expect { Apartment::Railtie.resolve_elevator_class(:nonexistent) }
+          .to(raise_error(Apartment::ConfigurationError, /Unknown elevator.*nonexistent/))
+      end
 
-    it 'includes available elevators in the error message' do
-      expect { Apartment::Railtie.resolve_elevator_class(:nonexistent) }
-        .to(raise_error(Apartment::ConfigurationError, /subdomain/))
-    end
+      it 'includes available elevators in the error message' do
+        expect { Apartment::Railtie.resolve_elevator_class(:nonexistent) }
+          .to(raise_error(Apartment::ConfigurationError, /subdomain/))
+      end
 
-    it 'passes through a class without resolution' do
-      klass = Apartment::Railtie.resolve_elevator_class(Apartment::Elevators::Subdomain)
-      expect(klass).to(eq(Apartment::Elevators::Subdomain))
-    end
+      it 'passes through a class without resolution' do
+        klass = Apartment::Railtie.resolve_elevator_class(Apartment::Elevators::Subdomain)
+        expect(klass).to(eq(Apartment::Elevators::Subdomain))
+      end
 
-    it 'passes through any custom class' do
-      custom_class = Class.new(Apartment::Elevators::Generic)
-      klass = Apartment::Railtie.resolve_elevator_class(custom_class)
-      expect(klass).to(eq(custom_class))
-    end
+      it 'passes through any custom class' do
+        custom_class = Class.new(Apartment::Elevators::Generic)
+        klass = Apartment::Railtie.resolve_elevator_class(custom_class)
+        expect(klass).to(eq(custom_class))
+      end
 
-    it 'resolves :header to Apartment::Elevators::Header' do
-      klass = Apartment::Railtie.resolve_elevator_class(:header)
-      expect(klass).to(eq(Apartment::Elevators::Header))
-    end
-  end
-
-  describe '.insert_elevator_middleware' do
-    let(:middleware_stack) { double('MiddlewareStack') }
-    let(:elevator_class) { Apartment::Elevators::Subdomain }
-
-    before do
-      Apartment.configure do |config|
-        config.tenant_strategy = :schema
-        config.tenants_provider = -> { [] }
-        config.elevator = :subdomain
+      it 'resolves :header to Apartment::Elevators::Header' do
+        klass = Apartment::Railtie.resolve_elevator_class(:header)
+        expect(klass).to(eq(Apartment::Elevators::Header))
       end
     end
 
-    it 'inserts after ActionDispatch::Callbacks' do
-      expect(middleware_stack).to(receive(:insert_after).with(ActionDispatch::Callbacks, elevator_class))
-      Apartment::Railtie.insert_elevator_middleware(middleware_stack, elevator_class)
+    describe '.insert_elevator_middleware' do
+      let(:middleware_stack) { double('MiddlewareStack') }
+      let(:elevator_class) { Apartment::Elevators::Subdomain }
+
+      before do
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { [] }
+          config.elevator = :subdomain
+        end
+      end
+
+      it 'inserts after ActionDispatch::Callbacks' do
+        expect(middleware_stack).to(receive(:insert_after).with(ActionDispatch::Callbacks, elevator_class))
+        Apartment::Railtie.insert_elevator_middleware(middleware_stack, elevator_class)
+      end
+
+      it 'forwards kwargs to insert_after' do
+        expect(middleware_stack).to(
+          receive(:insert_after).with(ActionDispatch::Callbacks, elevator_class, foo: :bar)
+        )
+        Apartment::Railtie.insert_elevator_middleware(middleware_stack, elevator_class, foo: :bar)
+      end
     end
 
-    it 'forwards kwargs to insert_after' do
-      expect(middleware_stack).to(
-        receive(:insert_after).with(ActionDispatch::Callbacks, elevator_class, foo: :bar)
-      )
-      Apartment::Railtie.insert_elevator_middleware(middleware_stack, elevator_class, foo: :bar)
+    describe '.header_trust_warning?' do
+      it 'returns true for Header with trusted: false' do
+        expect(Apartment::Railtie.header_trust_warning?(Apartment::Elevators::Header, {})).to(be(true))
+      end
+
+      it 'returns false for Header with trusted: true' do
+        expect(Apartment::Railtie.header_trust_warning?(Apartment::Elevators::Header, { trusted: true })).to(be(false))
+      end
+
+      it 'returns true for Header subclass with trusted: false' do
+        subclass = Class.new(Apartment::Elevators::Header)
+        expect(Apartment::Railtie.header_trust_warning?(subclass, {})).to(be(true))
+      end
+
+      it 'returns false for non-Header elevator' do
+        expect(Apartment::Railtie.header_trust_warning?(Apartment::Elevators::Subdomain, {})).to(be(false))
+      end
+    end
+
+    describe '.deactivate_pool_reaper_in_test_env!' do
+      it 'stops Apartment.pool_reaper when Rails.env.test? is true' do
+        reaper = instance_double(Apartment::PoolReaper, stop: nil)
+        allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+        Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+        expect(reaper).to(have_received(:stop))
+      end
+
+      it 'emits reaper_stopped.apartment with reason :test_env when it stops the reaper' do
+        reaper = instance_double(Apartment::PoolReaper, stop: nil)
+        allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+        events = []
+        sub = ActiveSupport::Notifications.subscribe('reaper_stopped.apartment') { |e| events << e }
+
+        Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+        expect(events.size).to(eq(1))
+        expect(events.first.payload).to(eq(reason: :test_env))
+      ensure
+        ActiveSupport::Notifications.unsubscribe(sub) if sub
+      end
+
+      it 'does nothing outside the test environment' do
+        reaper = instance_double(Apartment::PoolReaper, stop: nil)
+        allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('production')))
+
+        Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+        expect(reaper).not_to(have_received(:stop))
+      end
+
+      it 'is a no-op when no reaper is configured' do
+        allow(Apartment).to(receive(:pool_reaper).and_return(nil))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+        expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
+      end
+    end
+
+    describe 'TenantNotFound rescue_responses mapping' do
+      # Unit specs do not boot a Rails::Application, so railtie initializers
+      # never run on their own — invoke the initializer block directly.
+      it 'maps Apartment::TenantNotFound to :not_found' do
+        require 'action_dispatch'
+        initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.rescue_responses' }
+        expect(initializer).not_to(be_nil)
+
+        initializer.run
+
+        expect(ActionDispatch::ExceptionWrapper.rescue_responses['Apartment::TenantNotFound'])
+          .to(eq(:not_found))
+      end
     end
   end
-
-  describe '.header_trust_warning?' do
-    it 'returns true for Header with trusted: false' do
-      expect(Apartment::Railtie.header_trust_warning?(Apartment::Elevators::Header, {})).to(be(true))
-    end
-
-    it 'returns false for Header with trusted: true' do
-      expect(Apartment::Railtie.header_trust_warning?(Apartment::Elevators::Header, { trusted: true })).to(be(false))
-    end
-
-    it 'returns true for Header subclass with trusted: false' do
-      subclass = Class.new(Apartment::Elevators::Header)
-      expect(Apartment::Railtie.header_trust_warning?(subclass, {})).to(be(true))
-    end
-
-    it 'returns false for non-Header elevator' do
-      expect(Apartment::Railtie.header_trust_warning?(Apartment::Elevators::Subdomain, {})).to(be(false))
-    end
-  end
-
-  describe '.deactivate_pool_reaper_in_test_env!' do
-    it 'stops Apartment.pool_reaper when Rails.env.test? is true' do
-      reaper = instance_double(Apartment::PoolReaper, stop: nil)
-      allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
-      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
-
-      Apartment::Railtie.deactivate_pool_reaper_in_test_env!
-
-      expect(reaper).to(have_received(:stop))
-    end
-
-    it 'emits reaper_stopped.apartment with reason :test_env when it stops the reaper' do
-      reaper = instance_double(Apartment::PoolReaper, stop: nil)
-      allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
-      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
-      events = []
-      sub = ActiveSupport::Notifications.subscribe('reaper_stopped.apartment') { |e| events << e }
-
-      Apartment::Railtie.deactivate_pool_reaper_in_test_env!
-
-      expect(events.size).to(eq(1))
-      expect(events.first.payload).to(eq(reason: :test_env))
-    ensure
-      ActiveSupport::Notifications.unsubscribe(sub) if sub
-    end
-
-    it 'does nothing outside the test environment' do
-      reaper = instance_double(Apartment::PoolReaper, stop: nil)
-      allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
-      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('production')))
-
-      Apartment::Railtie.deactivate_pool_reaper_in_test_env!
-
-      expect(reaper).not_to(have_received(:stop))
-    end
-
-    it 'is a no-op when no reaper is configured' do
-      allow(Apartment).to(receive(:pool_reaper).and_return(nil))
-      allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
-
-      expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
-    end
-  end
-
-  describe 'TenantNotFound rescue_responses mapping' do
-    # Unit specs do not boot a Rails::Application, so railtie initializers
-    # never run on their own — invoke the initializer block directly.
-    it 'maps Apartment::TenantNotFound to :not_found' do
-      require 'action_dispatch'
-      initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.rescue_responses' }
-      expect(initializer).not_to(be_nil)
-
-      initializer.run
-
-      expect(ActionDispatch::ExceptionWrapper.rescue_responses['Apartment::TenantNotFound'])
-        .to(eq(:not_found))
-    end
+else
+  RSpec.describe('Apartment::Railtie') do
+    it('pins the Railtie contract') { skip('requires Rails (run via appraisal or with RAILTIE_SPEC_REQUIRED)') }
   end
 end

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -111,6 +111,40 @@ if railtie_loaded
       end
     end
 
+    # End-to-end coverage of the warning path: the predicate's return value is
+    # tested above, but those tests would still pass if the middleware
+    # initializer stopped calling the predicate or stopped emitting the
+    # warning. Run the initializer directly and assert on stderr.
+    describe 'apartment.middleware initializer Header trust warning' do
+      let(:middleware_stack) { double('MiddlewareStack', insert_after: nil) }
+      let(:app) { double('App', middleware: middleware_stack) }
+      let(:initializer) { Apartment::Railtie.initializers.find { |i| i.name == 'apartment.middleware' } }
+
+      def configure_with(elevator:, elevator_options: {})
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { [] }
+          config.elevator = elevator
+          config.elevator_options = elevator_options
+        end
+      end
+
+      it 'emits the warning for :header without trusted: true' do
+        configure_with(elevator: :header)
+        expect { initializer.run(app) }.to(output(/Header elevator with trusted: false/).to_stderr)
+      end
+
+      it 'does not emit the warning for :header with trusted: true' do
+        configure_with(elevator: :header, elevator_options: { trusted: true })
+        expect { initializer.run(app) }.not_to(output(/Header elevator/).to_stderr)
+      end
+
+      it 'does not emit the warning for a non-Header elevator' do
+        configure_with(elevator: :subdomain)
+        expect { initializer.run(app) }.not_to(output(/Header elevator/).to_stderr)
+      end
+    end
+
     describe '.deactivate_pool_reaper_in_test_env!' do
       it 'stops Apartment.pool_reaper when Rails.env.test? is true' do
         reaper = instance_double(Apartment::PoolReaper, stop: nil)

--- a/spec/unit/test_fixtures_spec.rb
+++ b/spec/unit/test_fixtures_spec.rb
@@ -102,24 +102,24 @@ RSpec.describe(Apartment::TestFixtures) do
   end
 
   describe 'without the patch' do
-    it 'raises ArgumentError from setup_shared_connection_pool when a tenant pool exists under :reading only' do
-      # Use a fresh anonymous host class to avoid contamination from the 'with the patch'
-      # tests (prepend is irreversible on a class; FixtureHost may already be patched).
-      fresh_host_class = Class.new do
-        include ActiveRecord::TestFixtures
-
-        def initialize
-          @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
-        end
-
-        def call_setup
-          setup_shared_connection_pool
-        end
-      end
-
+    # `include ActiveRecord::TestFixtures` triggers the module's `included do`
+    # block, which runs `ActiveSupport.run_load_hooks(:active_record_fixtures,
+    # self)` with `self` set to the *including class*. Apartment's Railtie
+    # listens for that hook and prepends Apartment::TestFixtures onto the
+    # including class -- so ANY class that includes AR::TestFixtures (fresh
+    # anonymous ones included) inherits the patch once the Railtie is loaded.
+    # The "fresh class" trick can't dodge the prepend; the patch is per-class
+    # but the on_load fires for *every* class that ever includes the module.
+    #
+    # To test AR's original behavior directly we bypass the prepend chain
+    # via UnboundMethod#bind_call on AR's own definition of the method. This
+    # is what "without the patch" actually means: AR's method as defined,
+    # ignoring whatever's prepended above it.
+    it 'AR setup_shared_connection_pool raises ArgumentError when a tenant pool exists under :reading only' do
+      ar_setup = ActiveRecord::TestFixtures.instance_method(:setup_shared_connection_pool)
+      host = FixtureHost.new
       register_tenant_pool('acme', :reading)
-      host = fresh_host_class.new
-      expect { host.call_setup }.to(raise_error(ArgumentError, /pool_config.*nil/i))
+      expect { ar_setup.bind_call(host) }.to(raise_error(ArgumentError, /pool_config.*nil/i))
     end
   end
 

--- a/spec/unit/test_fixtures_spec.rb
+++ b/spec/unit/test_fixtures_spec.rb
@@ -101,22 +101,31 @@ RSpec.describe(Apartment::TestFixtures) do
     Apartment.pool_manager.fetch_or_create(pool_key) { pool }
   end
 
-  describe 'without the patch' do
-    # `include ActiveRecord::TestFixtures` triggers the module's `included do`
-    # block, which runs `ActiveSupport.run_load_hooks(:active_record_fixtures,
-    # self)` with `self` set to the *including class*. Apartment's Railtie
-    # listens for that hook and prepends Apartment::TestFixtures onto the
-    # including class -- so ANY class that includes AR::TestFixtures (fresh
-    # anonymous ones included) inherits the patch once the Railtie is loaded.
-    # The "fresh class" trick can't dodge the prepend; the patch is per-class
-    # but the on_load fires for *every* class that ever includes the module.
-    #
-    # To test AR's original behavior directly we bypass the prepend chain
-    # via UnboundMethod#bind_call on AR's own definition of the method. This
-    # is what "without the patch" actually means: AR's method as defined,
-    # ignoring whatever's prepended above it.
+  # Documents AR's baseline behavior: setup_shared_connection_pool raises
+  # ArgumentError when a tenant pool exists under :reading without :writing.
+  # That bug is why Apartment::TestFixtures exists; this group is a
+  # regression guard against Rails fixing it (in which case the patch can
+  # be retired). The describe wording deliberately avoids "without the
+  # patch" -- under #412 the Railtie is now loaded in CI, the
+  # `:active_record_fixtures` on_load callback fires for every class that
+  # includes AR::TestFixtures (FixtureHost may already be prepended in
+  # full-suite order), and a fresh anonymous host can no longer dodge the
+  # prepend. The example below intentionally bypasses the prepend chain
+  # via UnboundMethod#bind_call to invoke AR's own definition directly.
+  describe 'AR baseline (unpatched method, invoked via bind_call)' do
     it 'AR setup_shared_connection_pool raises ArgumentError when a tenant pool exists under :reading only' do
       ar_setup = ActiveRecord::TestFixtures.instance_method(:setup_shared_connection_pool)
+
+      # Robustness guard: bind_call bypasses prepend ONLY when the prepend
+      # lands on the including class (per-class), not on AR::TestFixtures
+      # itself. The current design (ActiveSupport::Concern's `included do`
+      # block fires the on_load hook with `self == including class`) keeps
+      # the prepend per-class. If a future Rails or Apartment change shifts
+      # the prepend onto AR::TestFixtures itself, instance_method would
+      # return the prepended version and this test would silently test the
+      # wrong thing. The owner check fails loudly in that scenario.
+      expect(ar_setup.owner).to(eq(ActiveRecord::TestFixtures))
+
       host = FixtureHost.new
       register_tenant_pool('acme', :reading)
       expect { ar_setup.bind_call(host) }.to(raise_error(ArgumentError, /pool_config.*nil/i))


### PR DESCRIPTION
## Summary

Two-commit fix for a CI test-visibility gap:

- **`4cf7324` Test infra.** `spec/unit/railtie_spec.rb` was 19/19 pending under `bundle exec rspec spec/unit/` -- the CI unit job included. `spec_helper.rb` deliberately keeps the suite Rails-free (via the `rails_stub`), and the file's per-example `skip unless defined?(Apartment::Railtie)` then skipped everything. The spec only ran with `-r rails`, which nothing invoked. Applied the same idiom `rspec_rails_lifecycle_spec.rb` already uses: self-require `rails` + `apartment/railtie` in a `begin/rescue LoadError`, with `raise if ENV['RAILTIE_SPEC_REQUIRED']` turning a missing-Rails skip into a hard CI failure. CI's unit job now sets `RAILTIE_SPEC_REQUIRED='1'` alongside `RSPEC_RAILS_REQUIRED='1'`. `spec_helper.rb` also defaults `RAILS_ENV=test` so real Rails (once loaded) honors the same env the stub returned -- without this, adapter specs that compute environmentified names from `Rails.env` regress to `'development'`.

- **`5c63d3a` Bug fix.** With the spec running, `Railtie.header_trust_warning?(Apartment::Elevators::Subdomain, {})` returned `nil` where the spec expected `false`. `Module#<=` returns `nil` (not `false`) for unrelated classes, so the bare `&&` violated the predicate's boolean contract. Coerced with an explicit guard and documented the gotcha inline to discourage a future revert to the terse form.

The two commits must ship together: commit 1 alone turns CI red until commit 2 lands.

## Stack

Stacked on #410 (`feat/elevator-tenant-validation`). The diff vs `main` will include #410's commits until that PR merges; this PR's own changes are the two top commits.

## Verification

- `bundle exec rspec spec/unit/railtie_spec.rb` -> 19 examples, 0 failures (vs 19 pending before).
- `RAILTIE_SPEC_REQUIRED=1 RSPEC_RAILS_REQUIRED=1 bundle exec rspec spec/unit/` -> 792 examples, 0 failures, 39 pending (the pending are pre-existing DB-dependent specs).
- `bundle exec rubocop` on changed files -> clean.

## Deferred

- **Fiber scheduler skip in `spec/integration/v4/fiber_safety_spec.rb`** -- closing it needs a decision on adding `async` (or another Fiber::Scheduler implementation) as a dev dependency. Out of scope here.
- **General fail-on-all-skip CI guard** (the per-spec `*_REQUIRED` pattern doesn't scale to "did the file get loaded at all?" cases). Worth a follow-up but out of scope.

## Test plan

- [x] `bundle exec rspec spec/unit/railtie_spec.rb` -- 19/0/0
- [x] Full `spec/unit/` under CI env vars -- 792/0/39
- [x] `bundle exec rubocop` on changed files -- clean
- [ ] CI unit matrix passes across Ruby 3.3/3.4/4.0 x Rails 7.2/8.0/8.1/main