### PR TITLE
Test: actually run fiber_safety_spec's Fiber.scheduler context via Async

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+# Per-Rails gemfiles in gemfiles/ are regenerated from THIS file by
+# `bundle exec appraisal install` (Appraisals declares only the
+# rails-version-specific gems). Add new dev/test deps here, not by hand
+# in gemfiles/ — they'd be silently dropped on next regen.
+
 gem 'appraisal', '~> 2.5'
 gem 'rack-test', require: false
 gem 'rspec', '~> 3.10'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,13 @@ gem 'rspec', '~> 3.10'
 # it out of the plain-RSpec suite). That spec pins the rspec-rails
 # CurrentAttributes lifecycle that docs/testing.md depends on.
 gem 'rspec-rails', '~> 8.0', require: false
+# Provides Async::Scheduler — the Fiber::Scheduler implementation
+# spec/integration/v4/fiber_safety_spec.rb's "Fiber.scheduler integration"
+# context needs to actually run (MRI has no built-in concrete scheduler).
+# Targets the fiber-based async path Rails apps use when running on a
+# fiber-aware executor (e.g., Falcon); thread-based load_async tenant
+# propagation is a separate concern.
+gem 'async', '~> 2.0', require: false
 
 group :development do
   gem 'rubocop', require: false

--- a/gemfiles/rails_7.2_mysql2.gemfile
+++ b/gemfiles/rails_7.2_mysql2.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 7.2.0"
 gem "mysql2", "~> 0.5"
 

--- a/gemfiles/rails_7.2_postgresql.gemfile
+++ b/gemfiles/rails_7.2_postgresql.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 7.2.0"
 gem "pg", "~> 1.5"
 

--- a/gemfiles/rails_7.2_sqlite3.gemfile
+++ b/gemfiles/rails_7.2_sqlite3.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 7.2.0"
 gem "sqlite3", "~> 2.1"
 

--- a/gemfiles/rails_7.2_trilogy.gemfile
+++ b/gemfiles/rails_7.2_trilogy.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 7.2.0"
 gem "trilogy", ">= 2.9"
 

--- a/gemfiles/rails_8.0_mysql2.gemfile
+++ b/gemfiles/rails_8.0_mysql2.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.0.0"
 gem "mysql2", "~> 0.5"
 

--- a/gemfiles/rails_8.0_postgresql.gemfile
+++ b/gemfiles/rails_8.0_postgresql.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.0.0"
 gem "pg", "~> 1.5"
 

--- a/gemfiles/rails_8.0_sqlite3.gemfile
+++ b/gemfiles/rails_8.0_sqlite3.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.0.0"
 gem "sqlite3", "~> 2.1"
 

--- a/gemfiles/rails_8.0_trilogy.gemfile
+++ b/gemfiles/rails_8.0_trilogy.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.0.0"
 gem "trilogy", ">= 2.9"
 

--- a/gemfiles/rails_8.1_mysql2.gemfile
+++ b/gemfiles/rails_8.1_mysql2.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.1.0"
 gem "mysql2", "~> 0.5"
 

--- a/gemfiles/rails_8.1_postgresql.gemfile
+++ b/gemfiles/rails_8.1_postgresql.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.1.0"
 gem "pg", "~> 1.6"
 

--- a/gemfiles/rails_8.1_sqlite3.gemfile
+++ b/gemfiles/rails_8.1_sqlite3.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.1.0"
 gem "sqlite3", "~> 2.8"
 

--- a/gemfiles/rails_8.1_trilogy.gemfile
+++ b/gemfiles/rails_8.1_trilogy.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", "~> 8.1.0"
 gem "trilogy", ">= 2.9"
 

--- a/gemfiles/rails_main_postgresql.gemfile
+++ b/gemfiles/rails_main_postgresql.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", github: "rails/rails", branch: "main"
 gem "pg", "~> 1.6"
 

--- a/gemfiles/rails_main_sqlite3.gemfile
+++ b/gemfiles/rails_main_sqlite3.gemfile
@@ -6,6 +6,7 @@ gem "appraisal", "~> 2.5"
 gem "rack-test", require: false
 gem "rspec", "~> 3.10"
 gem "rspec-rails", "~> 8.0", require: false
+gem "async", "~> 2.0", require: false
 gem "rails", github: "rails/rails", branch: "main"
 gem "sqlite3", "~> 2.8"
 

--- a/spec/integration/v4/fiber_safety_spec.rb
+++ b/spec/integration/v4/fiber_safety_spec.rb
@@ -104,6 +104,11 @@ RSpec.describe('v4 Fiber safety integration', :integration,
   # provides one (Async::Scheduler) and is declared as a dev dep for exactly
   # this spec. Without it, this context skips — that path is reached only in
   # degraded local setups; CI's appraisal gemfiles all carry async.
+  #
+  # Depends on the outer `before` setting `isolation_level = :fiber`.
+  # CurrentAttributes' per-fiber store is what makes Tenant.current and
+  # connection_pool routing survive task.sleep yields. The test would
+  # silently degrade (looking like a "tenant leak" bug) under :thread.
   context 'Fiber.scheduler integration' do
     before do
       require('async')
@@ -111,21 +116,42 @@ RSpec.describe('v4 Fiber safety integration', :integration,
       skip("requires async gem: #{e.message}")
     end
 
-    it 'tenant state does not leak across scheduled fibers' do
+    it 'tenant state and pool routing do not leak across scheduled fibers' do
       results = []
       mutex = Mutex.new
 
       Async do |task|
         task.async do
           Apartment::Tenant.switch('fiber_a') do
+            Widget.create!(name: 'a_widget')
             task.sleep(0.01) # yield to scheduler so fiber_b interleaves
-            mutex.synchronize { results << { fiber: :a, tenant: Apartment::Tenant.current } }
+            # The Widget.count + .first reads route through Apartment's
+            # ConnectionHandling prepend AFTER the yield. They prove the
+            # connection_pool lookup honors per-fiber Current.tenant, not
+            # just that the Current attribute is preserved (which the .tenant
+            # read below already covers).
+            mutex.synchronize do
+              results << {
+                fiber: :a,
+                tenant: Apartment::Tenant.current,
+                count: Widget.count,
+                name: Widget.first&.name,
+              }
+            end
           end
         end
         task.async do
           Apartment::Tenant.switch('fiber_b') do
+            Widget.create!(name: 'b_widget')
             task.sleep(0.01)
-            mutex.synchronize { results << { fiber: :b, tenant: Apartment::Tenant.current } }
+            mutex.synchronize do
+              results << {
+                fiber: :b,
+                tenant: Apartment::Tenant.current,
+                count: Widget.count,
+                name: Widget.first&.name,
+              }
+            end
           end
         end
       end.wait
@@ -137,6 +163,13 @@ RSpec.describe('v4 Fiber safety integration', :integration,
       expect(b_result).not_to(be_nil, 'Fiber B did not produce a result')
       expect(a_result[:tenant]).to(eq('fiber_a'))
       expect(b_result[:tenant]).to(eq('fiber_b'))
+      # Pool-routing contract: each fiber sees ONLY its own tenant's data
+      # (SQLite gives us file-per-tenant isolation, so a routing leak would
+      # surface as wrong-count or wrong-name).
+      expect(a_result[:count]).to(eq(1))
+      expect(b_result[:count]).to(eq(1))
+      expect(a_result[:name]).to(eq('a_widget'))
+      expect(b_result[:name]).to(eq('b_widget'))
     end
   end
 

--- a/spec/integration/v4/fiber_safety_spec.rb
+++ b/spec/integration/v4/fiber_safety_spec.rb
@@ -99,16 +99,26 @@ RSpec.describe('v4 Fiber safety integration', :integration,
     end
   end
 
-  # Exercises scheduled fibers under a real Fiber::Scheduler. MRI ships the
-  # Fiber::Scheduler *interface* but no concrete implementation; the async gem
-  # provides one (Async::Scheduler) and is declared as a dev dep for exactly
-  # this spec. Without it, this context skips — that path is reached only in
-  # degraded local setups; CI's appraisal gemfiles all carry async.
+  # Exercises Apartment under a real Fiber::Scheduler. MRI ships the
+  # Fiber::Scheduler *interface* but no concrete implementation; the async
+  # gem provides one (Async::Scheduler) and is declared as a dev dep for
+  # exactly this spec. Without it, this context skips — that path is reached
+  # only in degraded local setups; CI's appraisal gemfiles all carry async.
   #
   # Depends on the outer `before` setting `isolation_level = :fiber`.
   # CurrentAttributes' per-fiber store is what makes Tenant.current and
-  # connection_pool routing survive task.sleep yields. The test would
-  # silently degrade (looking like a "tenant leak" bug) under :thread.
+  # connection_pool routing fiber-local. Under :thread the test would
+  # silently degrade and look like a tenant-leak bug.
+  #
+  # SCOPE NOTE: this test verifies per-fiber storage and pool routing while
+  # both fibers are scheduled by Async. It does NOT force interleaving —
+  # `task.sleep(0.01)` is the conventional Async yield point but assertions
+  # would also pass under sequential execution (each scheduled fiber holds
+  # its own context regardless of yield order). A Queue-handoff barrier was
+  # considered and rejected as over-engineering: it would only catch a
+  # narrow regression class (task.sleep silently failing to yield AND fiber
+  # isolation simultaneously regressing) and the AR-query assertions below
+  # already catch the apartment-relevant failure modes.
   context 'Fiber.scheduler integration' do
     before do
       require('async')
@@ -116,7 +126,7 @@ RSpec.describe('v4 Fiber safety integration', :integration,
       skip("requires async gem: #{e.message}")
     end
 
-    it 'tenant state and pool routing do not leak across scheduled fibers' do
+    it 'Apartment::Current and connection_pool routing are per-fiber under Async::Scheduler' do
       results = []
       mutex = Mutex.new
 
@@ -124,12 +134,12 @@ RSpec.describe('v4 Fiber safety integration', :integration,
         task.async do
           Apartment::Tenant.switch('fiber_a') do
             Widget.create!(name: 'a_widget')
-            task.sleep(0.01) # yield to scheduler so fiber_b interleaves
-            # The Widget.count + .first reads route through Apartment's
-            # ConnectionHandling prepend AFTER the yield. They prove the
-            # connection_pool lookup honors per-fiber Current.tenant, not
-            # just that the Current attribute is preserved (which the .tenant
-            # read below already covers).
+            task.sleep(0.01) # conventional Async yield point
+            # Widget.count + .first route through Apartment's
+            # ConnectionHandling prepend, which reads Current.tenant. A
+            # CurrentAttributes or routing leak across fibers would surface
+            # here as wrong-count or wrong-name (SQLite file-per-tenant
+            # isolation makes the failure mode observable).
             mutex.synchronize do
               results << {
                 fiber: :a,
@@ -163,9 +173,6 @@ RSpec.describe('v4 Fiber safety integration', :integration,
       expect(b_result).not_to(be_nil, 'Fiber B did not produce a result')
       expect(a_result[:tenant]).to(eq('fiber_a'))
       expect(b_result[:tenant]).to(eq('fiber_b'))
-      # Pool-routing contract: each fiber sees ONLY its own tenant's data
-      # (SQLite gives us file-per-tenant isolation, so a routing leak would
-      # surface as wrong-count or wrong-name).
       expect(a_result[:count]).to(eq(1))
       expect(b_result[:count]).to(eq(1))
       expect(a_result[:name]).to(eq('a_widget'))

--- a/spec/integration/v4/fiber_safety_spec.rb
+++ b/spec/integration/v4/fiber_safety_spec.rb
@@ -99,35 +99,36 @@ RSpec.describe('v4 Fiber safety integration', :integration,
     end
   end
 
-  # Exercises scheduled fibers under a real Fiber::Scheduler implementation
-  # (e.g., async gem). Standard MRI does not define Fiber::Scheduler as a
-  # concrete class, so this skips when the constant is absent.
+  # Exercises scheduled fibers under a real Fiber::Scheduler. MRI ships the
+  # Fiber::Scheduler *interface* but no concrete implementation; the async gem
+  # provides one (Async::Scheduler) and is declared as a dev dep for exactly
+  # this spec. Without it, this context skips — that path is reached only in
+  # degraded local setups; CI's appraisal gemfiles all carry async.
   context 'Fiber.scheduler integration' do
+    before do
+      require('async')
+    rescue LoadError => e
+      skip("requires async gem: #{e.message}")
+    end
+
     it 'tenant state does not leak across scheduled fibers' do
       results = []
       mutex = Mutex.new
 
-      scheduler = Fiber::Scheduler.new if defined?(Fiber::Scheduler)
-      skip 'no built-in Fiber::Scheduler available' unless scheduler
-
-      Fiber.set_scheduler(scheduler)
-
-      Fiber.schedule do
-        Apartment::Tenant.switch('fiber_a') do
-          sleep(0.01) # yield to scheduler
-          mutex.synchronize { results << { fiber: :a, tenant: Apartment::Tenant.current } }
+      Async do |task|
+        task.async do
+          Apartment::Tenant.switch('fiber_a') do
+            task.sleep(0.01) # yield to scheduler so fiber_b interleaves
+            mutex.synchronize { results << { fiber: :a, tenant: Apartment::Tenant.current } }
+          end
         end
-      end
-
-      Fiber.schedule do
-        Apartment::Tenant.switch('fiber_b') do
-          sleep(0.01) # yield to scheduler
-          mutex.synchronize { results << { fiber: :b, tenant: Apartment::Tenant.current } }
+        task.async do
+          Apartment::Tenant.switch('fiber_b') do
+            task.sleep(0.01)
+            mutex.synchronize { results << { fiber: :b, tenant: Apartment::Tenant.current } }
+          end
         end
-      end
-
-      Fiber.scheduler.close
-      Fiber.set_scheduler(nil)
+      end.wait
 
       a_result = results.find { |r| r[:fiber] == :a }
       b_result = results.find { |r| r[:fiber] == :b }


### PR DESCRIPTION
## Summary

Closes the part-3 deferral from #412. The 'Fiber.scheduler integration' context in `spec/integration/v4/fiber_safety_spec.rb` has been silently skipping since the file was added -- the previous structure was aspirational and never validated:

```ruby
scheduler = Fiber::Scheduler.new if defined?(Fiber::Scheduler)
skip 'no built-in Fiber::Scheduler available' unless scheduler
```

MRI ships the `Fiber::Scheduler` *interface* but no concrete class, so the skip kicked in 100% of the time. The body wouldn't have worked either: `scheduler.close` tears the scheduler down without running pending fibers to completion. Two commits:

- **`72ef36d` Add async as a dev dep.** Declares `gem 'async', '~> 2.0', require: false` in the root `Gemfile` and regenerates all 14 appraisal gemfiles. async provides `Async::Scheduler`, the canonical `Fiber::Scheduler` implementation.

- **`5a29b8f` Refactor the context to `Async { ... }`.** Replaces the broken manual `set_scheduler`/`close` dance with the idiomatic block form: Async owns the scheduler lifecycle, `.wait` runs the child tasks to completion. The assertion is the same -- tenant state set inside a scheduled fiber survives `task.sleep` yields and does not leak into a sibling fiber.

## Motivation

Targets the fiber-based async path: Rails apps running on a fiber-aware executor (e.g., Falcon) dispatch `load_async` onto fibers, where v4's fiber-isolated `CurrentAttributes` is the propagation mechanism that needs validated coverage.

**Out of scope:** thread-based `load_async` tenant propagation. Rails' default executor is `Concurrent.global_io_executor` (threads), and `CurrentAttributes` `:fiber` isolation does not cross threads -- so `Post.load_async` in a default Rails app would still lose tenant context. That's a separate design problem (likely needs explicit tenant capture at promise creation + restore inside the executor block). Worth a tracking issue.

## Stack

Independent PR off `main`. Not stacked on #412 -- this is the part-3 follow-up #412 explicitly deferred pending the decision on adding `async`.

## Verification

- `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/fiber_safety_spec.rb` -> 5 examples, 0 failures (the Fiber.scheduler context now runs; previously 4 ran + 1 skipped).
- `bundle exec rubocop Gemfile spec/integration/v4/fiber_safety_spec.rb` -> clean.

## Test plan

- [x] Local sqlite3 integration: full `fiber_safety_spec.rb` green, including the previously-skipped Fiber.scheduler context
- [x] Rubocop clean on changed files
- [ ] CI integration matrix (PG/MySQL/SQLite x Ruby 3.3/3.4/4.0 x Rails 7.2/8.0/8.1) green