### PR TITLE
Salvage: add async_query_correctness spec; remove dangling strict_tenant_lookup ref

### DIFF
--- a/docs/designs/apartment-v4.md
+++ b/docs/designs/apartment-v4.md
@@ -132,7 +132,7 @@ Apartment::Tenant.switch('acme') do
 end
 ```
 
-An optional `Apartment.config.strict_tenant_lookup` flag will turn the silent default-pool fallback into a raised `Apartment::ImplicitDefaultTenant` so this contract is enforceable in development/test. See its config docs for usage.
+There is no built-in runtime detection for violations of this contract. The gem deliberately does not raise or warn on nil-tenant default-pool fallthrough -- the same code path serves both legitimate no-tenant access (gem internals, default-tenant ops, `connects_to`-managed databases) and the leak case, so a centralized check produces either false positives or maintenance debt. See `spec/integration/v4/async_query_correctness_spec.rb` for an executable demonstration of the failure mode and the fix; if you need detection in your own app, a custom prepend over `ActiveRecord::Base.connection_pool` (~15 lines) gated on `Apartment::Current.tenant.nil?` is sufficient.
 
 ### Core: Immutable Connection Pool Per Tenant
 

--- a/spec/integration/v4/async_query_correctness_spec.rb
+++ b/spec/integration/v4/async_query_correctness_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+
+# Executable documentation of the silent-default-pool failure mode that
+# docs/designs/apartment-v4.md "Async query correctness" describes.
+#
+# When Apartment::Current.tenant is nil, ConnectionHandling#connection_pool
+# falls through to the default-tenant pool. That's correct for explicit
+# no-tenant code, but it's also the same path that fires when tenant
+# context was lost across a thread/fiber boundary -- a lazy AR
+# association accessed after its switch block exited, or a load_async
+# relation consumed outside the original switch.
+#
+# This spec demonstrates the failure mode end-to-end on sqlite3 with
+# planted distinguishing data (`in_acme` in tenant 'acme', `in_default`
+# in the default tenant). Without the spec, the doc section is just
+# prose; with it, the contract is enforceable as a regression test and
+# the failure shape is reproducible for anyone debugging a suspected
+# silent-fallback leak.
+#
+# Provenance: this spec was salvaged from PR #417 (closed). #417 also
+# shipped an opt-in debug-level diagnostic flag to log every fallback;
+# the flag was closed because adoption required workflow plumbing
+# (CI gate or post-session log triage) that we don't have. The spec
+# survives because it has standalone value as the executable
+# demonstration of the bug class.
+RSpec.describe('v4 async query correctness', :integration,
+               skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
+  include V4IntegrationHelper
+
+  let(:tmp_dir) { Dir.mktmpdir('apartment_async_correctness') }
+  let(:tenants) { %w[acme] }
+
+  before do
+    V4IntegrationHelper.ensure_test_database! unless V4IntegrationHelper.sqlite?
+    @connection_config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+    stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+
+    Apartment.configure do |c|
+      c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+      c.tenants_provider = -> { tenants }
+      c.default_tenant = V4IntegrationHelper.default_tenant
+      c.check_pending_migrations = false
+    end
+    Apartment.adapter = V4IntegrationHelper.build_adapter(@connection_config)
+    Apartment.activate!
+
+    tenants.each { |t| Apartment.adapter.create(t) }
+    V4IntegrationHelper.create_test_table!
+    Widget.create!(name: 'in_default')
+
+    tenants.each do |t|
+      Apartment::Tenant.switch(t) do
+        V4IntegrationHelper.create_test_table!('widgets', connection: ActiveRecord::Base.connection)
+        Widget.create!(name: "in_#{t}")
+      end
+    end
+  end
+
+  after do
+    V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter) if Apartment.adapter
+    Apartment.clear_config
+    Apartment::Current.reset
+    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:') if V4IntegrationHelper.sqlite?
+    FileUtils.rm_rf(tmp_dir)
+  end
+
+  # The failure case. A relation captured inside Tenant.switch('acme')
+  # carries the tenant scope at schedule time; consuming it after the
+  # block exits re-resolves connection_pool on the consumer fiber where
+  # Current.tenant is nil, falls through to super, and runs against the
+  # default tenant. No error, wrong data. This is what tenant-leak bugs
+  # actually look like.
+  it 'silently returns the DEFAULT tenant data when a captured relation is consumed outside its switch block' do
+    captured = Apartment::Tenant.switch('acme') { Widget.all }
+
+    names = captured.pluck(:name)
+    expect(names).to(eq(['in_default']))
+    expect(names).not_to(include('in_acme'))
+  end
+
+  # The contract. Consume the relation inside the same switch block
+  # that scheduled it. Both the main query and any lazy/preload paths
+  # resolve connection_pool with tenant context intact.
+  it 'returns the TENANT data when the same relation is consumed inside its switch block' do
+    Apartment::Tenant.switch('acme') do
+      expect(Widget.pluck(:name)).to(eq(['in_acme']))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Salvaged from #417 (closed): the integration spec that demonstrates the silent-default-pool failure mode end-to-end. With planted distinguishing data (\`in_default\` in the default tenant, \`in_acme\` in tenant \`acme\`), a captured relation consumed outside its switch block returns \`['in_default']\` — wrong tenant, no error.

Two examples:
- **The failure mode.** Captured-inside / consumed-outside ⇒ default-tenant data, the bug class \`apartment-v4.md\` "Async query correctness" describes.
- **The contract.** Captured-inside / consumed-inside ⇒ tenant data, the fix the doc prescribes.

## Why the doc forward-reference also changes

PR #415 (merged) added a forward-reference to an optional \`Apartment.config.strict_tenant_lookup\` flag anticipating #416 would land it. Both #416 (strict-mode raise) and #417 (opt-in debug log) were closed:

- **#416** broke gem-internal default-pool access (\`Tenant.init\` excluded-model processing, \`edge_cases\` schema ops, Migrator) under strict-on. Adopters who enabled it would hit raises from internal code on first boot.
- **#417** worked technically but failed the workflow-adoption test: the diagnostic only pays off with a CI fail-on-line gate or a post-session log-triage habit, neither of which we have. Without one, the flag is a config setting to explain to future engineers, not a tool that catches anything.

The doc now states the gem's actual posture honestly: no built-in runtime detection; the same code path serves both legitimate no-tenant access and the leak case, so a centralized check is either false-positive-prone or maintenance debt. Teams that want detection in their own app can write a ~15-line custom prepend.

## Changes

| File | Change |
|---|---|
| \`spec/integration/v4/async_query_correctness_spec.rb\` | New: 2 examples, ~85 LOC including provenance + rationale comments |
| \`docs/designs/apartment-v4.md\` | Replace the \`strict_tenant_lookup\` forward-reference (line 135) with an honest \"no built-in detection\" statement that points at the new spec and the custom-prepend pattern |

## Verification

- \`bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/async_query_correctness_spec.rb\` — 2 / 0
- \`bundle exec rubocop\` on changed files — clean

## Test plan

- [x] Spec passes on rails-8.1-sqlite3
- [x] Spec is self-contained (no dependency on closed-PR config flags)
- [x] Doc no longer forward-references unshipped APIs
- [ ] CI matrix passes (Ruby 3.3/3.4/4.0 × Rails 7.2/8.0/8.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)