### PR TITLE
Add opt-in strict_tenant_lookup guard against silent default-tenant fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage/
 .code-graph/
 # Repomix packed output (generated, can be 10MB+)
 repomix-output.*
+.zed/

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -25,7 +25,8 @@ module Apartment
                   :active_record_log, :sql_query_tags,
                   :shard_key_prefix,
                   :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
-                  :force_separate_pinned_pool, :test_fixture_cleanup
+                  :force_separate_pinned_pool, :test_fixture_cleanup,
+                  :strict_tenant_lookup
 
     def initialize # rubocop:disable Metrics/AbcSize
       @tenant_strategy = nil
@@ -57,6 +58,40 @@ module Apartment
       @check_pending_migrations = true
       @force_separate_pinned_pool = false
       @test_fixture_cleanup = true
+      # When true, ConnectionHandling#connection_pool raises
+      # Apartment::ImplicitDefaultTenant instead of silently falling through
+      # to the default-tenant pool when Apartment::Current.tenant is nil --
+      # catches tenant leaks across thread/fiber boundaries (e.g., load_async
+      # results accessed outside the original switch block). Pinned models
+      # legitimately use the default pool by design and are bypassed.
+      #
+      # Default false. Recommended opt-in:
+      #
+      #   Apartment.configure do |config|
+      #     config.strict_tenant_lookup = Rails.env.local?
+      #   end
+      #
+      # Caveats adopters should know:
+      #
+      #   * Raises on ActiveRecord::Base.connection_pool itself when called
+      #     with no tenant, not only on tenant-aware model classes. Wrap
+      #     interactive sessions (rails console, one-off scripts) in
+      #     Apartment::Tenant.switch(default_tenant) { ... }.
+      #   * Only the *nil tenant* case is caught. Wrong-tenant pinned reads
+      #     on shared-pool adapters (PG schema, MySQL) still resolve through
+      #     the tenant pool silently -- this flag does not detect them.
+      #   * API mismatch: Apartment::Tenant.current still falls back to
+      #     default_tenant when Current.tenant is nil; only connection_pool
+      #     raises. A reader of Tenant.current sees the default name while a
+      #     concurrent write raises -- by design, but surprising at first.
+      #
+      # An auto-default tied to Rails.env was tried and reverted: it raised
+      # inside Migrator setup, edge_cases schema operations, and other
+      # legitimate gem-internal default-pool access, breaking
+      # `apartment:migrate` and similar in dev/test. Until those paths are
+      # explicitly wrapped in switch(default_tenant), strict mode stays
+      # opt-in per environment. See PR #416 for details.
+      @strict_tenant_lookup = false
     end
 
     def excluded_models=(list)
@@ -188,6 +223,11 @@ module Apartment
       unless [true, false].include?(@test_fixture_cleanup)
         raise(ConfigurationError,
               "test_fixture_cleanup must be true or false, got: #{@test_fixture_cleanup.inspect}")
+      end
+
+      unless [true, false].include?(@strict_tenant_lookup)
+        raise(ConfigurationError,
+              "strict_tenant_lookup must be true or false, got: #{@strict_tenant_lookup.inspect}")
       end
 
       unless @tenant_validator.nil? || @tenant_validator == false || @tenant_validator.respond_to?(:call)

--- a/lib/apartment/errors.rb
+++ b/lib/apartment/errors.rb
@@ -64,6 +64,39 @@ module Apartment
     end
   end
 
+  # Raised by the {Apartment::Patches::ConnectionHandling} prepend when
+  # {Apartment::Current.tenant} is nil AND {Apartment.config.strict_tenant_lookup}
+  # is enabled. Without strict mode, that call would silently return the
+  # default tenant's pool — fine for explicit no-tenant code, dangerous when
+  # it happens because tenant context was lost across a thread/fiber boundary
+  # (e.g., a lazy association accessed outside the original Tenant.switch
+  # block, or a load_async relation consumed after switch exited). Strict
+  # mode turns the silent fallback into a loud failure so the leak surfaces
+  # in dev/test.
+  #
+  # Explicit default-tenant access is still allowed: call
+  # +Apartment::Tenant.switch(Apartment.config.default_tenant) { ... }+.
+  #
+  # See docs/designs/apartment-v4.md "Async query correctness" for the
+  # failure mode this is designed to catch.
+  class ImplicitDefaultTenant < ApartmentError
+    def initialize(message: nil)
+      super(message || default_message)
+    end
+
+    private
+
+    def default_message
+      'Apartment::Current.tenant is nil and Apartment.config.strict_tenant_lookup is enabled. ' \
+        'Wrap the call in Apartment::Tenant.switch(tenant) { ... } (or call ' \
+        'Apartment::Tenant.switch!(tenant) at the top of the unit of work). For explicit ' \
+        'default-tenant access use Apartment::Tenant.switch(Apartment.config.default_tenant). ' \
+        'Common culprit: lazy associations or load_async results accessed outside the ' \
+        'original switch block. Note: Apartment::Tenant.current still falls back to ' \
+        'default_tenant when Current.tenant is nil; only connection_pool raises.'
+    end
+  end
+
   # Raised in development when a tenant has pending migrations.
   class PendingMigrationError < ApartmentError
     attr_reader :tenant

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -93,9 +93,17 @@ module Apartment
 
     # Migrate the primary (default) tenant using AR::Base's existing pool.
     # No tenant switch needed — the default connection is already correct.
+    #
+    # Sets Apartment::Current.migrating around the AR::Base.connection_pool
+    # access so that strict_tenant_lookup (when enabled by the user) does
+    # not raise here. The migrator intentionally accesses the default pool
+    # with Current.tenant nil; the migrating flag is the gem's signal that
+    # this is a legitimate internal path. Mirrors the pattern in
+    # migrate_tenant below.
     def migrate_primary # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       tenant_name = Apartment.config.default_tenant
       start = monotonic_now
+      Apartment::Current.migrating = true
 
       context = ActiveRecord::Base.connection_pool.migration_context
 
@@ -120,6 +128,8 @@ module Apartment
         tenant: tenant_name, status: :failed,
         duration: monotonic_now - start, error: e, versions_run: []
       )
+    ensure
+      Apartment::Current.migrating = false
     end
 
     # Migrate a single tenant by switching via Apartment::Tenant.switch.

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -13,7 +13,35 @@ module Apartment
         tenant = Apartment::Current.tenant
         cfg = Apartment.config
 
-        return super if tenant.nil? || cfg.nil?
+        return super if cfg.nil?
+
+        # Strict mode: fail loud on the silent default-pool fallback. Without
+        # this, a lazy association accessed outside its switch block (or a
+        # load_async relation consumed after switch exited) would quietly run
+        # against the default tenant's data. Explicit default-tenant access
+        # via switch(default_tenant) bypasses this branch because tenant is
+        # then non-nil.
+        #
+        # Bypasses (in order):
+        #   * early-boot calls before pool_manager is wired (Apartment not
+        #     yet fully configured)
+        #   * pinned models (legitimately default-pool by design)
+        #   * migration paths (Migrator#migrate_primary, abstract_adapter,
+        #     CLI rollback) — these intentionally hit the default pool with
+        #     nil tenant. Apartment::Current.migrating is set by Migrator
+        #     and check_pending_migrations? already honors the same flag.
+        #
+        # See docs/designs/apartment-v4.md "Async query correctness".
+        if tenant.nil?
+          pinned = self != ActiveRecord::Base && Apartment.pinned_model?(self)
+          if cfg.strict_tenant_lookup && Apartment.pool_manager &&
+             !pinned && !Apartment::Current.migrating
+            raise(Apartment::ImplicitDefaultTenant)
+          end
+
+          return super
+        end
+
         return super if tenant.to_s == cfg.default_tenant.to_s
         return super unless Apartment.pool_manager
 
@@ -80,7 +108,7 @@ module Apartment
 
       def check_pending_migrations?(pool)
         return false unless Apartment.config.check_pending_migrations
-        return false unless defined?(Rails) && Rails.env.local? # rubocop:disable Rails/UnknownEnv
+        return false unless defined?(Rails) && Rails.env.local?
         return false if Apartment::Current.migrating
 
         pool.migration_context.needs_migration?

--- a/spec/integration/v4/strict_tenant_lookup_spec.rb
+++ b/spec/integration/v4/strict_tenant_lookup_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+
+# End-to-end proof of the failure mode strict_tenant_lookup is designed to
+# catch: a relation captured inside Tenant.switch and accessed afterwards
+# silently re-resolves connection_pool on the consumer thread. With
+# Current.tenant.nil?, ConnectionHandling#connection_pool falls through to
+# super and the query runs against the DEFAULT tenant's data -- no error,
+# wrong data. With strict_tenant_lookup ON, the same path raises loudly.
+#
+# This is the consumer-thread re-resolution case documented in
+# docs/designs/apartment-v4.md "Async query correctness". The exact same
+# mechanism backs lazy associations after load_async (relation.first.user
+# triggers an exec_queries on the consumer thread).
+RSpec.describe('strict_tenant_lookup integration', :integration,
+               skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
+  include V4IntegrationHelper
+
+  let(:tmp_dir) { Dir.mktmpdir('apartment_strict') }
+  let(:tenants) { %w[acme] }
+
+  before do
+    V4IntegrationHelper.ensure_test_database! unless V4IntegrationHelper.sqlite?
+    @connection_config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+    stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+  end
+
+  after do
+    V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter) if Apartment.adapter
+    Apartment.clear_config
+    Apartment::Current.reset
+    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:') if V4IntegrationHelper.sqlite?
+    FileUtils.rm_rf(tmp_dir)
+  end
+
+  # Plant 'in_default' in the default tenant and "in_<name>" in each tenant
+  # so the failure-mode test can prove WHICH tenant the silent fallback hit.
+  def populate_data(strict_mode:)
+    Apartment.configure do |c|
+      c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+      c.tenants_provider = -> { tenants }
+      c.default_tenant = V4IntegrationHelper.default_tenant
+      c.check_pending_migrations = false
+      c.strict_tenant_lookup = strict_mode
+    end
+    Apartment.adapter = V4IntegrationHelper.build_adapter(@connection_config)
+    Apartment.activate!
+
+    # Under strict mode, every connection_pool call needs an explicit tenant
+    # in context. Wrap default-tenant setup in switch(default_tenant) so the
+    # same setup path works in both modes.
+    Apartment::Tenant.switch(V4IntegrationHelper.default_tenant) do
+      tenants.each { |t| Apartment.adapter.create(t) }
+      V4IntegrationHelper.create_test_table!
+      Widget.create!(name: 'in_default')
+    end
+
+    tenants.each do |t|
+      Apartment::Tenant.switch(t) do
+        V4IntegrationHelper.create_test_table!('widgets', connection: ActiveRecord::Base.connection)
+        Widget.create!(name: "in_#{t}")
+      end
+    end
+  end
+
+  context 'without strict_tenant_lookup (current default in production)' do
+    before { populate_data(strict_mode: false) }
+
+    it 'silently returns the default tenant data when a captured relation is accessed outside its switch block' do
+      captured = Apartment::Tenant.switch('acme') { Widget.all }
+
+      # Outside the switch, Apartment::Current.tenant is nil. captured.pluck
+      # triggers exec_queries -> connection_pool -> the prepend falls through
+      # to super -> default-tenant pool. The query returns 'in_default'
+      # instead of 'in_acme'. No error. This is the failure mode.
+      names = captured.pluck(:name)
+      expect(names).to(eq(['in_default']))
+      expect(names).not_to(include('in_acme'))
+    end
+
+    it 'returns the tenant data when the same relation is accessed inside its switch' do
+      Apartment::Tenant.switch('acme') do
+        expect(Widget.pluck(:name)).to(eq(['in_acme']))
+      end
+    end
+  end
+
+  context 'with strict_tenant_lookup' do
+    before { populate_data(strict_mode: true) }
+
+    it 'raises ImplicitDefaultTenant when a captured relation is accessed outside its switch block' do
+      captured = Apartment::Tenant.switch('acme') { Widget.all }
+
+      expect { captured.pluck(:name) }.to(raise_error(Apartment::ImplicitDefaultTenant))
+    end
+
+    it 'does not interfere when the same relation is accessed inside its switch' do
+      Apartment::Tenant.switch('acme') do
+        expect(Widget.pluck(:name)).to(eq(['in_acme']))
+      end
+    end
+
+    it 'does not interfere with explicit default-tenant access' do
+      Apartment::Tenant.switch(V4IntegrationHelper.default_tenant) do
+        expect(Widget.pluck(:name)).to(eq(['in_default']))
+      end
+    end
+
+    # End-to-end proof of the Migrator exemption. With strict_tenant_lookup ON,
+    # Migrator#migrate_primary's AR::Base.connection_pool.migration_context call
+    # (line 100 in lib/apartment/migrator.rb) would raise without the
+    # Current.migrating bypass. Use migration_context directly inside a
+    # Current.migrating block to exercise the same path that migrate_primary
+    # takes; running the full Migrator under sqlite would also need a
+    # db/migrate directory which the integration suite doesn't ship.
+    it 'allows Migrator-style nil-tenant default-pool access when Current.migrating is set' do
+      Apartment::Current.migrating = true
+      expect { ActiveRecord::Base.connection_pool.migration_context }.not_to(raise_error)
+    ensure
+      Apartment::Current.migrating = false
+    end
+  end
+end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -600,6 +600,44 @@ RSpec.describe(Apartment::Config) do
         .to(raise_error(Apartment::ConfigurationError, /tenant_not_found_handler/))
     end
   end
+
+  describe '#strict_tenant_lookup' do
+    let(:config) do
+      described_class.new.tap do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+      end
+    end
+
+    it 'defaults to false (opt-in by user)' do
+      expect(described_class.new.strict_tenant_lookup).to(be(false))
+    end
+
+    it 'accepts true' do
+      config.strict_tenant_lookup = true
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'accepts false' do
+      config.strict_tenant_lookup = false
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    # Codex's review of the original PR caught this: Ruby truthiness would
+    # silently turn strict ON for "false" (String), 0, "no", etc. Match the
+    # validate! pattern used by every other boolean flag in this file.
+    it 'rejects non-boolean truthy values' do
+      config.strict_tenant_lookup = 'true'
+      expect { config.validate! }
+        .to(raise_error(Apartment::ConfigurationError, /strict_tenant_lookup/))
+    end
+
+    it 'rejects nil' do
+      config.strict_tenant_lookup = nil
+      expect { config.validate! }
+        .to(raise_error(Apartment::ConfigurationError, /strict_tenant_lookup/))
+    end
+  end
 end
 
 RSpec.describe('Apartment.configure') do

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -285,6 +285,43 @@ RSpec.describe(Apartment::Migrator) do
     end
   end
 
+  # Mirrors the migrate_tenant lifecycle tests above. migrate_primary is the
+  # one call site that accesses ActiveRecord::Base.connection_pool with
+  # Current.tenant nil by design; without the migrating-flag bypass added in
+  # this PR, strict_tenant_lookup users would have apartment:migrate raise
+  # ImplicitDefaultTenant.
+  describe '#migrate_primary Current.migrating lifecycle' do
+    let(:mock_pool) { double('pool', migration_context: double(needs_migration?: false)) }
+
+    it 'sets Current.migrating = true before accessing connection_pool' do
+      migrating_value_during_access = nil
+      allow(ActiveRecord::Base).to(receive(:connection_pool)) do
+        migrating_value_during_access = Apartment::Current.migrating
+        mock_pool
+      end
+
+      described_class.new.send(:migrate_primary)
+
+      expect(migrating_value_during_access).to(be(true))
+    end
+
+    it 'clears Current.migrating after migrate_primary completes' do
+      allow(ActiveRecord::Base).to(receive(:connection_pool).and_return(mock_pool))
+
+      described_class.new.send(:migrate_primary)
+
+      expect(Apartment::Current.migrating).to(be_falsey)
+    end
+
+    it 'clears Current.migrating even when migration_context raises' do
+      allow(ActiveRecord::Base).to(receive(:connection_pool).and_raise(StandardError, 'boom'))
+
+      described_class.new.send(:migrate_primary)
+
+      expect(Apartment::Current.migrating).to(be_falsey)
+    end
+  end
+
   describe '.with_migration_role' do
     it 'yields without connected_to when migration_role is nil' do
       expect(ActiveRecord::Base).not_to(receive(:connected_to))

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -455,6 +455,68 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
         expect(registered).to(be_nil)
       end
     end
+
+    context 'with strict_tenant_lookup enabled' do
+      # Reconfigure with the flag on. Config is frozen, so re-call configure;
+      # the after-hook in spec_helper.rb clears it between examples.
+      before do
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { %w[acme widgets] }
+          config.default_tenant = 'public'
+          config.check_pending_migrations = false
+          config.strict_tenant_lookup = true
+        end
+        Apartment.adapter = mock_adapter
+      end
+
+      it 'raises ImplicitDefaultTenant when tenant is nil instead of falling back to the default pool' do
+        Apartment::Current.tenant = nil
+        expect { ActiveRecord::Base.connection_pool }.to(raise_error(Apartment::ImplicitDefaultTenant))
+      end
+
+      it 'includes actionable guidance in the error message' do
+        Apartment::Current.tenant = nil
+        expect { ActiveRecord::Base.connection_pool }.to(
+          raise_error(Apartment::ImplicitDefaultTenant, /Apartment::Tenant\.switch/)
+        )
+      end
+
+      it 'does not interfere with explicit default-tenant access' do
+        Apartment::Current.tenant = 'public'
+        expect { ActiveRecord::Base.connection_pool }.not_to(raise_error)
+      end
+
+      it 'does not interfere with an active tenant' do
+        Apartment::Current.tenant = 'acme'
+        expect { ActiveRecord::Base.connection_pool }.not_to(raise_error)
+      end
+
+      it 'does not raise for pinned models accessed without a switch (they legitimately use the default pool)' do
+        pinned_class = Class.new(ActiveRecord::Base) do
+          include Apartment::Model
+        end
+        stub_const('PinnedNoSwitchTest', pinned_class)
+        pinned_class.pin_tenant
+
+        Apartment::Current.tenant = nil
+        expect { pinned_class.connection_pool }.not_to(raise_error)
+      end
+
+      # Migrator#migrate_primary calls AR::Base.connection_pool with nil tenant
+      # by design. Without this bypass, strict-on would break apartment:migrate
+      # in user dev/test environments — exactly the regression that killed the
+      # auto-default attempt. The Migrator sets Current.migrating around its
+      # default-pool access; the prepend honors it the same way
+      # check_pending_migrations? does.
+      it 'does not raise during a Migrator-run (Apartment::Current.migrating is true)' do
+        Apartment::Current.tenant = nil
+        Apartment::Current.migrating = true
+        expect { ActiveRecord::Base.connection_pool }.not_to(raise_error)
+      ensure
+        Apartment::Current.migrating = false
+      end
+    end
   end
 
   describe 'pinned_model? registry check' do


### PR DESCRIPTION
## Summary

`Apartment::Patches::ConnectionHandling#connection_pool` silently returns the default-tenant pool whenever `Apartment::Current.tenant` is `nil`. That's the right behavior for explicit no-tenant code. It's also the same code path that fires when tenant context was lost across a thread or fiber boundary — a lazy association accessed after its `switch` block exited, or a `load_async` relation consumed outside the original switch. Result: queries run against the wrong tenant's data with no error.

This PR adds an opt-in fail-loud guard. With the flag on and `Current.tenant` nil, `connection_pool` raises `Apartment::ImplicitDefaultTenant` instead of falling through. Explicit default-tenant access via `switch(default_tenant)` still works (non-nil tenant).

```ruby
Apartment.configure do |config|
  config.strict_tenant_lookup = Rails.env.local?  # recommended dev+test opt-in
end
```

## Bypasses (in the prepend, in order)

1. **Early boot** — calls before `pool_manager` is wired.
2. **Pinned models** — legitimately default-pool by design.
3. **Migration paths** — `Apartment::Current.migrating` is true. `Migrator#migrate_primary` intentionally accesses `AR::Base.connection_pool` with `Current.tenant` nil; this flag was already honored by `check_pending_migrations?`. Without this bypass, strict-on would break `apartment:migrate` in user dev/test — exactly the regression that killed the earlier auto-default attempt. (CLI rollback and `abstract_adapter#migrate` wrap in `Tenant.switch` and are unaffected.)

## Default = false

An auto-default tied to `Rails.env.local?` was tried and reverted. Once a dummy Rails app booted in `request_lifecycle_spec`, `Rails.env.local?` returned true for `test`, strict fired across the rest of the suite, and 11 specs failed across Migrator setup, edge_cases schema operations, and `Tenant.init`'s excluded-model processing — all legitimate gem-internal default-pool paths. An auto-default would have broken `apartment:migrate` in user dev/test the same way. Codifying `Current.migrating` as the bypass signal addresses Migrator; until the remaining internal paths are explicitly switch-wrapped (separate work), strict mode stays opt-in.

## Review polish baked in

Two panel rounds with Codex / Gemini / Cursor / Mistral; all findings either fixed or explicitly documented:

- **Codex:** boolean validation in `Config#validate!` so `"false"` / `0` / `"no"` (truthy non-true values) can't silently enable strict.
- **De Morgan cleanup** of the pinned-bypass predicate (extracted `pinned` local + positive form).
- **`ImplicitDefaultTenant#default_message`** mirrors `Tenant.assert_inside_tenant!`'s style: names the flag, points at `switch` / `switch!`, flags the `Tenant.current` vs `connection_pool` API asymmetry under strict.
- **Inline caveats in `config.rb`** call out: (a) `AR::Base.connection_pool` itself raises under strict — wrap `rails console` in `switch(default_tenant)`; (b) `shared_pinned_connection?` gap — strict only catches nil tenant, not wrong-tenant pinned reads on shared pools; (c) `Tenant.current` still falls back to `default_tenant` while `connection_pool` raises.

**Deferred (panel unanimous non-blocker):** `connects_to` / `connected_to(role:)` integration coverage. Orthogonal surface; flag is opt-in; existing v4 design contract already documents that `connects_to` models for non-tenant databases must `pin_tenant`.

## Pairs with [#415](https://github.com/rails-on-services/apartment/pull/415) (merged)

The async-query-correctness section in `docs/designs/apartment-v4.md` documents the contract this flag enforces; the error message references it.

## Changes

| File | Change |
|---|---|
| `lib/apartment/errors.rb` | New `Apartment::ImplicitDefaultTenant < ApartmentError` with actionable default message |
| `lib/apartment/config.rb` | New `attr_accessor :strict_tenant_lookup`, defaults `false`; boolean validation in `validate!`; inline caveats |
| `lib/apartment/patches/connection_handling.rb` | Restructured the prepend's early returns; raises when strict + nil tenant; bypasses pinned + pre-`pool_manager` boot + `Current.migrating` |
| `lib/apartment/migrator.rb` | `migrate_primary` sets `Current.migrating = true` / `ensure false` (mirrors `migrate_tenant`) |
| `spec/unit/config_spec.rb` | 5 new examples (default, settable both ways, rejects non-boolean truthy + nil) |
| `spec/unit/patches/connection_handling_spec.rb` | 6 new examples (raise path, error message, default + active tenant pass-through, pinned bypass, migrating bypass) |
| `spec/unit/migrator_spec.rb` | 3 new examples for `migrate_primary` `Current.migrating` lifecycle (sets, clears on success, clears on error — mirrors existing `migrate_tenant` tests) |
| `spec/integration/v4/strict_tenant_lookup_spec.rb` | New end-to-end spec, 6 examples on sqlite3 |
| `.gitignore` | Add `.zed/` |

## Verification (rails-8.1-sqlite3 appraisal)

- `bundle exec rspec spec/unit/` — **813 / 0**
- `bundle exec rspec spec/unit/migrator_spec.rb` — **47 / 0**
- `bundle exec rspec spec/integration/v4/` — **143 / 0 / 85 pending**
- `bundle exec rubocop` on changed files — clean (pre-existing redundant `Rails/UnknownEnv` directive removed during this work)

## Test plan

- [x] Strict on + nil tenant raises `ImplicitDefaultTenant`
- [x] Error message names the flag and points at `switch` / `switch!`
- [x] Strict on + explicit default tenant: no raise
- [x] Strict on + active tenant: no raise
- [x] Strict on + pinned model without switch: no raise (pinned bypass)
- [x] Strict on + `Current.migrating` true: no raise (Migrator bypass)
- [x] Default is `false`; settable via `Apartment.configure`; boolean-validated
- [x] End-to-end: captured-relation-outside-switch silently returns wrong tenant without strict; raises with strict
- [x] End-to-end: `Migrator`-style nil-tenant `migration_context` access works under strict
- [x] Unit: `migrate_primary` sets the flag, clears it on success, clears it on error
- [ ] CI matrix passes across Ruby 3.3/3.4/4.0 × Rails 7.2/8.0/8.1