### PR TITLE
Use ActiveRecord.dump_schema_after_migration; bump to 3.4.3

### DIFF
--- a/lib/apartment/tasks/schema_dumper.rb
+++ b/lib/apartment/tasks/schema_dumper.rb
@@ -99,9 +99,9 @@ module Apartment
         # Checks Rails' global schema dump setting. Older Rails versions
         # may not have this method, so we default to enabled.
         def rails_dump_schema_enabled?
-          return true unless ActiveRecord::Base.respond_to?(:dump_schema_after_migration)
+          return true unless ActiveRecord.respond_to?(:dump_schema_after_migration)
 
-          ActiveRecord::Base.dump_schema_after_migration
+          ActiveRecord.dump_schema_after_migration
         end
       end
     end

--- a/lib/apartment/tasks/schema_dumper.rb
+++ b/lib/apartment/tasks/schema_dumper.rb
@@ -96,8 +96,9 @@ module Apartment
           Rake::Task.task_defined?(task_name)
         end
 
-        # Checks Rails' global schema dump setting. Older Rails versions
-        # may not have this method, so we default to enabled.
+        # Reads Rails' global schema dump setting. ActiveRecord exposes this
+        # as a singleton accessor since 7.0; the respond_to? guard is a
+        # defensive fallback that defaults to enabled if the API is missing.
         def rails_dump_schema_enabled?
           return true unless ActiveRecord.respond_to?(:dump_schema_after_migration)
 

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '3.4.2'
+  VERSION = '3.4.3'
 end

--- a/spec/unit/schema_dumper_spec.rb
+++ b/spec/unit/schema_dumper_spec.rb
@@ -12,7 +12,7 @@ describe Apartment::Tasks::SchemaDumper do
   describe '.dump_if_enabled' do
     context 'when Rails dump_schema_after_migration is false' do
       before do
-        allow(ActiveRecord::Base).to(receive(:dump_schema_after_migration).and_return(false))
+        allow(ActiveRecord).to(receive(:dump_schema_after_migration).and_return(false))
       end
 
       it 'does not dump schema' do
@@ -25,7 +25,7 @@ describe Apartment::Tasks::SchemaDumper do
       let(:db_config) { double('DatabaseConfig', configuration_hash: { schema_dump: true }) }
 
       before do
-        allow(ActiveRecord::Base).to(receive(:dump_schema_after_migration).and_return(true))
+        allow(ActiveRecord).to(receive(:dump_schema_after_migration).and_return(true))
         allow(described_class).to(receive(:find_schema_dump_config).and_return(db_config))
         allow(Apartment::Tenant).to(receive(:switch).and_yield)
         allow(Rake::Task).to(receive(:task_defined?).with('db:schema:dump').and_return(true))

--- a/spec/unit/schema_dumper_spec.rb
+++ b/spec/unit/schema_dumper_spec.rb
@@ -21,6 +21,25 @@ describe Apartment::Tasks::SchemaDumper do
       end
     end
 
+    context 'when ActiveRecord.dump_schema_after_migration is false (real attr, no stub)' do
+      # Mutates the real attribute instead of stubbing it. Stubbing the receiver
+      # makes RSpec add the method back, which is exactly what hid the original
+      # bug on Rails 7.1+ where ActiveRecord::Base.dump_schema_after_migration
+      # no longer exists.
+      around do |example|
+        original = ActiveRecord.dump_schema_after_migration
+        ActiveRecord.dump_schema_after_migration = false
+        example.run
+      ensure
+        ActiveRecord.dump_schema_after_migration = original
+      end
+
+      it 'does not dump schema' do
+        expect(described_class).not_to(receive(:find_schema_dump_config))
+        described_class.dump_if_enabled
+      end
+    end
+
     context 'when Rails dump_schema_after_migration is true' do
       let(:db_config) { double('DatabaseConfig', configuration_hash: { schema_dump: true }) }
 


### PR DESCRIPTION
## Summary

Backport of #342 (by @oleksii-leonov, targets `main`) plus a 3.4.3 patch bump so the release ships as soon as this lands. Closes #342, which is structurally stale against `main` after the v4 restructure (`lib/apartment/tasks/schema_dumper.rb` no longer exists there — it was replaced by `lib/apartment/schema_dumper_patch.rb`).

`ActiveRecord::Base.dump_schema_after_migration` was removed in **Rails 7.1** (not 7.2 as the original PR body suggests — verified against `rails/rails` `v7.1.0`). The current guard `ActiveRecord::Base.respond_to?(:dump_schema_after_migration)` returns `false` on Rails 7.1+, so `SchemaDumper.rails_dump_schema_enabled?` silently returns `true` and unconditionally dumps schema regardless of the user's `config.active_record.dump_schema_after_migration = false`.

That means the bug silently fires on **4 of 5** Rails versions in our CI matrix (7.1, 7.2, 8.0, 8.1). Only Rails 7.0 honors the user's config today.

The module-level `ActiveRecord.dump_schema_after_migration` has been available since Rails 7.0 ([active_record.rb#L311](https://github.com/rails/rails/blob/v7.0.0/activerecord/lib/active_record.rb#L311)), which matches our gemspec floor of `activerecord >= 7.0.0`. The swap is safe across the full supported matrix.

Credit to @oleksii-leonov for the original diagnosis and fix in #342.

## Test plan

- [x] `bundle exec rubocop lib/apartment/tasks/schema_dumper.rb spec/unit/schema_dumper_spec.rb` — clean
- [x] `BUNDLE_GEMFILE=gemfiles/rails_8_1_sqlite3.gemfile DATABASE_ENGINE=sqlite bundle exec rspec spec/unit/schema_dumper_spec.rb` — 9 examples, 0 failures
- [x] CI matrix green (Rails 7.0 / 7.1 / 7.2 / 8.0 / 8.1 × PG/MySQL/SQLite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)