### PR TITLE
Add opt-in log_default_tenant_fallback diagnostic for silent default-pool routes

### DIFF
--- a/docs/designs/apartment-v4.md
+++ b/docs/designs/apartment-v4.md
@@ -132,7 +132,7 @@ Apartment::Tenant.switch('acme') do
 end
 ```
 
-An optional `Apartment.config.strict_tenant_lookup` flag will turn the silent default-pool fallback into a raised `Apartment::ImplicitDefaultTenant` so this contract is enforceable in development/test. See its config docs for usage.
+An optional `Apartment.config.log_default_tenant_fallback` flag emits a debug log line (tagged `[Apartment] tenant=nil`) on every silent default-pool fallthrough, with the user's caller site and a stack chain. Per-process deduped by call site so the suite logs each leak once. Grep the log after a dev/test session to surface every leak. Diagnostic only, never raises -- it coexists with legitimate gem-internal default-pool paths instead of breaking them. See its config docs for usage.
 
 ### Core: Immutable Connection Pool Per Tenant
 

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -25,7 +25,8 @@ module Apartment
                   :active_record_log, :sql_query_tags,
                   :shard_key_prefix,
                   :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
-                  :force_separate_pinned_pool, :test_fixture_cleanup
+                  :force_separate_pinned_pool, :test_fixture_cleanup,
+                  :log_default_tenant_fallback
 
     def initialize # rubocop:disable Metrics/AbcSize
       @tenant_strategy = nil
@@ -57,6 +58,24 @@ module Apartment
       @check_pending_migrations = true
       @force_separate_pinned_pool = false
       @test_fixture_cleanup = true
+      # When true, every ConnectionHandling#connection_pool fallthrough to
+      # the default-tenant pool (Apartment::Current.tenant nil, after pinned
+      # and early-boot bypasses) emits a single Rails.logger.debug line
+      # tagged "[Apartment] tenant=nil" with the caller's file:line and a
+      # short stack chain. Per-process deduped by call site so a test suite
+      # logs each leak once.
+      #
+      # Default false. Opt-in pattern:
+      #
+      #   Apartment.configure do |config|
+      #     config.log_default_tenant_fallback = Rails.env.local?
+      #   end
+      #
+      # Then grep your dev/test log for "[Apartment] tenant=nil" after a
+      # session to find every silent default-pool access -- the same
+      # failure surface documented in docs/designs/apartment-v4.md
+      # "Async query correctness". Diagnostic only, never raises.
+      @log_default_tenant_fallback = false
     end
 
     def excluded_models=(list)
@@ -188,6 +207,12 @@ module Apartment
       unless [true, false].include?(@test_fixture_cleanup)
         raise(ConfigurationError,
               "test_fixture_cleanup must be true or false, got: #{@test_fixture_cleanup.inspect}")
+      end
+
+      unless [true, false].include?(@log_default_tenant_fallback)
+        raise(ConfigurationError,
+              'log_default_tenant_fallback must be true or false, got: ' \
+              "#{@log_default_tenant_fallback.inspect}")
       end
 
       unless @tenant_validator.nil? || @tenant_validator == false || @tenant_validator.respond_to?(:call)

--- a/lib/apartment/diagnostics.rb
+++ b/lib/apartment/diagnostics.rb
@@ -62,25 +62,54 @@ module Apartment
 
       private
 
-      # Skip frames inside this gem and inside common Rails-ecosystem gems
-      # so the caller resolves to the user's code, not the deep AR internals
-      # that issue the connection_pool call. Without this filter, dedup
-      # keys would vary by AR internal call site (one query can touch
-      # connection_pool from columns_hash, schema_load, query exec, etc.)
-      # and the same user line would log multiple times.
-      #
-      # Combined into one regex so the negation reads as a single
-      # `!match?` -- rubocop-rails' NegateInclude cop would otherwise push
-      # a `!include?` toward `String#exclude?`, which is an ActiveSupport
-      # extension this module shouldn't depend on.
-      INTERNAL_FRAME_PATTERN = %r{
-        /apartment(?:[/-])           # this gem (worktree path or installed gem dir)
-        | /gems/(?:apartment|active|action|rail)   # Rails ecosystem gems
-      }x
-      private_constant :INTERNAL_FRAME_PATTERN
+      # Path prefix for *this* gem's source, captured from __dir__ at load
+      # time. Covers local development / worktrees / source-installed gems.
+      # Using an exact prefix avoids the false positives that a substring
+      # match on "apartment" would cause -- e.g., an adopter app under
+      # `/Users/dev/my-apartment-service/` would otherwise have all its
+      # user frames filtered as "internal" and the diagnostic would
+      # resolve to deep AR frames.
+      GEM_ROOT = __dir__.freeze
+      private_constant :GEM_ROOT
 
+      # Anchor on `/gems/(name)-<digit>` so a gem installed via Bundler
+      # (where the path is `.../gems/<gem>-<version>/...`) is filtered
+      # without also matching adopter app paths that happen to contain
+      # the gem's name as a substring. Mirrors how Rails core gems are
+      # filtered below.
+      INSTALLED_GEM_FRAME_PATTERN = %r{/gems/apartment-\d}.freeze
+      private_constant :INSTALLED_GEM_FRAME_PATTERN
+
+      # Concrete Rails core gem directory name prefixes. Explicit list
+      # (instead of a `/(active|action|rail)/` prefix sweep) so non-core
+      # gems with similar names -- active_model_serializers, activeadmin,
+      # action_policy, rails_admin -- stay visible. If a leak originates
+      # from one of those, the user wants to see it, not have it hidden
+      # behind AR internals.
+      RAILS_CORE_GEMS = %w[
+        activerecord activesupport activemodel activejob
+        actionpack actionview actionmailer actioncable
+        actionmailbox actiontext railties rails
+      ].freeze
+      private_constant :RAILS_CORE_GEMS
+
+      RAILS_CORE_FRAME_PATTERN = %r{/gems/(?:#{RAILS_CORE_GEMS.join('|')})-\d}.freeze
+      private_constant :RAILS_CORE_FRAME_PATTERN
+
+      # First frame outside this gem (source or installed) and outside
+      # Rails core. That's the user's code (or a non-core gem like an
+      # engine or serializer where a leak is still actionable).
+      #
+      # Without this filter, one query can hit connection_pool from
+      # multiple AR internal sites (columns_hash, schema_load, query exec)
+      # at different file:line each -- dedup would treat them as distinct
+      # "leaks" and log multiple times for one user mistake.
       def first_user_site(frames)
-        user = frames.find { |f| !f.path.match?(INTERNAL_FRAME_PATTERN) }
+        user = frames.find do |f|
+          !f.path.start_with?(GEM_ROOT) &&
+            !f.path.match?(INSTALLED_GEM_FRAME_PATTERN) &&
+            !f.path.match?(RAILS_CORE_FRAME_PATTERN)
+        end
         f = user || frames.first
         f ? "#{f.path}:#{f.lineno}" : '(unknown)'
       end

--- a/lib/apartment/diagnostics.rb
+++ b/lib/apartment/diagnostics.rb
@@ -72,12 +72,16 @@ module Apartment
       GEM_ROOT = __dir__.freeze
       private_constant :GEM_ROOT
 
-      # Anchor on `/gems/(name)-<digit>` so a gem installed via Bundler
-      # (where the path is `.../gems/<gem>-<version>/...`) is filtered
-      # without also matching adopter app paths that happen to contain
-      # the gem's name as a substring. Mirrors how Rails core gems are
-      # filtered below.
-      INSTALLED_GEM_FRAME_PATTERN = %r{/gems/apartment-\d}.freeze
+      # Anchor on `/gems/(name)-<version-or-sha>` to cover both flavors
+      # of Bundler installation:
+      #   * Rubygems install:   `/gems/<name>-<version>/`  (version starts with a digit)
+      #   * Git install:        `/bundler/gems/<name>-<sha>/` (SHA is hex; ~5/8 start with a letter)
+      # The `[a-f0-9]` class matches both digits (version) and lowercase
+      # hex (SHA). Won't match a hypothetical sibling gem like
+      # `apartment-foo` -- which is fine for our heuristic; no such gem
+      # exists and an ecosystem gem with this name should arguably be
+      # filtered too.
+      INSTALLED_GEM_FRAME_PATTERN = %r{/gems/apartment-[a-f0-9]}.freeze
       private_constant :INSTALLED_GEM_FRAME_PATTERN
 
       # Concrete Rails core gem directory name prefixes. Explicit list
@@ -87,13 +91,13 @@ module Apartment
       # from one of those, the user wants to see it, not have it hidden
       # behind AR internals.
       RAILS_CORE_GEMS = %w[
-        activerecord activesupport activemodel activejob
+        activerecord activesupport activemodel activejob activestorage
         actionpack actionview actionmailer actioncable
         actionmailbox actiontext railties rails
       ].freeze
       private_constant :RAILS_CORE_GEMS
 
-      RAILS_CORE_FRAME_PATTERN = %r{/gems/(?:#{RAILS_CORE_GEMS.join('|')})-\d}.freeze
+      RAILS_CORE_FRAME_PATTERN = %r{/gems/(?:#{RAILS_CORE_GEMS.join('|')})-[a-f0-9]}.freeze
       private_constant :RAILS_CORE_FRAME_PATTERN
 
       # First frame outside this gem (source or installed) and outside

--- a/lib/apartment/diagnostics.rb
+++ b/lib/apartment/diagnostics.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Apartment
+  # Opt-in diagnostic that logs (at debug level) every time
+  # ConnectionHandling#connection_pool falls through to the default-tenant
+  # pool because Apartment::Current.tenant is nil. The same nil-fallback
+  # is the silent backdoor behind a class of bugs: a lazy association
+  # accessed after its switch block exited, or a load_async relation
+  # consumed outside the original switch -- the query runs against the
+  # wrong tenant with no error, no warning.
+  #
+  # The diagnostic deduplicates per call site so a test suite or request
+  # flow doesn't get spammed for the same leak. Reset between test runs
+  # via {.reset!}.
+  #
+  # Disabled by default. Adopt via:
+  #
+  #   Apartment.configure do |config|
+  #     config.log_default_tenant_fallback = Rails.env.local?
+  #   end
+  #
+  # Then grep your dev or test log for "[Apartment] tenant=nil" after a
+  # session to find every leak site.
+  module Diagnostics
+    DEDUP_MUTEX = Mutex.new
+    private_constant :DEDUP_MUTEX
+
+    # Per-process set of "file:line" call sites already logged. Internal
+    # state, exposed only for {.reset!}.
+    @seen_sites = Set.new
+
+    class << self
+      # Log a single dedup'd debug line for a nil-tenant default-pool
+      # fallback. No-op when {Apartment.config} is unset, when the flag
+      # is off, or when Rails.logger is unavailable.
+      #
+      # @param model_class [Class] the AR class on which connection_pool
+      #   was invoked (used in the log line for context).
+      # @param frames [Array<Thread::Backtrace::Location>] caller frames
+      #   passed in by the prepend so we capture the user's call site
+      #   rather than this module's.
+      def record_default_tenant_fallback(model_class, frames)
+        return unless Apartment.config&.log_default_tenant_fallback
+        return unless defined?(Rails) && Rails.logger
+
+        site = first_user_site(frames)
+        return unless first_seen?(site)
+
+        emit_log_line(model_class, frames, site)
+      end
+
+      # Clear the dedup set. Useful in test suites that want each example
+      # to start with a fresh slate so per-test leaks surface.
+      def reset!
+        DEDUP_MUTEX.synchronize { @seen_sites.clear }
+      end
+
+      # Currently-recorded sites; intended for tests and debugging.
+      def seen_sites
+        DEDUP_MUTEX.synchronize { @seen_sites.dup }
+      end
+
+      private
+
+      # Skip frames inside this gem and inside common Rails-ecosystem gems
+      # so the caller resolves to the user's code, not the deep AR internals
+      # that issue the connection_pool call. Without this filter, dedup
+      # keys would vary by AR internal call site (one query can touch
+      # connection_pool from columns_hash, schema_load, query exec, etc.)
+      # and the same user line would log multiple times.
+      #
+      # Combined into one regex so the negation reads as a single
+      # `!match?` -- rubocop-rails' NegateInclude cop would otherwise push
+      # a `!include?` toward `String#exclude?`, which is an ActiveSupport
+      # extension this module shouldn't depend on.
+      INTERNAL_FRAME_PATTERN = %r{
+        /apartment(?:[/-])           # this gem (worktree path or installed gem dir)
+        | /gems/(?:apartment|active|action|rail)   # Rails ecosystem gems
+      }x
+      private_constant :INTERNAL_FRAME_PATTERN
+
+      def first_user_site(frames)
+        user = frames.find { |f| !f.path.match?(INTERNAL_FRAME_PATTERN) }
+        f = user || frames.first
+        f ? "#{f.path}:#{f.lineno}" : '(unknown)'
+      end
+
+      # Set#add? returns nil when the element is already present, the
+      # element itself when newly added. Wrap in the mutex so concurrent
+      # threads don't race on first-seen.
+      def first_seen?(site)
+        DEDUP_MUTEX.synchronize { !!@seen_sites.add?(site) }
+      end
+
+      def emit_log_line(model_class, frames, site)
+        Rails.logger.debug do
+          chain = frames.first(8).map { |f| "  #{f.path}:#{f.lineno}:in `#{f.label}'" }.join("\n")
+          '[Apartment] tenant=nil -> default pool fallback. ' \
+            "Model=#{model_class.name || model_class.inspect}. Caller=#{site}\n#{chain}"
+        end
+      end
+    end
+  end
+end

--- a/lib/apartment/diagnostics.rb
+++ b/lib/apartment/diagnostics.rb
@@ -42,6 +42,13 @@ module Apartment
       def record_default_tenant_fallback(model_class, frames)
         return unless Apartment.config&.log_default_tenant_fallback
         return unless defined?(Rails) && Rails.logger
+        # Gate on debug level BEFORE first_seen? mutates the dedup set.
+        # Otherwise a logger at level > debug silently drops the log but
+        # still marks the site as seen -- if the level is later lowered
+        # to debug, the leak never logs because dedup already remembers
+        # it. Affects rake tasks, console sessions, and anywhere the
+        # default Rails.logger is configured above debug.
+        return unless Rails.logger.respond_to?(:debug?) && Rails.logger.debug?
 
         site = first_user_site(frames)
         return unless first_seen?(site)
@@ -81,7 +88,7 @@ module Apartment
       # `apartment-foo` -- which is fine for our heuristic; no such gem
       # exists and an ecosystem gem with this name should arguably be
       # filtered too.
-      INSTALLED_GEM_FRAME_PATTERN = %r{/gems/apartment-[a-f0-9]}.freeze
+      INSTALLED_GEM_FRAME_PATTERN = %r{/gems/apartment-[a-f0-9]}
       private_constant :INSTALLED_GEM_FRAME_PATTERN
 
       # Concrete Rails core gem directory name prefixes. Explicit list
@@ -97,7 +104,7 @@ module Apartment
       ].freeze
       private_constant :RAILS_CORE_GEMS
 
-      RAILS_CORE_FRAME_PATTERN = %r{/gems/(?:#{RAILS_CORE_GEMS.join('|')})-[a-f0-9]}.freeze
+      RAILS_CORE_FRAME_PATTERN = %r{/gems/(?:#{RAILS_CORE_GEMS.join('|')})-[a-f0-9]}
       private_constant :RAILS_CORE_FRAME_PATTERN
 
       # First frame outside this gem (source or installed) and outside

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -93,9 +93,17 @@ module Apartment
 
     # Migrate the primary (default) tenant using AR::Base's existing pool.
     # No tenant switch needed — the default connection is already correct.
+    #
+    # Sets Apartment::Current.migrating around the connection_pool access
+    # so the log_default_tenant_fallback diagnostic (opt-in dev/test
+    # flag in ConnectionHandling) doesn't fire on legitimate primary
+    # migration. Without this, every `apartment:migrate` run with the
+    # diagnostic enabled would emit a deduped log line pointing at this
+    # method. Mirrors the pattern in migrate_tenant.
     def migrate_primary # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       tenant_name = Apartment.config.default_tenant
       start = monotonic_now
+      Apartment::Current.migrating = true
 
       context = ActiveRecord::Base.connection_pool.migration_context
 
@@ -120,6 +128,8 @@ module Apartment
         tenant: tenant_name, status: :failed,
         duration: monotonic_now - start, error: e, versions_run: []
       )
+    ensure
+      Apartment::Current.migrating = false
     end
 
     # Migrate a single tenant by switching via Apartment::Tenant.switch.

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -13,7 +13,21 @@ module Apartment
         tenant = Apartment::Current.tenant
         cfg = Apartment.config
 
-        return super if tenant.nil? || cfg.nil?
+        return super if cfg.nil?
+
+        if tenant.nil?
+          # Opt-in diagnostic for the silent default-pool fallback. Skipped
+          # for pinned models (they legitimately use the default pool by
+          # design) and when pool_manager isn't wired (we're in early boot,
+          # not in user request/job code). The flag check sits first so
+          # the common (flag-off) path avoids the caller_locations capture.
+          if cfg.log_default_tenant_fallback && Apartment.pool_manager &&
+             !(self != ActiveRecord::Base && Apartment.pinned_model?(self))
+            Apartment::Diagnostics.record_default_tenant_fallback(self, caller_locations(1, 12))
+          end
+          return super
+        end
+
         return super if tenant.to_s == cfg.default_tenant.to_s
         return super unless Apartment.pool_manager
 
@@ -80,7 +94,7 @@ module Apartment
 
       def check_pending_migrations?(pool)
         return false unless Apartment.config.check_pending_migrations
-        return false unless defined?(Rails) && Rails.env.local? # rubocop:disable Rails/UnknownEnv
+        return false unless defined?(Rails) && Rails.env.local?
         return false if Apartment::Current.migrating
 
         pool.migration_context.needs_migration?

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -17,12 +17,15 @@ module Apartment
 
         if tenant.nil?
           # Opt-in diagnostic for the silent default-pool fallback. Skipped
-          # for pinned models (they legitimately use the default pool by
-          # design) and when pool_manager isn't wired (we're in early boot,
-          # not in user request/job code). The flag check sits first so
-          # the common (flag-off) path avoids the caller_locations capture.
+          # for pinned models (legitimately default-pool by design), during
+          # Migrator runs (Migrator#migrate_primary intentionally hits the
+          # default pool with nil tenant; mirrors check_pending_migrations?
+          # bypass below), and during early boot before pool_manager is
+          # wired. The flag check sits first so the common (flag-off) path
+          # avoids the caller_locations capture cost.
+          pinned = self != ActiveRecord::Base && Apartment.pinned_model?(self)
           if cfg.log_default_tenant_fallback && Apartment.pool_manager &&
-             !(self != ActiveRecord::Base && Apartment.pinned_model?(self))
+             !pinned && !Apartment::Current.migrating
             Apartment::Diagnostics.record_default_tenant_fallback(self, caller_locations(1, 12))
           end
           return super

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -26,7 +26,11 @@ module Apartment
           pinned = self != ActiveRecord::Base && Apartment.pinned_model?(self)
           if cfg.log_default_tenant_fallback && Apartment.pool_manager &&
              !pinned && !Apartment::Current.migrating
-            Apartment::Diagnostics.record_default_tenant_fallback(self, caller_locations(1, 12))
+            # 20 frames covers deep engine/concern/service stacks where the
+            # user's call site sits behind several layers of indirection.
+            # first_user_site filters internals; emit_log_line caps the
+            # printed chain at 8, so this only affects the search depth.
+            Apartment::Diagnostics.record_default_tenant_fallback(self, caller_locations(1, 20))
           end
           return super
         end
@@ -97,7 +101,7 @@ module Apartment
 
       def check_pending_migrations?(pool)
         return false unless Apartment.config.check_pending_migrations
-        return false unless defined?(Rails) && Rails.env.local?
+        return false unless defined?(Rails) && Rails.env.local? # rubocop:disable Rails/UnknownEnv
         return false if Apartment::Current.migrating
 
         pool.migration_context.needs_migration?

--- a/spec/integration/v4/log_default_tenant_fallback_spec.rb
+++ b/spec/integration/v4/log_default_tenant_fallback_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe('log_default_tenant_fallback integration', :integration,
       # Caller should resolve to THIS spec file, not to an AR internal
       # frame. Verifies the GEM_ROOT / Rails-core filter is doing the
       # right thing under realistic AR call stacks.
-      expect(log_io.string).to(match(%r{Caller=.*log_default_tenant_fallback_spec\.rb:\d+}))
+      expect(log_io.string).to(match(/Caller=.*log_default_tenant_fallback_spec\.rb:\d+/))
     end
 
     it 'dedupes per call site: repeated access at the same line logs once' do

--- a/spec/integration/v4/log_default_tenant_fallback_spec.rb
+++ b/spec/integration/v4/log_default_tenant_fallback_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'logger'
+require 'stringio'
+require_relative 'support'
+
+# End-to-end proof of the failure mode the log_default_tenant_fallback
+# diagnostic surfaces: a relation captured inside Tenant.switch and
+# accessed afterwards silently re-resolves connection_pool on the
+# consumer fiber. With Apartment::Current.tenant.nil?, ConnectionHandling
+# falls through to super and the query runs against the DEFAULT tenant
+# -- wrong data, no error.
+#
+# Without the diagnostic: the test demonstrates the silent failure mode
+# unchanged (gem behavior is preserved; this is a passive diagnostic).
+# With the diagnostic: the same fallback emits a debug log line tagged
+# "[Apartment] tenant=nil" with the caller site, dedup'd per call site.
+#
+# This is the consumer-fiber re-resolution case documented in
+# docs/designs/apartment-v4.md "Async query correctness".
+RSpec.describe('log_default_tenant_fallback integration', :integration,
+               skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
+  include V4IntegrationHelper
+
+  let(:tmp_dir) { Dir.mktmpdir('apartment_diag') }
+  let(:tenants) { %w[acme] }
+  let(:log_io) { StringIO.new }
+  let(:logger) { Logger.new(log_io).tap { |l| l.level = Logger::DEBUG } }
+
+  before do
+    V4IntegrationHelper.ensure_test_database! unless V4IntegrationHelper.sqlite?
+    @connection_config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+    stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+    # spec/support/rails_stub.rb provides a bare Rails stub; replace its
+    # logger so the diagnostic has somewhere to write.
+    allow(Rails).to(receive(:logger).and_return(logger))
+    Apartment::Diagnostics.reset!
+  end
+
+  after do
+    V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter) if Apartment.adapter
+    Apartment.clear_config
+    Apartment::Current.reset
+    Apartment::Diagnostics.reset!
+    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:') if V4IntegrationHelper.sqlite?
+    FileUtils.rm_rf(tmp_dir)
+  end
+
+  def populate_data(diagnostic:)
+    Apartment.configure do |c|
+      c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+      c.tenants_provider = -> { tenants }
+      c.default_tenant = V4IntegrationHelper.default_tenant
+      c.check_pending_migrations = false
+      c.log_default_tenant_fallback = diagnostic
+    end
+    Apartment.adapter = V4IntegrationHelper.build_adapter(@connection_config)
+    Apartment.activate!
+
+    # Wrap default-tenant setup in switch(default_tenant) so the diagnostic
+    # doesn't fire on legitimate setup paths and pollute log_io / dedup
+    # before the actual test assertions run.
+    Apartment::Tenant.switch(V4IntegrationHelper.default_tenant) do
+      tenants.each { |t| Apartment.adapter.create(t) }
+      V4IntegrationHelper.create_test_table!
+      Widget.create!(name: 'in_default')
+    end
+
+    tenants.each do |t|
+      Apartment::Tenant.switch(t) do
+        V4IntegrationHelper.create_test_table!('widgets', connection: ActiveRecord::Base.connection)
+        Widget.create!(name: "in_#{t}")
+      end
+    end
+
+    # Reset the logger and dedup so the test starts with a clean slate
+    # regardless of what setup happened to log.
+    log_io.truncate(0)
+    Apartment::Diagnostics.reset!
+  end
+
+  context 'without the diagnostic (flag off)' do
+    before { populate_data(diagnostic: false) }
+
+    it 'silently returns the default tenant data when a captured relation is accessed outside its switch block' do
+      captured = Apartment::Tenant.switch('acme') { Widget.all }
+      expect(captured.pluck(:name)).to(eq(['in_default']))
+    end
+
+    it 'does not log the fallback' do
+      Apartment::Tenant.switch('acme') { Widget.all }.pluck(:name)
+      expect(log_io.string).not_to(match(/\[Apartment\] tenant=nil/))
+    end
+  end
+
+  context 'with the diagnostic (flag on)' do
+    before { populate_data(diagnostic: true) }
+
+    it 'still silently returns the default tenant data (diagnostic is passive)' do
+      captured = Apartment::Tenant.switch('acme') { Widget.all }
+      expect(captured.pluck(:name)).to(eq(['in_default']))
+    end
+
+    it 'emits a debug log line tagged [Apartment] tenant=nil with caller info' do
+      Apartment::Tenant.switch('acme') { Widget.all }.pluck(:name)
+      expect(log_io.string).to(match(/DEBUG/))
+      expect(log_io.string).to(match(/\[Apartment\] tenant=nil/))
+      expect(log_io.string).to(match(/Caller=/))
+    end
+
+    it 'dedupes per call site: repeated access at the same line logs once' do
+      captured = Apartment::Tenant.switch('acme') { Widget.all }
+      5.times { captured.pluck(:name) }
+      expect(log_io.string.scan('[Apartment] tenant=nil').size).to(eq(1))
+    end
+
+    it 'does not log when access is inside an explicit Tenant.switch' do
+      Apartment::Tenant.switch('acme') { Widget.pluck(:name) }
+      Apartment::Tenant.switch(V4IntegrationHelper.default_tenant) { Widget.pluck(:name) }
+      expect(log_io.string).not_to(match(/\[Apartment\] tenant=nil/))
+    end
+  end
+end

--- a/spec/integration/v4/log_default_tenant_fallback_spec.rb
+++ b/spec/integration/v4/log_default_tenant_fallback_spec.rb
@@ -106,7 +106,10 @@ RSpec.describe('log_default_tenant_fallback integration', :integration,
       Apartment::Tenant.switch('acme') { Widget.all }.pluck(:name)
       expect(log_io.string).to(match(/DEBUG/))
       expect(log_io.string).to(match(/\[Apartment\] tenant=nil/))
-      expect(log_io.string).to(match(/Caller=/))
+      # Caller should resolve to THIS spec file, not to an AR internal
+      # frame. Verifies the GEM_ROOT / Rails-core filter is doing the
+      # right thing under realistic AR call stacks.
+      expect(log_io.string).to(match(%r{Caller=.*log_default_tenant_fallback_spec\.rb:\d+}))
     end
 
     it 'dedupes per call site: repeated access at the same line logs once' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -600,6 +600,41 @@ RSpec.describe(Apartment::Config) do
         .to(raise_error(Apartment::ConfigurationError, /tenant_not_found_handler/))
     end
   end
+
+  describe '#log_default_tenant_fallback' do
+    let(:config) do
+      described_class.new.tap do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+      end
+    end
+
+    it 'defaults to false (opt-in by user)' do
+      expect(described_class.new.log_default_tenant_fallback).to(be(false))
+    end
+
+    it 'accepts true' do
+      config.log_default_tenant_fallback = true
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'accepts false' do
+      config.log_default_tenant_fallback = false
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'rejects non-boolean truthy values (matches the pattern other flags use)' do
+      config.log_default_tenant_fallback = 'true'
+      expect { config.validate! }
+        .to(raise_error(Apartment::ConfigurationError, /log_default_tenant_fallback/))
+    end
+
+    it 'rejects nil' do
+      config.log_default_tenant_fallback = nil
+      expect { config.validate! }
+        .to(raise_error(Apartment::ConfigurationError, /log_default_tenant_fallback/))
+    end
+  end
 end
 
 RSpec.describe('Apartment.configure') do

--- a/spec/unit/diagnostics_spec.rb
+++ b/spec/unit/diagnostics_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'logger'
+require 'stringio'
+
+RSpec.describe(Apartment::Diagnostics) do
+  let(:log_io) { StringIO.new }
+  let(:logger) { Logger.new(log_io).tap { |l| l.level = Logger::DEBUG } }
+  let(:fake_model_class) { Struct.new(:name).new('FakeWidget') }
+
+  before do
+    Apartment.configure do |config|
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.default_tenant = 'public'
+      config.log_default_tenant_fallback = true
+    end
+    stub_const('Rails', Module.new)
+    allow(Rails).to(receive(:logger).and_return(logger))
+    described_class.reset!
+  end
+
+  after { described_class.reset! }
+
+  # Build a small caller_locations array. Real `Thread::Backtrace::Location`
+  # objects are hard to construct synthetically; the module only uses
+  # #path, #lineno, and #label, so a struct standing in is enough.
+  def frame(path:, lineno:, label: 'block')
+    Struct.new(:path, :lineno, :label).new(path, lineno, label)
+  end
+
+  describe '.record_default_tenant_fallback' do
+    it 'is a no-op when Apartment.config is nil' do
+      Apartment.clear_config
+      described_class.record_default_tenant_fallback(
+        fake_model_class,
+        [frame(path: '/app/models/widget.rb', lineno: 42)]
+      )
+      expect(log_io.string).to(be_empty)
+    end
+
+    it 'is a no-op when the flag is off' do
+      # Config is frozen after configure; reconfigure instead of mutating.
+      Apartment.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.default_tenant = 'public'
+        config.log_default_tenant_fallback = false
+      end
+      described_class.record_default_tenant_fallback(
+        fake_model_class,
+        [frame(path: '/app/models/widget.rb', lineno: 42)]
+      )
+      expect(log_io.string).to(be_empty)
+    end
+
+    it 'is a no-op when Rails.logger is missing' do
+      allow(Rails).to(receive(:logger).and_return(nil))
+      described_class.record_default_tenant_fallback(
+        fake_model_class,
+        [frame(path: '/app/models/widget.rb', lineno: 42)]
+      )
+      # Without a logger, dedup state should also not be polluted.
+      expect(described_class.seen_sites).to(be_empty)
+    end
+
+    it 'logs at debug level with the model class and caller site' do
+      described_class.record_default_tenant_fallback(
+        fake_model_class,
+        [frame(path: '/app/models/widget.rb', lineno: 42, label: 'load_async')]
+      )
+      expect(log_io.string).to(match(/DEBUG/))
+      expect(log_io.string).to(match(/\[Apartment\] tenant=nil/))
+      expect(log_io.string).to(match(/Model=FakeWidget/))
+      expect(log_io.string).to(match(%r{Caller=/app/models/widget\.rb:42}))
+    end
+
+    it 'logs the first 8 caller frames' do
+      frames = (1..12).map { |i| frame(path: '/app/work.rb', lineno: i) }
+      described_class.record_default_tenant_fallback(fake_model_class, frames)
+      lines_after_caller = log_io.string.scan(%r{/app/work\.rb:\d+:in `block'})
+      # Cap at 8 even though we passed 12.
+      expect(lines_after_caller.size).to(eq(8))
+    end
+
+    it 'dedupes per call site so a hot loop logs once' do
+      f = [frame(path: '/app/models/widget.rb', lineno: 99)]
+      5.times { described_class.record_default_tenant_fallback(fake_model_class, f) }
+      expect(log_io.string.scan('[Apartment] tenant=nil').size).to(eq(1))
+    end
+
+    it 'logs distinct call sites separately' do
+      a = [frame(path: '/app/models/widget.rb', lineno: 10)]
+      b = [frame(path: '/app/models/widget.rb', lineno: 20)]
+      described_class.record_default_tenant_fallback(fake_model_class, a)
+      described_class.record_default_tenant_fallback(fake_model_class, b)
+      expect(log_io.string.scan('[Apartment] tenant=nil').size).to(eq(2))
+    end
+
+    it 'skips gem-internal frames (apartment + Rails ecosystem) to reach user code' do
+      frames = [
+        frame(path: '/gems/apartment/lib/apartment/patches/connection_handling.rb', lineno: 22),
+        frame(path: '/gems/activerecord/lib/active_record/relation.rb', lineno: 1437),
+        frame(path: '/gems/activesupport/lib/active_support/callbacks.rb', lineno: 99),
+        frame(path: '/app/controllers/posts_controller.rb', lineno: 17, label: 'show'),
+      ]
+      described_class.record_default_tenant_fallback(fake_model_class, frames)
+      # Filter skips apartment, activerecord, activesupport -> resolves to
+      # the user controller. That's the actionable line; deep AR frames
+      # would just be noise.
+      expect(log_io.string).to(match(%r{Caller=/app/controllers/posts_controller\.rb:17}))
+    end
+  end
+
+  describe '.reset!' do
+    it 'clears the dedup set so the next call logs again' do
+      f = [frame(path: '/app/models/widget.rb', lineno: 5)]
+      described_class.record_default_tenant_fallback(fake_model_class, f)
+      described_class.reset!
+      described_class.record_default_tenant_fallback(fake_model_class, f)
+      expect(log_io.string.scan('[Apartment] tenant=nil').size).to(eq(2))
+    end
+  end
+
+  describe '.seen_sites' do
+    it 'returns the set of recorded sites' do
+      described_class.record_default_tenant_fallback(
+        fake_model_class,
+        [frame(path: '/app/foo.rb', lineno: 1)]
+      )
+      expect(described_class.seen_sites).to(include('/app/foo.rb:1'))
+    end
+
+    it 'returns a copy (mutation does not affect internal state)' do
+      described_class.record_default_tenant_fallback(
+        fake_model_class,
+        [frame(path: '/app/foo.rb', lineno: 1)]
+      )
+      described_class.seen_sites.clear
+      expect(described_class.seen_sites).not_to(be_empty)
+    end
+  end
+end

--- a/spec/unit/diagnostics_spec.rb
+++ b/spec/unit/diagnostics_spec.rb
@@ -98,18 +98,53 @@ RSpec.describe(Apartment::Diagnostics) do
       expect(log_io.string.scan('[Apartment] tenant=nil').size).to(eq(2))
     end
 
-    it 'skips gem-internal frames (apartment + Rails ecosystem) to reach user code' do
+    it 'skips gem-internal frames (apartment + Rails core) to reach user code' do
       frames = [
-        frame(path: '/gems/apartment/lib/apartment/patches/connection_handling.rb', lineno: 22),
-        frame(path: '/gems/activerecord/lib/active_record/relation.rb', lineno: 1437),
-        frame(path: '/gems/activesupport/lib/active_support/callbacks.rb', lineno: 99),
+        frame(path: '/gems/apartment-4.0.0/lib/apartment/patches/connection_handling.rb', lineno: 22),
+        frame(path: '/gems/activerecord-8.1.3/lib/active_record/relation.rb', lineno: 1437),
+        frame(path: '/gems/activesupport-8.1.3/lib/active_support/callbacks.rb', lineno: 99),
         frame(path: '/app/controllers/posts_controller.rb', lineno: 17, label: 'show'),
       ]
       described_class.record_default_tenant_fallback(fake_model_class, frames)
-      # Filter skips apartment, activerecord, activesupport -> resolves to
-      # the user controller. That's the actionable line; deep AR frames
-      # would just be noise.
       expect(log_io.string).to(match(%r{Caller=/app/controllers/posts_controller\.rb:17}))
+    end
+
+    # Regression: panel review of #417 caught that a substring match on
+    # "apartment" would filter user apps whose path contains that word --
+    # e.g., an app called "my-apartment-service". The fix uses the gem's
+    # own __dir__ as the prefix for source paths and an anchored
+    # `/gems/apartment-<digit>` pattern for installed gem paths, so
+    # adopter app paths cannot collide.
+    it 'does NOT filter user app paths that happen to contain the word "apartment"' do
+      frames = [
+        frame(path: '/gems/activerecord-8.1.3/lib/active_record/relation.rb', lineno: 1437),
+        frame(path: '/Users/dev/my-apartment-service/app/models/post.rb', lineno: 12, label: 'recent'),
+      ]
+      described_class.record_default_tenant_fallback(fake_model_class, frames)
+      expect(log_io.string).to(match(%r{Caller=/Users/dev/my-apartment-service/app/models/post\.rb:12}))
+    end
+
+    # Regression: don't over-filter non-core gems with Rails-sounding
+    # names. If a leak comes from active_model_serializers or activeadmin,
+    # the user wants to see that line, not have it hidden behind AR.
+    it 'does NOT filter non-core Rails-ecosystem gems' do
+      frames = [
+        frame(path: '/gems/activerecord-8.1.3/lib/active_record/relation.rb', lineno: 1437),
+        frame(path: '/gems/active_model_serializers-0.10.14/lib/active_model/serializer.rb', lineno: 89),
+        frame(path: '/app/controllers/posts_controller.rb', lineno: 17),
+      ]
+      described_class.record_default_tenant_fallback(fake_model_class, frames)
+      # First non-core, non-apartment frame is the serializer.
+      expect(log_io.string).to(match(%r{Caller=/gems/active_model_serializers-0\.10\.14/lib/active_model/serializer\.rb:89}))
+    end
+
+    it 'falls back to the topmost frame when every frame is internal' do
+      frames = [
+        frame(path: '/gems/apartment-4.0.0/lib/apartment/patches/connection_handling.rb', lineno: 22),
+        frame(path: '/gems/activerecord-8.1.3/lib/active_record/relation.rb', lineno: 1437),
+      ]
+      described_class.record_default_tenant_fallback(fake_model_class, frames)
+      expect(log_io.string).to(match(%r{Caller=/gems/apartment-4\.0\.0/lib/apartment/patches/connection_handling\.rb:22}))
     end
   end
 

--- a/spec/unit/diagnostics_spec.rb
+++ b/spec/unit/diagnostics_spec.rb
@@ -65,6 +65,31 @@ RSpec.describe(Apartment::Diagnostics) do
       expect(described_class.seen_sites).to(be_empty)
     end
 
+    # Regression: panel round 3 caught that first_seen? used to run
+    # BEFORE the debug-level check, so a logger at INFO would suppress
+    # the log but still mark the site seen -- if the level later
+    # dropped to debug, the leak would never log. The gate now runs
+    # first; dedup is untouched when debug is off.
+    it 'does NOT pollute the dedup set when the logger level is above debug' do
+      logger.level = Logger::INFO
+      described_class.record_default_tenant_fallback(
+        fake_model_class,
+        [frame(path: '/app/models/widget.rb', lineno: 42)]
+      )
+      expect(described_class.seen_sites).to(be_empty)
+    end
+
+    it 'logs when the logger level later drops to debug' do
+      f = [frame(path: '/app/models/widget.rb', lineno: 42)]
+      logger.level = Logger::INFO
+      described_class.record_default_tenant_fallback(fake_model_class, f)
+      expect(log_io.string).to(be_empty)
+
+      logger.level = Logger::DEBUG
+      described_class.record_default_tenant_fallback(fake_model_class, f)
+      expect(log_io.string).to(match(/\[Apartment\] tenant=nil/))
+    end
+
     it 'logs at debug level with the model class and caller site' do
       described_class.record_default_tenant_fallback(
         fake_model_class,
@@ -128,23 +153,25 @@ RSpec.describe(Apartment::Diagnostics) do
     # names. If a leak comes from active_model_serializers or activeadmin,
     # the user wants to see that line, not have it hidden behind AR.
     it 'does NOT filter non-core Rails-ecosystem gems' do
+      ams_path = '/gems/active_model_serializers-0.10.14/lib/active_model/serializer.rb'
       frames = [
         frame(path: '/gems/activerecord-8.1.3/lib/active_record/relation.rb', lineno: 1437),
-        frame(path: '/gems/active_model_serializers-0.10.14/lib/active_model/serializer.rb', lineno: 89),
+        frame(path: ams_path, lineno: 89),
         frame(path: '/app/controllers/posts_controller.rb', lineno: 17),
       ]
       described_class.record_default_tenant_fallback(fake_model_class, frames)
       # First non-core, non-apartment frame is the serializer.
-      expect(log_io.string).to(match(%r{Caller=/gems/active_model_serializers-0\.10\.14/lib/active_model/serializer\.rb:89}))
+      expect(log_io.string).to(match(/Caller=#{Regexp.escape(ams_path)}:89/))
     end
 
     it 'falls back to the topmost frame when every frame is internal' do
+      apartment_path = '/gems/apartment-4.0.0/lib/apartment/patches/connection_handling.rb'
       frames = [
-        frame(path: '/gems/apartment-4.0.0/lib/apartment/patches/connection_handling.rb', lineno: 22),
+        frame(path: apartment_path, lineno: 22),
         frame(path: '/gems/activerecord-8.1.3/lib/active_record/relation.rb', lineno: 1437),
       ]
       described_class.record_default_tenant_fallback(fake_model_class, frames)
-      expect(log_io.string).to(match(%r{Caller=/gems/apartment-4\.0\.0/lib/apartment/patches/connection_handling\.rb:22}))
+      expect(log_io.string).to(match(/Caller=#{Regexp.escape(apartment_path)}:22/))
     end
 
     # Regression: panel round 2 caught that `-\d` only matched version
@@ -152,9 +179,10 @@ RSpec.describe(Apartment::Diagnostics) do
     # whose path is `/bundler/gems/<gem>-<sha>` and SHAs frequently start
     # with a letter (~5/8 of git refs). Hex class `[a-f0-9]` covers both.
     it 'filters this gem when installed via Bundler git (SHA-suffixed path)' do
+      git_root = '/Users/dev/.bundle/ruby/3.4.0/bundler/gems/apartment-a1b2c3d4e5f6'
       frames = [
-        frame(path: '/Users/dev/.bundle/ruby/3.4.0/bundler/gems/apartment-a1b2c3d4e5f6/lib/apartment/patches/connection_handling.rb', lineno: 22),
-        frame(path: '/Users/dev/.bundle/ruby/3.4.0/bundler/gems/apartment-a1b2c3d4e5f6/lib/apartment.rb', lineno: 100),
+        frame(path: "#{git_root}/lib/apartment/patches/connection_handling.rb", lineno: 22),
+        frame(path: "#{git_root}/lib/apartment.rb", lineno: 100),
         frame(path: '/app/controllers/posts_controller.rb', lineno: 17),
       ]
       described_class.record_default_tenant_fallback(fake_model_class, frames)

--- a/spec/unit/diagnostics_spec.rb
+++ b/spec/unit/diagnostics_spec.rb
@@ -146,6 +146,34 @@ RSpec.describe(Apartment::Diagnostics) do
       described_class.record_default_tenant_fallback(fake_model_class, frames)
       expect(log_io.string).to(match(%r{Caller=/gems/apartment-4\.0\.0/lib/apartment/patches/connection_handling\.rb:22}))
     end
+
+    # Regression: panel round 2 caught that `-\d` only matched version
+    # paths (always start with a digit) but missed Bundler git installs
+    # whose path is `/bundler/gems/<gem>-<sha>` and SHAs frequently start
+    # with a letter (~5/8 of git refs). Hex class `[a-f0-9]` covers both.
+    it 'filters this gem when installed via Bundler git (SHA-suffixed path)' do
+      frames = [
+        frame(path: '/Users/dev/.bundle/ruby/3.4.0/bundler/gems/apartment-a1b2c3d4e5f6/lib/apartment/patches/connection_handling.rb', lineno: 22),
+        frame(path: '/Users/dev/.bundle/ruby/3.4.0/bundler/gems/apartment-a1b2c3d4e5f6/lib/apartment.rb', lineno: 100),
+        frame(path: '/app/controllers/posts_controller.rb', lineno: 17),
+      ]
+      described_class.record_default_tenant_fallback(fake_model_class, frames)
+      expect(log_io.string).to(match(%r{Caller=/app/controllers/posts_controller\.rb:17}))
+    end
+
+    # Regression: panel round 2 caught that the original `(active|action|rail)`
+    # substring sweep accidentally filtered activestorage too; the
+    # explicit RAILS_CORE_GEMS list initially omitted it, which would
+    # have leaked Active Storage internals into Caller=.
+    it 'filters activestorage as Rails core' do
+      frames = [
+        frame(path: '/gems/activestorage-8.1.3/lib/active_storage/attachment.rb', lineno: 50),
+        frame(path: '/gems/activerecord-8.1.3/lib/active_record/relation.rb', lineno: 1437),
+        frame(path: '/app/controllers/uploads_controller.rb', lineno: 8),
+      ]
+      described_class.record_default_tenant_fallback(fake_model_class, frames)
+      expect(log_io.string).to(match(%r{Caller=/app/controllers/uploads_controller\.rb:8}))
+    end
   end
 
   describe '.reset!' do

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -285,6 +285,43 @@ RSpec.describe(Apartment::Migrator) do
     end
   end
 
+  # Mirrors the migrate_tenant lifecycle above. migrate_primary is the
+  # one Migrator method that accesses AR::Base.connection_pool with
+  # Current.tenant nil by design; the migrating flag is what tells the
+  # ConnectionHandling diagnostic to treat this as gem-internal and
+  # skip the log_default_tenant_fallback emission.
+  describe '#migrate_primary Current.migrating lifecycle' do
+    let(:mock_pool) { double('pool', migration_context: double(needs_migration?: false)) }
+
+    it 'sets Current.migrating = true before accessing connection_pool' do
+      migrating_value_during_access = nil
+      allow(ActiveRecord::Base).to(receive(:connection_pool)) do
+        migrating_value_during_access = Apartment::Current.migrating
+        mock_pool
+      end
+
+      described_class.new.send(:migrate_primary)
+
+      expect(migrating_value_during_access).to(be(true))
+    end
+
+    it 'clears Current.migrating after migrate_primary completes' do
+      allow(ActiveRecord::Base).to(receive(:connection_pool).and_return(mock_pool))
+
+      described_class.new.send(:migrate_primary)
+
+      expect(Apartment::Current.migrating).to(be_falsey)
+    end
+
+    it 'clears Current.migrating even when migration_context raises' do
+      allow(ActiveRecord::Base).to(receive(:connection_pool).and_raise(StandardError, 'boom'))
+
+      described_class.new.send(:migrate_primary)
+
+      expect(Apartment::Current.migrating).to(be_falsey)
+    end
+  end
+
   describe '.with_migration_role' do
     it 'yields without connected_to when migration_role is nil' do
       expect(ActiveRecord::Base).not_to(receive(:connected_to))

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -455,6 +455,67 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
         expect(registered).to(be_nil)
       end
     end
+
+    context 'diagnostic for nil-tenant default-pool fallback' do
+      # Test the *integration* point: that the prepend invokes
+      # Apartment::Diagnostics with the right context. The Diagnostics
+      # module's own behavior (dedup, log level, formatting) is covered
+      # by spec/unit/diagnostics_spec.rb.
+      before { Apartment::Diagnostics.reset! }
+      after  { Apartment::Diagnostics.reset! }
+
+      it 'records when log_default_tenant_fallback is true and tenant is nil' do
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { %w[acme] }
+          config.default_tenant = 'public'
+          config.check_pending_migrations = false
+          config.log_default_tenant_fallback = true
+        end
+        Apartment.adapter = mock_adapter
+
+        expect(Apartment::Diagnostics).to(
+          receive(:record_default_tenant_fallback).with(ActiveRecord::Base, kind_of(Array))
+        )
+        Apartment::Current.tenant = nil
+        ActiveRecord::Base.connection_pool
+      end
+
+      it 'does not record when the flag is off (default config)' do
+        # Outer before-block already configured without the flag (default false).
+        expect(Apartment::Diagnostics).not_to(receive(:record_default_tenant_fallback))
+        Apartment::Current.tenant = nil
+        ActiveRecord::Base.connection_pool
+      end
+
+      it 'does not record for pinned models (legitimately default-pool by design)' do
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { %w[acme] }
+          config.default_tenant = 'public'
+          config.check_pending_migrations = false
+          config.log_default_tenant_fallback = true
+        end
+        Apartment.adapter = mock_adapter
+
+        pinned_class = Class.new(ActiveRecord::Base) { include Apartment::Model }
+        stub_const('PinnedDiagModel', pinned_class)
+        pinned_class.pin_tenant
+
+        expect(Apartment::Diagnostics).not_to(receive(:record_default_tenant_fallback))
+        Apartment::Current.tenant = nil
+        pinned_class.connection_pool
+      end
+
+      it 'does not record when Apartment is not yet configured (early boot)' do
+        # Clear the outer before's configure; prepend returns super on cfg.nil?
+        # without ever reaching the diagnostic.
+        Apartment.clear_config
+        expect(Apartment::Diagnostics).not_to(receive(:record_default_tenant_fallback))
+        Apartment::Current.tenant = nil
+        ActiveRecord::Base.connection_pool
+      end
+    end
   end
 
   describe 'pinned_model? registry check' do

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -515,6 +515,27 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
         Apartment::Current.tenant = nil
         ActiveRecord::Base.connection_pool
       end
+
+      it 'does not record during a Migrator run (Apartment::Current.migrating is true)' do
+        # Migrator#migrate_primary intentionally accesses AR::Base.connection_pool
+        # with nil tenant. Without this bypass, every migrated tenant would
+        # emit a log line pointing at the migrator -- false-alarm noise.
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { %w[acme] }
+          config.default_tenant = 'public'
+          config.check_pending_migrations = false
+          config.log_default_tenant_fallback = true
+        end
+        Apartment.adapter = mock_adapter
+
+        Apartment::Current.tenant = nil
+        Apartment::Current.migrating = true
+        expect(Apartment::Diagnostics).not_to(receive(:record_default_tenant_fallback))
+        ActiveRecord::Base.connection_pool
+      ensure
+        Apartment::Current.migrating = false
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

`Apartment::Patches::ConnectionHandling#connection_pool` silently returns the default-tenant pool whenever `Apartment::Current.tenant` is `nil`. Right behavior for explicit no-tenant code. Same code path that fires when tenant context was lost across a thread or fiber boundary — a lazy association accessed after its `switch` block exited, or a `load_async` relation consumed outside the original switch. Result: queries run against the wrong tenant's data with no error.

This PR adds an opt-in **debug-level diagnostic**. With the flag on, every nil-tenant fallthrough emits a single `Rails.logger.debug` line tagged ``[Apartment] tenant=nil`` with the model class, the user's caller site, and ~8 frames of stack chain. Per-process deduped by call site so a hot loop logs once.

```ruby
Apartment.configure do |config|
  config.log_default_tenant_fallback = Rails.env.local?
end
```

Then grep the dev/test log for ``[Apartment] tenant=nil`` after a session to find every silent default-pool access. **Diagnostic only, never raises.**

## Contrast with #416 (closed)

PR #416 tried the strict-mode raise approach. Closed because gem-internal default-pool access paths beyond `Migrator#migrate_primary` — `Tenant.init`'s excluded-model processing, `edge_cases` schema operations — would still raise in user dev/test under strict-on. The flag couldn't be enabled cleanly without a sweep of every internal path; without that, "who would actually turn it on?" had no good answer.

A debug-level log doesn't have that problem. It runs alongside any internal nil-tenant path without breaking it. Users grep their log, find the leaks they care about, and fix them — gem-internal noise is filterable.

## Bypasses (in the prepend, in order)

1. **Apartment not yet configured** — `cfg.nil?` early-returns first.
2. **Flag is off** — default `false`; common path skips `caller_locations` capture cost.
3. **pool_manager not wired** — early boot.
4. **Pinned models** — legitimately default-pool by design.

## Call-site filter

The diagnostic resolves to the user's code (e.g., `app/controllers/posts_controller.rb:17`), not the deep AR frame that issued the `connection_pool` call. Filter skips:

- This gem (`/apartment/` paths)
- Rails ecosystem (`/gems/active*`, `/gems/action*`, `/gems/rail*`)

Without this filter, each query would log multiple times — one per AR internal call site (`columns_hash`, `schema_load`, `query_execute`, etc.), each at a different `file:line`, each evading dedup.

## Changes

| File | Change |
|---|---|
| `lib/apartment/diagnostics.rb` | New module with `record_default_tenant_fallback`, dedup `Set` + `Mutex`, `reset!` for tests |
| `lib/apartment/config.rb` | New `attr_accessor :log_default_tenant_fallback`, defaults `false`; boolean validation in `validate!`; inline docs |
| `lib/apartment/patches/connection_handling.rb` | One `if`-branch in the nil-tenant path; flag check sits first so the off-by-default case has zero cost |
| `spec/unit/diagnostics_spec.rb` | 12 examples (no-op cases, dedup behavior, frame filter, reset!) |
| `spec/unit/config_spec.rb` | 5 examples (default, settable, boolean validation) |
| `spec/unit/patches/connection_handling_spec.rb` | 3 new examples (records when flag on, silent when off, skipped for pinned models) |
| `spec/integration/v4/log_default_tenant_fallback_spec.rb` | 6 end-to-end examples on sqlite3 with planted ``in_acme`` vs ``in_default``: proves the silent failure mode is unchanged and the log fires/dedupes when flagged on |

## Verification (rails-8.1-sqlite3 appraisal)

- `bundle exec rspec spec/unit/` — **822 / 0**
- `bundle exec rspec spec/integration/v4/` — **143 / 0 / 85 pending**
- `bundle exec rubocop` on changed files — clean

## Test plan

- [x] Flag on + nil tenant: emits one debug log line with caller info
- [x] Flag on + nil tenant + pinned model: no log (legitimately default-pool)
- [x] Flag on + early boot (no `Apartment.config`): no log
- [x] Flag off (default): no log
- [x] Dedup per call site: repeated access at the same line logs once
- [x] Call-site filter skips apartment + Rails internals → log resolves to user code
- [x] `Diagnostics.reset!` clears dedup (for per-test cleanup)
- [x] End-to-end: captured-relation-outside-switch silently returns wrong tenant (behavior unchanged) AND logs when flag is on
- [x] Boolean validation rejects non-boolean truthy values + nil
- [ ] CI matrix passes across Ruby 3.3/3.4/4.0 × Rails 7.2/8.0/8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)