### PR TITLE
Auto-handle tenant continuity across ActionController::Live (#304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,28 @@ Workaround: add `include Apartment::Model` and `pin_tenant` on the abstract clas
 
 The common pattern of `ApplicationRecord` using `connects_to` with multiple roles (writing/reading) on the same database works correctly; Apartment keys pools by `tenant:role` and respects Rails' role routing.
 
+## ActionController::Live Streaming
+
+Apartment v4 auto-handles tenant propagation across `ActionController::Live`'s spawned streaming thread under both `:thread` and `:fiber` isolation. Including `ActionController::Live` in your controller is sufficient — no additional configuration:
+
+```ruby
+class StreamingController < ApplicationController
+  include ActionController::Live
+
+  def show
+    response.headers['Content-Type'] = 'text/event-stream'
+    # Apartment::Tenant.current returns the request's tenant here,
+    # even though we're now executing on the OS thread Rails spawned
+    # for streaming.
+    response.stream.write("data: #{{ tenant: Apartment::Tenant.current }.to_json}\n\n")
+  ensure
+    response.stream.close
+  end
+end
+```
+
+User-spawned threads or fibers inside a Live action (`Thread.new`, `Async { }`, raw `Fiber.new`) escape the auto-wrap and need explicit `Apartment::Tenant.switch` wrapping. See the [upgrading guide](docs/upgrading-to-v4.md) and [`docs/designs/rails-boundary-tenancy.md`](docs/designs/rails-boundary-tenancy.md) for the full caveat list (custom elevators that skip `super`, app-defined `around_action`s on `ApplicationController`).
+
 ## Background Workers
 
 Use block-scoped switching in jobs:

--- a/docs/designs/apartment-v4.md
+++ b/docs/designs/apartment-v4.md
@@ -72,7 +72,7 @@ Replaces `Thread.current[:apartment_adapter]`. Benefits:
 
 - `ActiveSupport::IsolatedExecutionState.isolation_level` defaults to `:thread` (`activesupport-8.1.3/lib/active_support/isolated_execution_state.rb:74`). No `load_defaults` flips it; users opt into `:fiber` via `config.active_support.isolation_level = :fiber`. v4 recommends `:fiber` for fiber-aware servers; the Railtie warns when it observes `:thread`.
 - `:fiber` does not cross OS threads. Worker threads (Rails' opt-in `load_async` executor — see "Async query correctness" — or any `Thread.new`) start with `Apartment::Current.tenant == nil` regardless of isolation level. `CurrentAttributes` provides no cross-thread propagation by itself.
-- `ActionController::Live` (`actionpack-8.1.3/lib/action_controller/metal/live.rb:308-323`) spawns a child thread and calls `IsolatedExecutionState.share_with(t1, ...)` to copy state. Under `:thread`, `t1.active_support_execution_state` holds the state and the copy works. Under `:fiber` it doesn't, because the parent's state lives on `Fiber.current`, not on the Thread — Live's propagation breaks. Apps that need both Live and v4 must wrap the Live action in an explicit `Apartment::Tenant.switch` rather than relying on inheritance.
+- `ActionController::Live` (`actionpack-8.1.3/lib/action_controller/metal/live.rb:308-323`) spawns a child thread and calls `IsolatedExecutionState.share_with(t1, ...)` to copy state. Under `:thread`, `t1.active_support_execution_state` holds the state and the copy works. Under `:fiber` it doesn't, because the parent's state lives on `Fiber.current`, not on the Thread — Live's propagation breaks. Apartment v4 resolves this by auto-including `Apartment::LiveTenancy` into `ActionController::Live` via `ActiveSupport::Concern` composition; the concern's `around_action` reads the tenant identifier the elevator stashes on `request.env` and re-enters `Apartment::Tenant.switch` from inside the spawned thread. See `docs/designs/rails-boundary-tenancy.md`. (Rails main has refactored `share_with(t1)` to `share_with(context)` which would propagate state correctly under `:fiber`; that fix has not landed in a stable Rails release as of 2026-05.)
 
 ### Async query correctness: pool capture vs. consumer re-resolution
 
@@ -682,10 +682,12 @@ class Apartment::Railtie < Rails::Railtie
     # regardless of isolation_level — the SQL path stays correct via
     # FutureResult's captured pool. See "Async query correctness" above.
     #
-    # Trade-off note: under :fiber, ActionController::Live's own propagation
-    # (Thread-to-Thread `IsolatedExecutionState.share_with`) breaks, because
-    # the parent's state lives on Fiber, not Thread. Apps using both Live and
-    # v4 must wrap the Live action in an explicit Apartment::Tenant.switch.
+    # ActionController::Live: Apartment v4 resolves the :fiber-vs-Thread
+    # share_with mismatch by auto-including Apartment::LiveTenancy into
+    # ActionController::Live (see docs/designs/rails-boundary-tenancy.md).
+    # The around_action re-establishes the tenant from request.env inside
+    # the spawned streaming thread; no user code changes are needed for
+    # the standard case.
     if ActiveSupport::IsolatedExecutionState.isolation_level == :thread
       Rails.logger.warn "[Apartment] ActiveSupport::IsolatedExecutionState.isolation_level " \
         "is :thread. v4 recommends :fiber for fiber-aware concurrency. Set " \
@@ -925,7 +927,7 @@ No compatibility shims in v4 — clean break.
 | #302 PgBouncer/RDS Proxy session pinning | Improved: per-switch `SET` eliminated; connection-level config with libpq `options` avoids session pinning. See PgBouncer section for details. |
 | #239 Concurrency in specs | Solved: `CurrentAttributes` provides fiber isolation; per-tenant pools eliminate the shared `Thread.current` slot the v3 design depended on |
 | #199 `load_async` ignores tenant | Improved: when the user opts into `async_query_executor`, `FutureResult` captures the tenant pool at schedule time. Default config runs `load_async` synchronously. Consumer-fiber access (preload, `after_find` callbacks, lazy assoc, nested-async) must stay inside the same `Tenant.switch`. `eager_load` is worker-safe (folds into main query). See "Async query correctness" |
-| #304 ActionController::Live | Partially addressed and isolation-level dependent. Under `:thread` (Rails default), Live's `IsolatedExecutionState.share_with` copies `CurrentAttributes` from parent to spawned thread, and tenant context propagates. Under `:fiber` (v4-recommended) the share_with copy is empty because state lives on `Fiber.current`, not on the parent Thread — Live actions must wrap themselves in `Apartment::Tenant.switch` explicitly. Pinned to the issue for a permanent resolution. |
+| #304 ActionController::Live | Resolved via Bucket 1 (auto-include `Apartment::LiveTenancy` into `ActionController::Live`). See `docs/designs/rails-boundary-tenancy.md` § Worked example: ActionController::Live. Works on all supported Rails versions under both `:thread` and `:fiber` isolation. |
 | #323 Connection leaks under load | Solved: pools cached in `Concurrent::Map`, lazy creation, eviction |
 | #341 Rails 8.1 `public.` prefix | Solved: schema dumper patch strips prefix for tenant loading |
 | #303 Missing `create_schema` in schema.rb | Solved: `include_schemas_in_dump` config option |

--- a/docs/designs/rails-boundary-tenancy.md
+++ b/docs/designs/rails-boundary-tenancy.md
@@ -1,0 +1,268 @@
+# Multi-Tenancy at Rails-Created Execution Boundaries
+
+## Purpose
+
+Rails creates execution and structural boundaries where tenant context can be lost or where multi-tenancy must slot into a framework subsystem: Rack requests, `ActionController::Live`'s spawned thread, ActionCable channel workers, Sidekiq/SolidQueue jobs, ActiveStorage variant pipelines, future async APIs. The gem has historically handled these case by case, sometimes introducing parallel state channels that contradict the v4 design.
+
+This document defines the decision rubric for new (and re-evaluated) integrations. It answers: which boundaries does the gem own, by what mechanism, and what does it explicitly refuse.
+
+## Rubric
+
+Each Rails-created tenancy concern lands in exactly one bucket. Evaluate in order; first match wins.
+
+### Bucket 1: auto-handle in core
+
+All six conditions must hold:
+
+1. The boundary is created by Rails, not by user code.
+2. The right policy is mechanical and tenant-agnostic: re-establish the tenant the caller had.
+3. Re-establishment is reachable from a public Rails extension point (load hook, `ActiveSupport::Concern` composition, `ActiveSupport::Notifications`, middleware, callback API). No `:nodoc:` overrides; no prepends on private Rails internals.
+4. The failure mode on doing nothing is silent (wrong-tenant queries, not raised exceptions).
+5. The mechanism writes tenant **state** only through the gem's existing channel (`Apartment::Current` via `CurrentAttributes`) in the *target* execution context. No parallel state stores like `Thread#thread_variable_set`, custom per-subsystem caches, or pointer-mirroring between thread-keyed and fiber-keyed storage. The canonical primitive is `Apartment::Tenant.switch(tenant) { ... }` invoked from inside the boundary's execution context, not from outside it.
+   - **Identifiers vs state.** A tenant *identifier* (the name string) may be carried across a boundary through framework-provided request carriers like `Rack::env`, job arguments, or message headers — these are not tenant state channels, they are how Rails already moves request-scoped data between execution contexts. The crossing must be *identifier in*, *`Tenant.switch` out*: the spawned-side code reads the identifier and re-establishes state through `Tenant.switch`. Two reads of the same identifier through two carriers (env + `CurrentAttributes`) are acceptable; two *writes* of state through two channels (`CurrentAttributes` + `Thread.thread_variable_set`) are not.
+6. The integration surface is small: a handful of touchpoints with stable signatures across the supported Rails matrix, so core's per-Rails-version maintenance cost stays near zero.
+
+The earlier draft of this rubric permitted "temporarily realigning Rails' execution-state pointers" as in-model. That loophole is closed. Realigning `Thread.current.active_support_execution_state` to point at `Fiber.current.active_support_execution_state` shares a reference between two storage scopes the isolation model was chosen to keep separate; it is a parallel channel by construction, not a use of the existing one.
+
+### Bucket 2: provide a primitive, document a recipe
+
+One or more of:
+
+- Boundary is created by user code (`Thread.new`, `Async {}`, custom fiber).
+- The right policy is app-specific (auth flow, broadcast scoping, custom security model).
+- Discoverability is acceptable because the user is already authoring integration code.
+
+Mechanism: the same primitive (`Apartment::Tenant.switch`), applied at the user's call site. The gem ships documentation in `docs/integrations/<subsystem>.md`; no prepend, no auto-wiring.
+
+```ruby
+# ActionCable example. around_subscribe is app code; the gem ships the recipe.
+class ApplicationChannel < ActionCable::Channel::Base
+  around_subscribe :with_tenant_context
+
+  def with_tenant_context(&block)
+    Apartment::Tenant.switch(current_user.tenant, &block)
+  end
+end
+```
+
+### Bucket 3: companion gem
+
+One or more of:
+
+- The integration surface is large: many Rails touchpoints, signatures that churn across Rails versions, transitive dependencies on subsystem internals.
+- The integration is structural, not temporal: model graph, storage layer, route helpers, service configuration.
+- The integration can ship independently without churning core API.
+
+Mechanism: a separate gem (`apartment-<subsystem>`), versioned independently, declared as optional in core. Core exposes hooks the companion uses (pinned-model registry, current-tenant accessor); core does not host the companion's logic.
+
+## Anti-patterns
+
+The rubric exists in part to forbid these. They appear when it is bypassed.
+
+- **Parallel state channels.** `Thread#thread_variable_set`, custom fiber storage, or per-subsystem stores that read or write tenant context outside `Apartment::Current`. The hot path (`lib/apartment/patches/connection_handling.rb:12-13`) reads one source: `Apartment::Current.tenant`. Adding fallback sources installs permanent branches and quiet ambiguity, and makes the subsystem whose channel got added special in a way the others are not.
+- **Pointer-mirroring across isolation scopes.** Assigning `Thread.current.active_support_execution_state = Fiber.current.active_support_execution_state` (or any variant) to coax Rails' propagation into working under `:fiber`. Two storage scopes were chosen to be separate; sharing a reference between them is a parallel channel masquerading as the existing one. Closed by Bucket 1 criterion 5.
+- **Mechanism per subsystem.** If Live uses one storage scheme and ActionCable uses another and Sidekiq uses a third, contributors stop seeing the gem as having a coherent tenancy model. Different mechanisms are acceptable across buckets (1 vs 3); within a bucket they should converge on `Apartment::Tenant.switch`.
+- **Auto-handling app-specific policy.** Anything that needs to know about authentication, broadcast scoping, or security policy stays in bucket 2. Auto-wiring it creates the wrong defaults for half of users.
+- **Companion-gem absorption.** Pulling structural integrations into core because "we already depend on this" inflates the core's Rails-subsystem skew surface. Resist.
+
+## Current applications
+
+| Boundary | Bucket | Status |
+|---|---|---|
+| Rack request | 1 | Shipped: `lib/apartment/elevators/generic.rb` |
+| Sidekiq 7+ / SolidQueue | 1 | Shipped: `docs/designs/apartment-v4.md` (Sidekiq middleware section) |
+| ActionController::Live | 1 | Pending: this doc's worked example |
+| ActionCable channel | 2 | Recipe TBD: `docs/integrations/actioncable.md` |
+| User `Thread.new` / `Async {}` | 2 | Documented: `docs/upgrading-to-v4.md` |
+| Generic ActiveJob (non-Sidekiq, non-SolidQueue) | 2, promotable to 1 | `Apartment::Jobs::ActiveJobExtension` opt-in; promotable if backends without `CurrentAttributes` serialization stay common |
+| ActiveStorage | 3 | Out of core; companion gem path |
+
+## Worked example: ActionController::Live (#304)
+
+### Problem
+
+`ActionController::Live#process` spawns an OS thread per streaming response and calls `ActiveSupport::IsolatedExecutionState.share_with(...)` to copy execution state into it. The signature changed in Rails 8.1.2:
+
+- **Rails 7.2 – 8.1.1**: `share_with(Thread.current)`. Reads from the parent **Thread's** `active_support_execution_state` accessor and dup's the result into the spawned thread's root fiber. Under `:fiber` isolation, `CurrentAttributes` and other ExecutionContext data live on `Fiber.current`'s accessor, not `Thread.current`'s. The parent Thread's accessor is empty. `share_with` copies an empty hash. Inside the streaming block, `Apartment::Current.tenant` is `nil`; queries route to the default-tenant pool. Silent cross-tenant data exposure.
+- **Rails 8.1.2+**: `share_with(IsolatedExecutionState.context, except: live_streaming_excluded_keys)`. Reads from the **current isolation context** — `Fiber.current` under `:fiber`, `Thread.current` under `:thread`. Under `:fiber`, the parent fiber's state copies through to the spawned thread's root fiber. The bug is fixed at the framework level (rails/rails#56393).
+
+Rails' upstream stance on `:fiber`-to-thread propagation in general (rails/rails#48279, closed wontfix): fiber apps must explicitly forward state across thread boundaries. The 8.1.2 fix is narrow to `Live`, not a generalization.
+
+Apartment v4's supported Rails matrix is 7.2 through main. The bug exists on 7.2, 8.0, 8.1.0, 8.1.1 and must be fixed there. On 8.1.2+ Apartment's fix is redundant but harmless.
+
+### Why direct prepends on the spawn site don't work
+
+The natural-looking fix is to capture the parent tenant on the request fiber, then `Apartment::Tenant.switch(captured) { ... }` somewhere inside `ActionController::Live#process` or `#new_controller_thread` to re-establish it on the spawned thread's root fiber.
+
+This fails by construction. Trace through `Live#process` (pre-8.1.2 form):
+
+```ruby
+new_controller_thread do                    # block runs on spawned thread
+  t2 = Thread.current
+  locals.each { |k, v| t2[k] = v }
+  ActiveSupport::IsolatedExecutionState.share_with(t1)  # OVERWRITES execution_state
+  super(name)                                # action body runs with overwritten state
+end
+```
+
+`share_with` does:
+
+```ruby
+old_state, context.active_support_execution_state = context.active_support_execution_state, copied_state
+block.call
+ensure
+context.active_support_execution_state = old_state
+```
+
+A `Tenant.switch` ahead of `share_with` (whether via prepend on `new_controller_thread` or on the block it `yield`s to) sets state that `share_with` immediately overwrites. The action body sees the empty copy, not the captured tenant. The patch is a no-op.
+
+The two ways out are:
+
+1. Populate the channel `share_with` reads from before it runs. On `:fiber` that means assigning `Thread.current.active_support_execution_state = Fiber.current.active_support_execution_state` — pointer-mirroring across isolation scopes. Forbidden by Bucket 1 criterion 5.
+2. Run the re-establishment **inside the spawned thread, after `share_with` has done its work, in a hook Rails calls from inside the action body**. That is what `around_action` does: callbacks run inside `process_action`, which runs inside `super(name)`, which runs inside `share_with`'s block, on the spawned thread.
+
+### Bucket
+
+1. Rails-created boundary; mechanical re-establishment; reachable from public Rails extension points (`ActiveSupport::Concern` composition + `around_action` + `Rack::Request#env`); silent failure mode; uses only the existing `Apartment::Current` channel in the spawned thread's root fiber; surface is two touchpoints (one concern, one elevator one-liner) that don't depend on `:nodoc:` API.
+
+### Design
+
+Three pieces:
+
+**1. Elevator stash.** After the tenant is resolved, store the name on `request.env["apartment.tenant"]`. `env` is shared by reference between the request fiber and the spawned thread (same `Request` object reaches both), so it survives the boundary without needing to ride on `IsolatedExecutionState`.
+
+```ruby
+# lib/apartment/elevators/generic.rb
+def call(env)
+  request = Rack::Request.new(env)
+  database = parse_tenant_name(request)
+  if database
+    env[Apartment::ENV_TENANT_KEY] = database  # NEW
+    Apartment::Tenant.switch(database) { @app.call(env) }
+  else
+    @app.call(env)
+  end
+end
+```
+
+`Apartment::ENV_TENANT_KEY` is a constant (`"apartment.tenant"`) so applications and downstream gems read one canonical key.
+
+**2. Concern that re-establishes inside the spawned thread.**
+
+```ruby
+# lib/apartment/concerns/live_tenancy.rb
+module Apartment
+  module LiveTenancy
+    extend ActiveSupport::Concern
+
+    included do
+      around_action :_apartment_with_live_tenant
+    end
+
+    private
+
+    def _apartment_with_live_tenant
+      tenant = request.env[Apartment::ENV_TENANT_KEY]
+      tenant ? Apartment::Tenant.switch(tenant) { yield } : yield
+    end
+  end
+end
+```
+
+The file lives in `lib/apartment/concerns/` to mirror the existing convention for `Apartment::Model` (`lib/apartment/concerns/model.rb` → `Apartment::Model`). Module name is top-level under `Apartment`.
+
+`around_action` wraps the entire callback chain (before/after callbacks plus the action body), all of which run on the spawned thread's root fiber after `share_with` has executed. `Apartment::Tenant.switch` writes to `Apartment::Current.tenant`, which writes to `IsolatedExecutionState`, which under `:fiber` lands on the spawned thread's root fiber. In-model: the spawned thread's fiber gets its own tenant entry, scoped to the action's duration, with `ensure`-based cleanup that handles `live_thread_pool_executor`'s thread reuse.
+
+**3. Auto-inject the concern into every `ActionController::Live` controller.**
+
+`ActionController::Live` itself uses `extend ActiveSupport::Concern` (`actionpack/lib/action_controller/metal/live.rb`, all supported versions). Including a Concern into a Concern queues the inner Concern's `included do ... end` blocks to fire when the outer Concern is included in a class:
+
+```ruby
+# lib/apartment/railtie.rb (added)
+initializer 'apartment.live_tenancy' do
+  next unless defined?(ActionController::Base)  # apps without action_pack are skipped
+
+  require "action_controller/metal/live"        # force-load (Live is autoloaded; defined? can be false)
+  next if ActionController::Live.include?(Apartment::LiveTenancy)
+
+  ActionController::Live.include(Apartment::LiveTenancy)
+end
+```
+
+A named `initializer` (rather than `config.after_initialize`) — this hook does not depend on `Apartment.config`, and a named initializer runs earlier and gives a stable, name-addressable extension point if the include order ever needs to be constrained (`after: :something`). The explicit `require` is needed because `ActionController::Live` is autoloaded — `defined?(ActionController::Live)` returns falsy until something triggers the autoload, which doesn't happen by Apartment's initializer in apps that haven't yet referenced a Live controller. Requiring the file directly is idempotent and adds trivial memory overhead. The `include?` guard makes the operation idempotent under test reloads. Sibling pattern: the existing `initializer 'apartment.rescue_responses'` block.
+
+The `:action_controller_live` load hook (`ActiveSupport.run_load_hooks(:action_controller_live, self)`) does not exist on Rails 7.2 / 8.0 / 8.1; it lands on Rails main and will ship in a future release. Using it instead of the unconditional initializer would skip the auto-include on exactly the versions where the fix is needed.
+
+`Apartment::ENV_TENANT_KEY` is defined in `lib/apartment.rb` alongside the other top-level constants:
+
+```ruby
+# lib/apartment.rb
+module Apartment
+  ENV_TENANT_KEY = "apartment.tenant"
+  # ...
+end
+```
+
+Frozen string; one canonical reference shared by the elevator and the concern.
+
+Custom-elevator backwards compatibility: apps that subclass `Apartment::Elevators::Generic` and override `#call` without calling `super` won't pick up the `env[Apartment::ENV_TENANT_KEY] = database` line. Their Live actions will continue to fail under `:fiber` on pre-8.1.2 Rails as they do today. The migration guide will surface this. The base-class one-line change is sufficient for the standard Subdomain / HostHash / Domain / FirstSubdomain elevators, all of which call `super` into `Generic#call`.
+
+### Mechanism, plain
+
+The elevator records which tenant the request belongs to in a place that crosses the Live spawn boundary by reference (`request.env`). Every Live controller gets an `around_action` that reads that record from inside the spawned thread and re-enters `Apartment::Tenant.switch` there. No state is shared across isolation scopes; the spawned thread's fiber gets its own tenant entry via the gem's normal write path.
+
+### Behavior across Rails versions
+
+| Rails | Native `share_with` propagates tenant? | Apartment's around_action |
+|---|---|---|
+| 7.2 / 8.0 / 8.1.0 / 8.1.1 | No (reads `Thread.current` under `:fiber`) | Sets tenant from `env`; the only thing that works |
+| 8.1.2+ | Yes (reads `IsolatedExecutionState.context`) | Re-sets the same tenant; redundant no-op switch |
+| main (with `:action_controller_live` load hook) | Yes | Same as 8.1.2+ |
+
+No version branching. The around_action is unconditional; on Rails versions where Rails handles propagation, the switch is a same-tenant re-entry with `ensure` cleanup.
+
+### Behavior across isolation levels
+
+| Isolation | Behavior |
+|---|---|
+| `:fiber` (v4 default) | The bug exists pre-8.1.2; the fix applies. |
+| `:thread` (v3-compatible, opt-in) | Rails' `share_with(Thread.current)` already propagates state on all versions. The around_action's re-entry is a same-tenant no-op. |
+
+No isolation-level guard needed.
+
+### Trade-offs
+
+- **Nested user threads / fibers inside the Live action.** `Thread.new { response.stream.write(...) }` or `Async {}` spawned inside the action body escape the `around_action` wrap. Same contract `:fiber` isolation imposes everywhere else: user-spawned threads/fibers must wrap themselves in `Apartment::Tenant.switch`. See `docs/upgrading-to-v4.md` § Async.
+- **Elevator order.** Apps that disable Apartment's elevator and run their own tenant-resolution middleware must populate `env[Apartment::ENV_TENANT_KEY]` themselves for Live propagation to work. Documented in the migration guide.
+- **App-defined `around_action` ordering.** `Apartment::LiveTenancy` registers its `around_action` when each Live controller class is composed, which places it *first* in the callback chain for that class. App-defined `around_action`s registered in `ApplicationController` (or any superclass loaded before the controller includes `ActionController::Live`) run earlier in the chain — they execute with the *default* tenant unless they wait for Apartment's wrap to enter first. Apps that hit the DB in such an outer `around_action` should declare it on the Live controller itself (so it nests inside `Apartment::LiveTenancy`'s wrap), or wrap the relevant body in `Apartment::Tenant.switch(request.env[Apartment::ENV_TENANT_KEY]) { ... }`. Documented in the migration guide.
+- **Reused threads in `live_thread_pool_executor`.** `Apartment::Tenant.switch`'s block form `ensure`s teardown, so the spawned thread's root fiber state is restored on action exit; subsequent requests reusing the same worker thread start clean.
+
+### Test coverage
+
+- Unit spec for `Apartment::LiveTenancy`: included into a stub controller, the `around_action` reads `request.env`, calls `Apartment::Tenant.switch`, restores on raise.
+- Unit spec confirming `ActionController::Live.include(Apartment::LiveTenancy)` queues the `included do` block such that a fresh controller class including `ActionController::Live` picks up the `around_action`.
+- Integration spec in `spec/integration/v4/` against a real `ActionController::Live` controller in the dummy app. Exercised under both `:thread` and `:fiber` isolation. Asserts queries inside `response.stream.write` route to the captured tenant, on the appraised Rails versions (7.2 / 8.0 / 8.1 / main). The fix being effective on 7.2 and the same controller still passing on 8.1.2+ are both required; both confirm the around_action is invariant to Rails' own propagation.
+
+### Documentation updates
+
+- `docs/designs/apartment-v4.md` (#304 row in the limitations table): "Resolved via Bucket 1; see `docs/designs/rails-boundary-tenancy.md`."
+- `docs/upgrading-to-v4.md` § Async: drop the "wrap the Live action in an explicit `Apartment::Tenant.switch`" instruction; replace with a one-liner pointing to the auto-propagation. The child-fiber-inside-Live caveat stays.
+- `README.md` § Live streaming (new short section): note that Live controllers work out of the box on `:fiber`, and that nested user-spawned threads/fibers still need explicit switching.
+
+## Worked example: ActiveStorage (#314)
+
+### Problem
+
+ActiveStorage assumes a global namespace: blob keys, attachment records, service mounts. Multi-tenancy needs storage paths scoped per tenant, blob and attachment models pinned, variant and preview jobs to inherit tenant context. The temporal piece (variant jobs) already rides on Bucket 1 infrastructure (Sidekiq/SolidQueue middleware) and is not blocked. The structural piece (paths, model graph, service configuration) needs sustained integration work.
+
+### Bucket
+
+3. The integration surface is large (blob key generation, attachment model, service configuration, route helpers, variant pipeline, signed-URL handling, direct-upload handlers, mirror services); each touchpoint churns across Rails minors; the integration is structural rather than temporal; it can ship independently. `kelder` (`rails-on-services/apartment#314`) has been offered as a starting point.
+
+### Design
+
+Companion gem `apartment-activestorage`. Core ships nothing new for this. Core's responsibility is to expose stable hooks (pinned-model registry, current-tenant accessor) that the companion uses. Adopters install the companion when they need it.
+
+### Note
+
+This row stops the recurring pull to absorb ActiveStorage into core. The temporal piece works today via Bucket 1 infrastructure; the structural piece is its own product with its own release cadence.

--- a/docs/designs/rails-boundary-tenancy.md
+++ b/docs/designs/rails-boundary-tenancy.md
@@ -83,12 +83,12 @@ The rubric exists in part to forbid these. They appear when it is bypassed.
 
 `ActionController::Live#process` spawns an OS thread per streaming response and calls `ActiveSupport::IsolatedExecutionState.share_with(...)` to copy execution state into it. The signature changed in Rails 8.1.2:
 
-- **Rails 7.2 – 8.1.1**: `share_with(Thread.current)`. Reads from the parent **Thread's** `active_support_execution_state` accessor and dup's the result into the spawned thread's root fiber. Under `:fiber` isolation, `CurrentAttributes` and other ExecutionContext data live on `Fiber.current`'s accessor, not `Thread.current`'s. The parent Thread's accessor is empty. `share_with` copies an empty hash. Inside the streaming block, `Apartment::Current.tenant` is `nil`; queries route to the default-tenant pool. Silent cross-tenant data exposure.
-- **Rails 8.1.2+**: `share_with(IsolatedExecutionState.context, except: live_streaming_excluded_keys)`. Reads from the **current isolation context** — `Fiber.current` under `:fiber`, `Thread.current` under `:thread`. Under `:fiber`, the parent fiber's state copies through to the spawned thread's root fiber. The bug is fixed at the framework level (rails/rails#56393).
+- **Rails 7.2 – 8.1 stable (verified through 8.1.3)**: `share_with(Thread.current, except: live_streaming_excluded_keys)`. Reads from the parent **Thread's** `active_support_execution_state` accessor and dup's the result into the spawned thread's root fiber. Under `:fiber` isolation, `CurrentAttributes` and other ExecutionContext data live on `Fiber.current`'s accessor, not `Thread.current`'s. The parent Thread's accessor is empty. `share_with` copies an empty hash. Inside the streaming block, `Apartment::Current.tenant` is `nil`; queries route to the default-tenant pool. Silent cross-tenant data exposure.
+- **Rails main (unreleased, future 8.2+)**: `share_with(IsolatedExecutionState.context, except: live_streaming_excluded_keys)`. Reads from the **current isolation context** — `Fiber.current` under `:fiber`. Under `:fiber`, the parent fiber's state copies through to the spawned thread's root fiber. The bug is fixed at the framework level once this refactor reaches a stable release.
 
-Rails' upstream stance on `:fiber`-to-thread propagation in general (rails/rails#48279, closed wontfix): fiber apps must explicitly forward state across thread boundaries. The 8.1.2 fix is narrow to `Live`, not a generalization.
+Rails' upstream stance on `:fiber`-to-thread propagation in general (rails/rails#48279, closed wontfix): fiber apps must explicitly forward state across thread boundaries. The `share_with(context)` refactor on main is narrow to `Live`, not a generalization.
 
-Apartment v4's supported Rails matrix is 7.2 through main. The bug exists on 7.2, 8.0, 8.1.0, 8.1.1 and must be fixed there. On 8.1.2+ Apartment's fix is redundant but harmless.
+Apartment v4's supported Rails matrix is 7.2 through main. The bug exists on every currently-released Rails version (7.2, 8.0, 8.1.0–8.1.3) and must be fixed there. On Rails main Apartment's fix is redundant but harmless; once the `share_with(context)` change reaches a stable release, the around_action will no-op into Rails' own propagation.
 
 ### Why direct prepends on the spawn site don't work
 
@@ -213,13 +213,12 @@ The elevator records which tenant the request belongs to in a place that crosses
 
 ### Behavior across Rails versions
 
-| Rails | Native `share_with` propagates tenant? | Apartment's around_action |
+| Rails | Native `share_with` propagates tenant under `:fiber`? | Apartment's around_action |
 |---|---|---|
-| 7.2 / 8.0 / 8.1.0 / 8.1.1 | No (reads `Thread.current` under `:fiber`) | Sets tenant from `env`; the only thing that works |
-| 8.1.2+ | Yes (reads `IsolatedExecutionState.context`) | Re-sets the same tenant; redundant no-op switch |
-| main (with `:action_controller_live` load hook) | Yes | Same as 8.1.2+ |
+| 7.2 / 8.0 / 8.1.x (incl. 8.1.3) — every currently-released stable | No (reads `Thread.current`, empty under `:fiber`) | Sets tenant from `env`; the only thing that works |
+| main (future 8.2+, when `share_with(context)` ships) | Yes (reads `Fiber.current` under `:fiber`) | Re-sets the same tenant; redundant no-op switch |
 
-No version branching. The around_action is unconditional; on Rails versions where Rails handles propagation, the switch is a same-tenant re-entry with `ensure` cleanup.
+No version branching in code. The around_action is unconditional; once Rails ships the `share_with(context)` refactor in a stable release, the switch becomes a same-tenant re-entry with `ensure` cleanup.
 
 ### Behavior across isolation levels
 
@@ -241,7 +240,7 @@ No isolation-level guard needed.
 
 - Unit spec for `Apartment::LiveTenancy`: included into a stub controller, the `around_action` reads `request.env`, calls `Apartment::Tenant.switch`, restores on raise.
 - Unit spec confirming `ActionController::Live.include(Apartment::LiveTenancy)` queues the `included do` block such that a fresh controller class including `ActionController::Live` picks up the `around_action`.
-- Integration spec in `spec/integration/v4/` against a real `ActionController::Live` controller in the dummy app. Exercised under both `:thread` and `:fiber` isolation. Asserts queries inside `response.stream.write` route to the captured tenant, on the appraised Rails versions (7.2 / 8.0 / 8.1 / main). The fix being effective on 7.2 and the same controller still passing on 8.1.2+ are both required; both confirm the around_action is invariant to Rails' own propagation.
+- Integration spec in `spec/integration/v4/live_streaming_spec.rb` against a real `ActionController::Live` controller in the dummy app. Exercised under both `:thread` and `:fiber` isolation. Asserts queries inside `response.stream.write` route to the captured tenant, on the appraised Rails versions (7.2 / 8.0 / 8.1 / main). Includes a negative-control example that alias-swaps `Generic#call` to omit the env stash and asserts the streamed tenant falls back to the default — proving the around_action is causal, not coincidental.
 
 ### Documentation updates
 

--- a/docs/plans/live-tenant-propagation/plan.md
+++ b/docs/plans/live-tenant-propagation/plan.md
@@ -1,0 +1,1181 @@
+# Live Tenant Propagation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Apartment::Tenant.current` survive the `ActionController::Live` thread-spawn boundary under `:fiber` isolation on Rails 7.2 – 8.1.1 (and remain correct on 8.1.2+), without monkey-patching `:nodoc:` Rails internals or introducing thread-keyed state.
+
+**Architecture:** Three pieces wired by the Apartment Railtie. (1) A new constant `Apartment::ENV_TENANT_KEY = "apartment.tenant"` and a one-line addition to `Apartment::Elevators::Generic#call` that stashes the resolved tenant on `request.env` (the cross-thread carrier). (2) A new `Apartment::LiveTenancy` concern at `lib/apartment/concerns/live_tenancy.rb` that adds an `around_action` reading the env value and re-entering `Apartment::Tenant.switch` from inside the spawned thread. (3) A new `initializer 'apartment.live_tenancy'` in the Railtie that auto-includes the concern into `ActionController::Live` via Concern-into-Concern composition — every Live controller picks up the around_action without user opt-in.
+
+**Tech Stack:** Ruby, Rails (`ActionController::Live`, `ActiveSupport::Concern`, `ActiveSupport::IsolatedExecutionState`), RSpec, Appraisal (Rails matrix), Rack.
+
+**Design spec:** `docs/designs/rails-boundary-tenancy.md` § Worked example: ActionController::Live (#304).
+
+---
+
+## File map
+
+**Create:**
+- `lib/apartment/concerns/live_tenancy.rb` — `Apartment::LiveTenancy` concern with the `around_action`.
+- `spec/unit/live_tenancy_spec.rb` — unit tests for the concern: `included do` adds the callback, `_apartment_with_live_tenant` switches when env set, falls through when not, restores on raise.
+- `spec/dummy/app/controllers/streaming_controller.rb` — Live controller exercised by integration spec (recovered from `stash@{0}`).
+- `spec/integration/v4/live_streaming_spec.rb` — integration test against the dummy app: real HTTP, real Subdomain elevator, real Live action; asserts tenant continuity inside `response.stream.write` under both `:thread` and `:fiber`.
+
+**Modify:**
+- `lib/apartment.rb` — add `ENV_TENANT_KEY = "apartment.tenant"` constant after the `module Apartment` declaration.
+- `lib/apartment/elevators/generic.rb` — one-line `env[Apartment::ENV_TENANT_KEY] = database` before the `Apartment::Tenant.switch` call.
+- `lib/apartment/railtie.rb` — new `initializer 'apartment.live_tenancy'` block that force-loads `action_controller/metal/live` and includes `Apartment::LiveTenancy` into `ActionController::Live`.
+- `spec/dummy/config/routes.rb` — add `get '/stream' => 'streaming#show'` (recovered from stash).
+- `spec/unit/elevators/generic_spec.rb` — add `env stash` describe block.
+- `spec/unit/elevators/subdomain_spec.rb` — add inheritance test asserting Subdomain (via `super`) picks up the env stash.
+- `spec/unit/railtie_spec.rb` — add `apartment.live_tenancy initializer` describe block.
+- `docs/designs/apartment-v4.md` — update the #304 row and the inline Live caveat (~line 75) to point at `docs/designs/rails-boundary-tenancy.md`.
+- `docs/upgrading-to-v4.md` — replace the "wrap Live actions in explicit `Apartment::Tenant.switch`" instruction with the auto-propagation note + three caveats (nested user threads, custom elevator subclasses, app-defined around_action ordering).
+- `README.md` — add a "ActionController::Live streaming" section showing the now-out-of-the-box behavior.
+
+---
+
+### Task 1: Recover dummy-app infrastructure from stash
+
+**Why first:** the integration test (Task 8) needs the dummy streaming controller and route already in place. Recovering from `stash@{0}` is faster and gives us bytewise-identical content to what was tested before.
+
+**Files:**
+- Create: `spec/dummy/app/controllers/streaming_controller.rb`
+- Modify: `spec/dummy/config/routes.rb`
+
+- [ ] **Step 1: Inspect the stash for the two files**
+
+```bash
+git show "stash@{0}^3:spec/dummy/app/controllers/streaming_controller.rb"
+git stash show -p stash@{0} -- spec/dummy/config/routes.rb
+```
+
+Expected: the streaming controller body (an `ActionController::Live` controller with `def show`) and the routes patch adding `get '/stream' => 'streaming#show'`.
+
+- [ ] **Step 2: Restore the streaming controller**
+
+```bash
+git show "stash@{0}^3:spec/dummy/app/controllers/streaming_controller.rb" > spec/dummy/app/controllers/streaming_controller.rb
+```
+
+Expected content (verify after restore):
+
+```ruby
+class StreamingController < ApplicationController
+  include ActionController::Live
+
+  def show
+    response.headers['Content-Type'] = 'text/event-stream'
+    response.headers['Cache-Control'] = 'no-cache'
+    payload = { tenant: Apartment::Tenant.current, user_count: User.count }
+    response.stream.write("data: #{payload.to_json}\n\n")
+  ensure
+    response.stream.close
+  end
+end
+```
+
+If the stashed content differs, overwrite with the body above — this is what the integration spec assumes.
+
+- [ ] **Step 3: Apply the routes patch**
+
+```bash
+git stash show -p stash@{0} -- spec/dummy/config/routes.rb | git apply
+```
+
+Verify by running:
+
+```bash
+git diff spec/dummy/config/routes.rb
+```
+
+Expected diff: one `+` line `get '/stream' => 'streaming#show'` inside `Rails.application.routes.draw do ... end`. If the patch context is stale (it may not be on `main`), open `spec/dummy/config/routes.rb` and add that single line manually inside the `draw` block before any catch-all.
+
+- [ ] **Step 4: Verify dummy still boots**
+
+```bash
+bundle exec appraisal rails-8.1-sqlite3 rspec spec/dummy/config/routes.rb 2>/dev/null || true
+bundle exec appraisal rails-8.1-sqlite3 rails runner -e test 'puts Rails.application.routes.routes.map(&:path).map(&:spec).grep(/stream/)' 2>&1 | tail
+```
+
+Expected: no syntax errors loading the dummy; `/stream(.:format)` appears in the route table.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spec/dummy/app/controllers/streaming_controller.rb spec/dummy/config/routes.rb
+git commit -m "Test: add streaming controller and /stream route to dummy app"
+```
+
+---
+
+### Task 2: Add `Apartment::ENV_TENANT_KEY` constant
+
+**Files:**
+- Modify: `lib/apartment.rb` (insert near top of module body)
+- Test: `spec/unit/apartment_constants_spec.rb` (new file, ~10 lines)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/unit/apartment_constants_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Apartment do
+  describe 'ENV_TENANT_KEY' do
+    it 'is the canonical Rack env key for cross-thread tenant lookup' do
+      expect(Apartment::ENV_TENANT_KEY).to eq('apartment.tenant')
+    end
+
+    it 'is frozen' do
+      expect(Apartment::ENV_TENANT_KEY).to be_frozen
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bundle exec rspec spec/unit/apartment_constants_spec.rb
+```
+
+Expected: FAIL with `NameError: uninitialized constant Apartment::ENV_TENANT_KEY`.
+
+- [ ] **Step 3: Add the constant**
+
+In `lib/apartment.rb`, immediately after the `module Apartment # rubocop:disable Metrics/ModuleLength` line (around line 38), add:
+
+```ruby
+  # Rack env key used to carry the resolved tenant across execution boundaries
+  # (notably the OS thread spawned by ActionController::Live#process). The
+  # elevator writes this; Apartment::LiveTenancy reads it.
+  ENV_TENANT_KEY = 'apartment.tenant'
+```
+
+Note the two-space indent matching the existing module body.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+bundle exec rspec spec/unit/apartment_constants_spec.rb
+```
+
+Expected: PASS (2 examples).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment.rb spec/unit/apartment_constants_spec.rb
+git commit -m "Add Apartment::ENV_TENANT_KEY constant for cross-boundary tenant lookup"
+```
+
+---
+
+### Task 3: Stash the tenant on `request.env` in `Elevators::Generic#call`
+
+**Files:**
+- Modify: `lib/apartment/elevators/generic.rb` (line 32 area)
+- Test: `spec/unit/elevators/generic_spec.rb` (existing file; add one example)
+
+- [ ] **Step 1: Locate the existing generic_spec**
+
+```bash
+ls spec/unit/elevators/
+```
+
+Expected: `generic_spec.rb` exists. If it doesn't, create it (see Step 2). Read it to understand the existing test scaffolding (`Rack::MockRequest`, the test elevator subclass, etc.).
+
+- [ ] **Step 2: Write the failing test**
+
+Add this example to `spec/unit/elevators/generic_spec.rb` inside the appropriate `describe Apartment::Elevators::Generic do` block. If a `describe '#call'` group exists, add it there; otherwise create one:
+
+```ruby
+  describe 'env stash' do
+    let(:app) { ->(env) { [200, {}, [env[Apartment::ENV_TENANT_KEY].to_s]] } }
+    let(:elevator_class) do
+      Class.new(described_class) do
+        def parse_tenant_name(request)
+          request.host.split('.').first
+        end
+      end
+    end
+
+    before do
+      allow(Apartment::Tenant).to receive(:switch).and_yield
+      allow(Apartment).to receive(:tenant_validator).and_return(->(_) { true })
+      allow(Apartment).to receive(:config).and_return(double(default_tenant: 'public'))
+    end
+
+    it 'writes Apartment::ENV_TENANT_KEY on env before invoking the app' do
+      env = Rack::MockRequest.env_for('http://acme.example.com/')
+      elevator_class.new(app).call(env)
+      expect(env[Apartment::ENV_TENANT_KEY]).to eq('acme')
+    end
+
+    it 'does not set ENV_TENANT_KEY when no tenant is resolved' do
+      no_tenant_elevator = Class.new(described_class) do
+        def parse_tenant_name(_request)
+          nil
+        end
+      end
+      env = Rack::MockRequest.env_for('http://example.com/')
+      no_tenant_elevator.new(app).call(env)
+      expect(env).not_to have_key(Apartment::ENV_TENANT_KEY)
+    end
+  end
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+bundle exec rspec spec/unit/elevators/generic_spec.rb -e 'env stash'
+```
+
+Expected: the "writes Apartment::ENV_TENANT_KEY" example FAILs because the elevator doesn't currently set the key. The "does not set" example may pass already (vacuous).
+
+- [ ] **Step 4: Implement the env stash**
+
+In `lib/apartment/elevators/generic.rb`, modify `#call`. Original tail of the method (line 29–33):
+
+```ruby
+        return @app.call(env) if database.nil?
+        return handle_tenant_not_found(database, request) unless tenant_valid?(database)
+
+        Apartment::Tenant.switch(database) { @app.call(env) }
+```
+
+Replace with:
+
+```ruby
+        return @app.call(env) if database.nil?
+        return handle_tenant_not_found(database, request) unless tenant_valid?(database)
+
+        env[Apartment::ENV_TENANT_KEY] = database
+        Apartment::Tenant.switch(database) { @app.call(env) }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+bundle exec rspec spec/unit/elevators/generic_spec.rb -e 'env stash'
+```
+
+Expected: PASS (2 examples).
+
+- [ ] **Step 6: Add a subclass-inheritance test**
+
+Subclasses of `Generic` (`Subdomain`, `HostHash`, `Domain`, `FirstSubdomain`, `Host`, `Header`) all delegate to `Generic#call` via `super` or by not overriding `call`. The env stash must reach those subclasses for free. Add this example to `spec/unit/elevators/subdomain_spec.rb`:
+
+```ruby
+  describe 'env stash inheritance' do
+    let(:app) { ->(env) { [200, {}, [env[Apartment::ENV_TENANT_KEY].to_s]] } }
+
+    before do
+      allow(Apartment::Tenant).to receive(:switch).and_yield
+      allow(Apartment).to receive(:tenant_validator).and_return(->(_) { true })
+      allow(Apartment).to receive(:config).and_return(double(default_tenant: 'public'))
+    end
+
+    it 'inherits env stash behavior from Generic#call (Subdomain via super)' do
+      env = Rack::MockRequest.env_for('http://acme.example.com/')
+      Apartment::Elevators::Subdomain.new(app).call(env)
+      expect(env[Apartment::ENV_TENANT_KEY]).to eq('acme')
+    end
+  end
+```
+
+- [ ] **Step 7: Run the subclass test**
+
+```bash
+bundle exec rspec spec/unit/elevators/subdomain_spec.rb -e 'env stash inheritance'
+```
+
+Expected: PASS — Subdomain's `parse_tenant_name` returns `'acme'`; `Generic#call` writes the env key.
+
+- [ ] **Step 8: Run the full elevator spec to confirm no regression**
+
+```bash
+bundle exec rspec spec/unit/elevators/
+```
+
+Expected: all pre-existing examples still PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/apartment/elevators/generic.rb spec/unit/elevators/generic_spec.rb spec/unit/elevators/subdomain_spec.rb
+git commit -m "Elevator: stash resolved tenant on request.env for cross-boundary lookup"
+```
+
+---
+
+### Task 4: Create `Apartment::LiveTenancy` concern
+
+**Files:**
+- Create: `lib/apartment/concerns/live_tenancy.rb`
+- Test: `spec/unit/live_tenancy_spec.rb`
+
+The Zeitwerk `loader.collapse("#{__dir__}/apartment/concerns")` line in `lib/apartment.rb` (line 31) maps `concerns/live_tenancy.rb` to `Apartment::LiveTenancy`, not `Apartment::Concerns::LiveTenancy`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/unit/live_tenancy_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'action_controller'
+require 'action_controller/metal/live'
+
+RSpec.describe Apartment::LiveTenancy do
+  # A minimal controller-like host that records around_action registration
+  # and exposes the private callback method for direct invocation.
+  let(:controller_class) do
+    Class.new do
+      attr_accessor :request
+
+      def self.registered_around_actions
+        @registered_around_actions ||= []
+      end
+
+      def self.around_action(name)
+        registered_around_actions << name
+      end
+
+      include Apartment::LiveTenancy
+    end
+  end
+
+  describe 'when included' do
+    it 'registers an around_action callback' do
+      expect(controller_class.registered_around_actions)
+        .to include(:_apartment_with_live_tenant)
+    end
+  end
+
+  describe '#_apartment_with_live_tenant' do
+    let(:instance) { controller_class.new }
+    let(:env) { {} }
+
+    before do
+      instance.request = double('Request', env: env)
+    end
+
+    context 'when env carries Apartment::ENV_TENANT_KEY' do
+      before { env[Apartment::ENV_TENANT_KEY] = 'acme' }
+
+      it 'wraps the block in Apartment::Tenant.switch with the env tenant' do
+        expect(Apartment::Tenant).to receive(:switch).with('acme').and_yield
+        result = instance.send(:_apartment_with_live_tenant) { 42 }
+        expect(result).to eq(42)
+      end
+    end
+
+    context 'when env has no tenant key' do
+      it 'yields without calling Apartment::Tenant.switch' do
+        expect(Apartment::Tenant).not_to receive(:switch)
+        result = instance.send(:_apartment_with_live_tenant) { 'plain' }
+        expect(result).to eq('plain')
+      end
+    end
+
+    context 'when the block raises' do
+      before { env[Apartment::ENV_TENANT_KEY] = 'acme' }
+
+      it 'propagates the exception (switch handles restore via its own ensure)' do
+        allow(Apartment::Tenant).to receive(:switch).with('acme').and_yield
+        expect {
+          instance.send(:_apartment_with_live_tenant) { raise 'boom' }
+        }.to raise_error('boom')
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+bundle exec rspec spec/unit/live_tenancy_spec.rb
+```
+
+Expected: FAIL with `NameError: uninitialized constant Apartment::LiveTenancy`.
+
+- [ ] **Step 3: Create the concern**
+
+Create `lib/apartment/concerns/live_tenancy.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module Apartment
+  # Re-establishes the request's tenant inside the OS thread that
+  # ActionController::Live spawns for streaming responses. Auto-included
+  # into ActionController::Live by the Apartment Railtie; every controller
+  # that includes ActionController::Live picks up this around_action via
+  # ActiveSupport::Concern composition.
+  #
+  # See docs/designs/rails-boundary-tenancy.md for the mechanism and why
+  # an around_action (not a prepend on Live#process or new_controller_thread)
+  # is the only correct hook on Rails < 8.1.2.
+  module LiveTenancy
+    extend ActiveSupport::Concern
+
+    included do
+      around_action :_apartment_with_live_tenant
+    end
+
+    private
+
+    def _apartment_with_live_tenant
+      tenant = request.env[Apartment::ENV_TENANT_KEY]
+      tenant ? Apartment::Tenant.switch(tenant) { yield } : yield
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+bundle exec rspec spec/unit/live_tenancy_spec.rb
+```
+
+Expected: PASS (4 examples).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/concerns/live_tenancy.rb spec/unit/live_tenancy_spec.rb
+git commit -m "Add Apartment::LiveTenancy concern with around_action for tenant continuity"
+```
+
+---
+
+### Task 5: Auto-include `Apartment::LiveTenancy` into `ActionController::Live` via Railtie
+
+**Files:**
+- Modify: `lib/apartment/railtie.rb` (add new `initializer 'apartment.live_tenancy'` block)
+- Test: `spec/unit/railtie_spec.rb` (add a `describe '.live_tenancy_auto_include'` group)
+
+- [ ] **Step 1: Read the existing railtie spec layout**
+
+```bash
+ls spec/unit/railtie_spec.rb 2>/dev/null && wc -l spec/unit/railtie_spec.rb
+```
+
+Expected: file exists. Read its top to understand the test harness (it likely instantiates a Rails::Railtie subclass and calls initializers manually). The new test must follow the same pattern.
+
+- [ ] **Step 2: Write the failing test**
+
+The previous spec used `skip 'already auto-included' if ActionController::Live.include?(Apartment::LiveTenancy)` — but the railtie has already run by the time the railtie spec executes (the test process boots Rails), so that guard nullifies every assertion. The test needs to assert facts that hold regardless of include order:
+
+1. The initializer exists by name.
+2. After the initializer has run (whether by the test process boot or invoked here), the include? state is true.
+3. A controller class that subsequently includes `ActionController::Live` gets the around_action queued via Concern composition.
+
+Append to `spec/unit/railtie_spec.rb`, inside the top-level `RSpec.describe Apartment::Railtie do` block:
+
+```ruby
+  describe 'apartment.live_tenancy initializer' do
+    it 'is registered on the railtie by name' do
+      names = Apartment::Railtie.initializers.map(&:name)
+      expect(names).to include('apartment.live_tenancy')
+    end
+
+    it 'has included Apartment::LiveTenancy into ActionController::Live once boot has completed' do
+      require 'action_controller/metal/live'
+      # The railtie initializer ran during spec process boot; this asserts the
+      # observable end state, not the mechanics of running it again.
+      expect(ActionController::Live.include?(Apartment::LiveTenancy)).to be(true)
+    end
+
+    it 'queues the around_action on every class that subsequently includes ActionController::Live' do
+      require 'action_controller'
+      require 'action_controller/metal/live'
+      # A freshly-built controller class that includes Live (after boot) must
+      # pick up the around_action through ActiveSupport::Concern composition.
+      fresh_controller = Class.new(ActionController::Base) { include ActionController::Live }
+      callbacks = fresh_controller._process_action_callbacks.map(&:filter)
+      expect(callbacks).to include(:_apartment_with_live_tenant)
+    end
+
+    it 'is idempotent — re-running does not double-include' do
+      require 'action_controller/metal/live'
+      before_count = ActionController::Live.ancestors.count(Apartment::LiveTenancy)
+      initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.live_tenancy' }
+      initializer.run(Rails.application)
+      after_count = ActionController::Live.ancestors.count(Apartment::LiveTenancy)
+      expect(after_count).to eq(before_count)
+    end
+  end
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+bundle exec rspec spec/unit/railtie_spec.rb -e 'apartment.live_tenancy'
+```
+
+Expected: the first example fails because no initializer named `apartment.live_tenancy` is registered yet.
+
+- [ ] **Step 4: Add the initializer in the Railtie**
+
+In `lib/apartment/railtie.rb`, add the following block. Place it after the existing `initializer 'apartment.rescue_responses'` block (the rescue_responses initializer is the closest existing match — both are unconditional initializers without ordering constraints):
+
+```ruby
+    # Auto-include Apartment::LiveTenancy into ActionController::Live so every
+    # controller that includes Live picks up the around_action that re-establishes
+    # the request's tenant inside the OS thread Live spawns for streaming.
+    #
+    # The :action_controller_live load hook only exists on Rails main (8.2+);
+    # we force-require Live and include unconditionally so the fix lands on
+    # Rails 7.2 / 8.0 / 8.1 — exactly the versions where Rails' own share_with
+    # propagation is buggy under :fiber. On Rails 8.1.2+, share_with(context)
+    # already carries the tenant; the around_action runs as a redundant no-op
+    # same-tenant switch.
+    #
+    # See docs/designs/rails-boundary-tenancy.md.
+    initializer 'apartment.live_tenancy' do
+      next unless defined?(ActionController::Base)  # non-ActionPack apps (rare; ActiveRecord-only)
+      require 'action_controller/metal/live'
+      next if ActionController::Live.include?(Apartment::LiveTenancy)
+
+      ActionController::Live.include(Apartment::LiveTenancy)
+    end
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+bundle exec rspec spec/unit/railtie_spec.rb -e 'apartment.live_tenancy'
+```
+
+Expected: PASS (2 examples).
+
+- [ ] **Step 6: Run the full railtie spec for regression**
+
+```bash
+bundle exec rspec spec/unit/railtie_spec.rb
+```
+
+Expected: all examples PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/apartment/railtie.rb spec/unit/railtie_spec.rb
+git commit -m "Railtie: auto-include Apartment::LiveTenancy into ActionController::Live"
+```
+
+---
+
+### Task 6: Integration test — scaffolding + Live under `:thread` isolation (baseline)
+
+**Harness pattern:** modeled on `spec/integration/v4/request_lifecycle_spec.rb` — it's the only existing v4 integration spec that boots the dummy app + issues HTTP + reads JSON from the response. The harness rules:
+
+1. `require 'spec_helper'; require_relative 'support'` — there is no `integration_spec_helper`.
+2. `DUMMY_APP_AVAILABLE` guard at file top: `require_relative('../../dummy/config/environment')` + `require('rack/test')`, rescued to a skip-with-warn (unless `REQUEST_LIFECYCLE_REQUIRED=1`).
+3. `V4IntegrationHelper.postgresql?` skip: the dummy app's `database.yml` is PostgreSQL-only.
+4. `spec_helper.rb`'s `config.after do Apartment.clear_config; Apartment::Current.reset end` runs after every example — so `before(:all) { Apartment.configure ... }` does not survive. Each example must call `establish_apartment!` (load the dummy's `config/initializers/apartment.rb` + `Apartment.activate!` + `Apartment::Tenant.init`) in a per-example `before`.
+5. `before` creates the tenants and rebuilds the `users` table per example (matches `request_lifecycle_spec.rb` lines ~58–80).
+6. `after(:all)` drops tenants and clears apartment state so the suite leaves no residue for the next spec file.
+7. Run command: `DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec ...` — not `rails-8.1-sqlite3`.
+
+**Why this comes before `:fiber`:** under `:thread` isolation, Rails' own `share_with(Thread.current)` propagates state correctly without the new around_action doing anything load-bearing. This task validates the harness works (the dummy boots, the elevator+route+controller round-trip), so Task 7 can change isolation_level and isolate the bug.
+
+**Files:**
+- Create: `spec/integration/v4/live_streaming_spec.rb`
+
+- [ ] **Step 1: Read the canonical pattern**
+
+```bash
+sed -n '1,30p' spec/integration/v4/request_lifecycle_spec.rb
+sed -n '40,100p' spec/integration/v4/request_lifecycle_spec.rb
+```
+
+Confirm: file top has `DUMMY_APP_AVAILABLE` + `RSpec.describe(..., skip: ...)`; per-example `before` calls `establish_apartment!` and rebuilds tables; `after(:all)` drops tenants and clears config.
+
+- [ ] **Step 2: Write the integration spec**
+
+Create `spec/integration/v4/live_streaming_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+# Live streaming + tenant propagation requires the dummy Rails app + real PostgreSQL
+# (the dummy app's database.yml is PG-only). Modeled on request_lifecycle_spec.rb.
+# Run via: DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql \
+#   rspec spec/integration/v4/live_streaming_spec.rb
+
+require 'spec_helper'
+require_relative 'support'
+
+ENV['RAILS_ENV'] ||= 'test'
+
+LIVE_STREAMING_DUMMY_AVAILABLE = begin
+  require_relative('../../dummy/config/environment')
+  require('rack/test')
+  require('json')
+  true
+rescue LoadError, StandardError => e
+  raise if ENV['REQUEST_LIFECYCLE_REQUIRED']
+
+  warn "[live_streaming_spec] Skipping: #{e.message}"
+  false
+end
+
+RSpec.describe(
+  'ActionController::Live tenant propagation', :integration, :request_lifecycle,
+  skip: (LIVE_STREAMING_DUMMY_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires dummy Rails app + PostgreSQL')
+) do
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+
+  def test_tenants = %w[acme widgets]
+
+  def establish_apartment!
+    load(Rails.root.join('config/initializers/apartment.rb'))
+    Apartment.activate!
+    Apartment::Tenant.init
+  end
+
+  def stream_payload(response)
+    JSON.parse(response.body.sub(/\Adata:\s*/, '').strip)
+  end
+
+  before do
+    establish_apartment!
+
+    test_tenants.each do |tenant|
+      Apartment.adapter.create(tenant)
+    rescue Apartment::TenantExists
+      nil
+    end
+
+    [Apartment.config.default_tenant, *test_tenants].each do |tenant|
+      Apartment::Tenant.switch(tenant) do
+        ActiveRecord::Base.connection.create_table(:users, force: true) do |t|
+          t.string(:name)
+        end
+      end
+    end
+
+    Apartment::Tenant.switch('acme')    { User.create!(name: 'A'); User.create!(name: 'B'); User.create!(name: 'C') }
+    Apartment::Tenant.switch('widgets') { User.create!(name: 'X') }
+  end
+
+  after { Apartment::Current.reset }
+
+  after(:all) do
+    establish_apartment!
+    test_tenants.each do |tenant|
+      Apartment.adapter.drop(tenant)
+    rescue StandardError
+      nil
+    end
+    Apartment::Tenant.switch(Apartment.config.default_tenant) do
+      ActiveRecord::Base.connection.drop_table(:users, if_exists: true)
+    end
+  ensure
+    Apartment.clear_config
+    Apartment::Current.reset
+  end
+
+  shared_examples 'propagates tenant into the Live stream' do
+    it 'streams the acme tenant (3 users) inside response.stream.write' do
+      header 'Host', 'acme.example.com'
+      get '/stream'
+      expect(last_response).to be_ok
+      data = stream_payload(last_response)
+      expect(data['tenant']).to eq('acme')
+      expect(data['user_count']).to eq(3)
+    end
+
+    it 'streams the widgets tenant (1 user) inside response.stream.write' do
+      header 'Host', 'widgets.example.com'
+      get '/stream'
+      expect(last_response).to be_ok
+      data = stream_payload(last_response)
+      expect(data['tenant']).to eq('widgets')
+      expect(data['user_count']).to eq(1)
+    end
+  end
+
+  context 'under :thread isolation' do
+    around do |example|
+      original = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :thread
+      example.run
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = original
+    end
+
+    include_examples 'propagates tenant into the Live stream'
+  end
+end
+```
+
+- [ ] **Step 3: Run the integration spec under `:thread` on PostgreSQL**
+
+```bash
+DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/live_streaming_spec.rb
+```
+
+Expected: both `:thread` examples PASS. This confirms the harness works (dummy boots, /stream route resolves, controller streams JSON, JSON parses) without the around_action doing anything load-bearing — under `:thread`, Rails' `share_with(Thread.current)` already carries state.
+
+If the spec is skipped with "requires dummy Rails app + PostgreSQL", set `DATABASE_ENGINE=postgresql` and provision the test DB per `CLAUDE.md` Commands section.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add spec/integration/v4/live_streaming_spec.rb
+git commit -m "Test: Live tenant propagation integration spec (thread isolation baseline)"
+```
+
+---
+
+### Task 7: Add `:fiber` context to the integration spec — the load-bearing assertion + negative control
+
+**Files:**
+- Modify: `spec/integration/v4/live_streaming_spec.rb`
+
+- [ ] **Step 1: Add the `:fiber` context with the propagation examples**
+
+In `spec/integration/v4/live_streaming_spec.rb`, append after the existing `context 'under :thread isolation'` block (still inside the top-level `RSpec.describe`):
+
+```ruby
+  context 'under :fiber isolation' do
+    around do |example|
+      original = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+      example.run
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = original
+    end
+
+    include_examples 'propagates tenant into the Live stream'
+  end
+```
+
+- [ ] **Step 2: Add the negative-control example**
+
+Inside the same `context 'under :fiber isolation'` block, after `include_examples`, add the negative control. This proves the fix is *causal* — when the env stash is absent, the bug returns. Without this, a passing fiber example could be coincidental (e.g., Rails 8.1.2+'s native fix masking ours).
+
+```ruby
+    it '(negative control) leaks tenant when the elevator does not stash the env key' do
+      # Simulate a custom elevator that omits the env stash — alias-swap
+      # Generic#call to a variant that does not set Apartment::ENV_TENANT_KEY.
+      # The Subdomain elevator inherits Generic#call, so this hits both.
+      Apartment::Elevators::Generic.class_eval do
+        alias_method :_original_call_for_neg_ctrl, :call
+        define_method(:call) do |env|
+          request = Rack::Request.new(env)
+          begin
+            database = @processor.call(request)
+          rescue Apartment::TenantNotFound => e
+            return handle_tenant_not_found(e.tenant || request.host, request)
+          end
+          return @app.call(env) if database.nil?
+          return handle_tenant_not_found(database, request) unless tenant_valid?(database)
+
+          # NOTE: deliberately omitting `env[Apartment::ENV_TENANT_KEY] = database`
+          # — this is what the test reproduces.
+          Apartment::Tenant.switch(database) { @app.call(env) }
+        end
+      end
+
+      begin
+        header 'Host', 'acme.example.com'
+        get '/stream'
+        data = stream_payload(last_response)
+
+        if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new('8.1.2')
+          # 8.1.2+ propagates via Rails' own share_with(context) regardless of
+          # our env stash. The fix is redundant here; the test is informational.
+          expect(data['tenant']).to eq('acme')
+        else
+          # Pre-8.1.2: without the env stash, the around_action falls through
+          # to a plain yield and the spawned thread sees no captured tenant.
+          # The streamed tenant is NOT 'acme' — the original leak reproduces.
+          expect(data['tenant']).not_to eq('acme')
+        end
+      ensure
+        Apartment::Elevators::Generic.class_eval do
+          alias_method :call, :_original_call_for_neg_ctrl
+          remove_method :_original_call_for_neg_ctrl
+        end
+      end
+    end
+```
+
+The alias-swap is fully reversed in `ensure`, so this example is safe to run in any order alongside the positive examples in the same context.
+
+- [ ] **Step 3: Run the full integration spec on Rails 8.1**
+
+```bash
+DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/live_streaming_spec.rb
+```
+
+Expected: all 5 examples PASS (2 under `:thread`, 2 propagation + 1 negative-control under `:fiber`).
+
+If the positive `:fiber` examples FAIL with `data['tenant']` returning `'public'` or nil and `data['user_count']` being 0:
+1. Railtie initializer didn't run before the dummy controller was loaded — check `ActionController::Live.include?(Apartment::LiveTenancy)` is true after dummy boot.
+2. Elevator didn't run on the request — check `request.env['apartment.tenant']` is set on the parent fiber.
+3. The streaming controller was loaded before the auto-include — restart the test process.
+
+If the negative-control example FAILS on Rails < 8.1.2 (i.e., the leak does *not* reproduce when env is stripped), the fix may be coincidental rather than causal — investigate before proceeding.
+
+- [ ] **Step 4: Run the same spec across the appraisal matrix on PostgreSQL**
+
+```bash
+DATABASE_ENGINE=postgresql bundle exec appraisal rails-7.2-postgresql rspec spec/integration/v4/live_streaming_spec.rb
+DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.0-postgresql rspec spec/integration/v4/live_streaming_spec.rb
+DATABASE_ENGINE=postgresql bundle exec appraisal rails-main-postgresql rspec spec/integration/v4/live_streaming_spec.rb
+```
+
+Expected: all 5 examples PASS on every Rails version. The negative control's `if rails_at_least_812` branch handles the version-aware assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spec/integration/v4/live_streaming_spec.rb
+git commit -m "Test: Live tenant propagation under :fiber + negative control (load-bearing)"
+```
+
+---
+
+### Task 8: Integration test — thread pool reuse
+
+**Why:** `ActionController::Live` uses `Concurrent::CachedThreadPool` for streaming workers (`new_controller_thread`). Two consecutive requests to different tenants may reuse the same worker thread. The around_action's `Apartment::Tenant.switch` block form must restore prior state so the second request doesn't see leftover state from the first.
+
+**Files:**
+- Modify: `spec/integration/v4/live_streaming_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Inside the top-level `RSpec.describe`, after the existing contexts, add:
+
+```ruby
+  context 'with thread-pool reuse across requests under :fiber' do
+    around do |example|
+      original = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+      example.run
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = original
+    end
+
+    it 'does not leak tenant state between consecutive Live requests' do
+      header 'Host', 'acme.example.com'
+      get '/stream'
+      acme_data = stream_payload(last_response)
+
+      header 'Host', 'widgets.example.com'
+      get '/stream'
+      widgets_data = stream_payload(last_response)
+
+      header 'Host', 'acme.example.com'
+      get '/stream'
+      acme_data_again = stream_payload(last_response)
+
+      expect(acme_data['tenant']).to eq('acme')
+      expect(acme_data['user_count']).to eq(3)
+      expect(widgets_data['tenant']).to eq('widgets')
+      expect(widgets_data['user_count']).to eq(1)
+      expect(acme_data_again['tenant']).to eq('acme')
+      expect(acme_data_again['user_count']).to eq(3)
+    end
+  end
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/live_streaming_spec.rb -e 'thread-pool reuse'
+```
+
+Expected: PASS. If a request returns the wrong tenant, the `ensure` in `Apartment::Tenant.switch` is not restoring properly, or the around_action is running too late. Investigate before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec/integration/v4/live_streaming_spec.rb
+git commit -m "Test: Live thread pool reuse does not leak tenant between requests"
+```
+
+---
+
+### Task 9: Update v4 design doc — #304 row + inline Live caveat
+
+**Files:**
+- Modify: `docs/designs/apartment-v4.md`
+
+- [ ] **Step 1: Find both Live mentions**
+
+```bash
+grep -n '#304\|ActionController::Live\|Live\b' docs/designs/apartment-v4.md
+```
+
+Expected: at least two locations — the #304 row in the limitations table (around line 928 per the prior stash diff), and an inline "Live" caveat in the early-document caveats section (around line 75 per the stash diff). Both need to change.
+
+- [ ] **Step 2: Replace the #304 row body cell**
+
+The current row body says users must wrap Live actions in `Apartment::Tenant.switch`. Replace with:
+
+```
+Resolved via Bucket 1 (auto-include `Apartment::LiveTenancy` into `ActionController::Live`). See `docs/designs/rails-boundary-tenancy.md` § Worked example: ActionController::Live.
+```
+
+- [ ] **Step 3: Replace the inline Live caveat**
+
+The early caveats section likely says something like "ActionController::Live requires manual `Apartment::Tenant.switch` wrapping under :fiber." Replace with:
+
+```
+**ActionController::Live**: works out of the box under both `:thread` and `:fiber` isolation. Apartment v4 auto-includes `Apartment::LiveTenancy` into `ActionController::Live` (see `docs/designs/rails-boundary-tenancy.md`). User-spawned threads/fibers inside a Live action still require explicit `Apartment::Tenant.switch` wrapping — same contract as everywhere else.
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+grep -A3 'ActionController::Live\|#304' docs/designs/apartment-v4.md
+```
+
+Expected: both locations updated; no remaining "wrap manually" instructions for the standard Live case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/designs/apartment-v4.md
+git commit -m "Docs: point #304 row and inline Live caveat at the rubric doc"
+```
+
+---
+
+### Task 10: Update upgrading guide + README (Live + caveats)
+
+**Files:**
+- Modify: `docs/upgrading-to-v4.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Find the Live caveat in the upgrading guide**
+
+```bash
+grep -n 'ActionController::Live\|Live\b' docs/upgrading-to-v4.md
+```
+
+Expected: a line (around line 166 per the stash diff) saying users must wrap Live actions in `Apartment::Tenant.switch`.
+
+- [ ] **Step 2: Replace with the auto-propagation note + caveats**
+
+Locate the Live paragraph in `docs/upgrading-to-v4.md` and replace its body with:
+
+```markdown
+**ActionController::Live**: works out of the box. Apartment v4 auto-includes `Apartment::LiveTenancy` into `ActionController::Live`; every Live controller picks up an `around_action` that re-establishes the request's tenant inside the OS thread Rails spawns for streaming. No user code changes required for the standard case.
+
+Caveats:
+
+- **User-spawned threads or fibers inside a Live action** (`Thread.new { ... }`, `Async { ... }`, raw `Fiber.new`) are not covered by the around_action wrap. Wrap them in `Apartment::Tenant.switch(Apartment::Tenant.current) { ... }` explicitly — same contract `:fiber` isolation imposes everywhere else.
+- **Custom elevator subclasses** that override `Apartment::Elevators::Generic#call` without calling `super` will not populate `request.env[Apartment::ENV_TENANT_KEY]`. The around_action falls through to a plain `yield` (no switch), and the Live action runs with the default tenant. Either call `super` from your override, or set `env[Apartment::ENV_TENANT_KEY] = tenant_name` yourself after resolving the tenant.
+- **App-defined `around_action`s registered on `ApplicationController`** (or any superclass) run *before* `Apartment::LiveTenancy`'s wrap in the callback chain — they execute against the default tenant. If your app callback hits the DB, declare it on the Live controller itself (so it nests inside the Apartment wrap), or wrap its body in `Apartment::Tenant.switch(request.env[Apartment::ENV_TENANT_KEY]) { ... }`.
+
+See `docs/designs/rails-boundary-tenancy.md` for the mechanism.
+```
+
+If the existing "wrap manually" instruction lives outside a Live-specific paragraph (e.g., in a generic "Async" section), keep that section and add a new "ActionController::Live" subsection with the text above.
+
+- [ ] **Step 3: Add a Live section to README.md**
+
+```bash
+grep -n 'ActionController::Live\|Live\|## ' README.md | head -30
+```
+
+Locate an appropriate insertion point (e.g., after the "Configuration" or "Usage" section; before "Limitations" if one exists). Add:
+
+```markdown
+### ActionController::Live streaming
+
+Apartment v4 auto-handles tenant propagation across `ActionController::Live`'s spawned streaming thread under both `:thread` and `:fiber` isolation. Including `ActionController::Live` in your controller is sufficient:
+
+```ruby
+class StreamingController < ApplicationController
+  include ActionController::Live
+
+  def show
+    response.headers['Content-Type'] = 'text/event-stream'
+    Apartment::Tenant.current # => the request's tenant, even inside the stream
+    response.stream.write("data: ...\n\n")
+  ensure
+    response.stream.close
+  end
+end
+```
+
+User-spawned threads/fibers inside a Live action (`Thread.new`, `Async {}`, raw `Fiber.new`) escape the auto-wrap and need explicit `Apartment::Tenant.switch` wrapping. See the upgrading guide for the full caveat list.
+```
+
+- [ ] **Step 4: Verify both docs**
+
+```bash
+grep -A5 'ActionController::Live' docs/upgrading-to-v4.md | head -30
+grep -A5 'ActionController::Live' README.md | head -20
+```
+
+Expected: auto-propagation note + caveats in upgrading guide; new section in README.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/upgrading-to-v4.md README.md
+git commit -m "Docs: upgrading guide + README — Live is auto-handled; caveats documented"
+```
+
+---
+
+### Task 11: Rubocop sweep on all changed files
+
+**Per user preference (memory: rubocop-before-push), every changed file must pass rubocop before push.**
+
+- [ ] **Step 1: Identify changed files**
+
+```bash
+git diff --name-only origin/main..HEAD
+```
+
+Expected output:
+
+```
+docs/designs/apartment-v4.md
+docs/designs/rails-boundary-tenancy.md
+docs/plans/live-tenant-propagation/plan.md
+docs/upgrading-to-v4.md
+lib/apartment.rb
+lib/apartment/concerns/live_tenancy.rb
+lib/apartment/elevators/generic.rb
+lib/apartment/railtie.rb
+spec/dummy/app/controllers/streaming_controller.rb
+spec/dummy/config/routes.rb
+spec/integration/v4/live_streaming_spec.rb
+spec/unit/apartment_constants_spec.rb
+spec/unit/elevators/generic_spec.rb
+spec/unit/live_tenancy_spec.rb
+spec/unit/railtie_spec.rb
+```
+
+- [ ] **Step 2: Run rubocop on Ruby files only**
+
+```bash
+git diff --name-only origin/main..HEAD | grep -E '\.rb$' | xargs bundle exec rubocop
+```
+
+Expected: no offenses. If offenses are reported, fix them inline — do not skip with `# rubocop:disable` unless the offense is genuinely a false positive (rare).
+
+- [ ] **Step 3: Commit any rubocop fixes**
+
+```bash
+git add -u
+git commit -m "Rubocop: address style offenses on Live tenant propagation" || echo "No rubocop fixes needed"
+```
+
+---
+
+### Task 12: Full test sweep across appraisal matrix
+
+**Files:** None (test execution only).
+
+- [ ] **Step 1: Unit tests across all Rails versions**
+
+```bash
+bundle exec appraisal rspec spec/unit/
+```
+
+Expected: all unit examples PASS across the matrix. The new `spec/unit/live_tenancy_spec.rb`, `spec/unit/apartment_constants_spec.rb`, and the additions to `spec/unit/elevators/generic_spec.rb` and `spec/unit/railtie_spec.rb` must pass on Rails 7.2 / 8.0 / 8.1 / main.
+
+- [ ] **Step 2: Integration tests on SQLite (default)**
+
+```bash
+bundle exec appraisal rails-7.2-sqlite3 rspec spec/integration/v4/live_streaming_spec.rb
+bundle exec appraisal rails-8.0-sqlite3 rspec spec/integration/v4/live_streaming_spec.rb
+bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/live_streaming_spec.rb
+bundle exec appraisal rails-main-sqlite3 rspec spec/integration/v4/live_streaming_spec.rb
+```
+
+Expected: all examples PASS on every version.
+
+- [ ] **Step 3: Integration tests on PostgreSQL and MySQL**
+
+```bash
+DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/live_streaming_spec.rb
+DATABASE_ENGINE=mysql bundle exec appraisal rails-8.1-mysql2 rspec spec/integration/v4/live_streaming_spec.rb
+```
+
+Expected: PASS. These require provisioned PG and MySQL test databases per `CLAUDE.md` Commands section.
+
+- [ ] **Step 4: Quick regression sweep — existing integration specs**
+
+```bash
+bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/
+```
+
+Expected: all pre-existing integration examples still PASS. The auto-include of `Apartment::LiveTenancy` into `ActionController::Live` is invisible to non-Live controllers, but a regression here would indicate the include is firing on the wrong target.
+
+---
+
+## Self-review (post panel-review revisions)
+
+### Spec coverage
+
+- Rubric Bucket 1 criteria (incl. tightened criterion 5 with identifier-vs-state distinction) → enforced by mechanism choice in Tasks 3–5.
+- Bucket 1 worked example design (elevator stash + concern + Railtie auto-include) → Tasks 3, 4, 5.
+- "Why direct prepends on the spawn site don't work" → design rationale; referenced from concern source comments in Task 4.
+- "Behavior across Rails versions" table → exercised by Task 7 (`:fiber` + matrix) and Task 12 (full sweep).
+- "Behavior across isolation levels" table → exercised by Tasks 6 (`:thread`) and 7 (`:fiber`).
+- Trade-offs (nested user threads, elevator order, app-defined `around_action` ordering, thread pool reuse) → reuse covered by Task 8; the three doc caveats covered by Task 10.
+- Test coverage section of spec → Tasks 4 (unit on concern), 5 (unit on Railtie include + idempotence), 6+7+8 (integration on isolation + reuse + negative control).
+- Documentation updates section of spec → Tasks 9 (design doc) and 10 (upgrading guide + README).
+- ActiveStorage worked example (Bucket 3) → no code change required; explicitly out of scope.
+
+### Panel-review fixes applied
+
+- **Integration harness rewritten** (blocker from Cursor): Tasks 6/7/8 now use `spec_helper` + `support`, `DUMMY_APP_AVAILABLE` guard, `V4IntegrationHelper.postgresql?`, per-example `establish_apartment!`, PostgreSQL appraisal commands. Mirrors `request_lifecycle_spec.rb`.
+- **Task 5 self-nullifying `skip` replaced** (blocker from Cursor): four examples that assert facts regardless of include order, plus an idempotence check.
+- **`defined?(ActionController::Base)` guard re-added** to the railtie code (blocker from Codex).
+- **Spec/plan reconciled on `initializer` vs `after_initialize`**: spec updated to match plan's `initializer`.
+- **Negative-control test added** to Task 7 (Cursor): alias-swap removes the env stash; assertion is Rails-version-aware (8.1.2+ still passes via Rails' own propagation).
+- **Subclass-elevator inheritance test added** to Task 3 (Codex).
+- **Inline #75 caveat in apartment-v4.md added** to Task 9 (Cursor).
+- **README section added** to Task 10 (Cursor).
+- **Callback-order trade-off documented** in Task 10's upgrading-guide content (Gemini).
+
+### Placeholder scan
+
+No "TBD" / "TODO" / "fill in details" in any task. All code snippets are complete. All commands are exact with expected output.
+
+### Type consistency
+
+- `Apartment::ENV_TENANT_KEY` used identically in elevator (Task 3), concern (Task 4), and docs (Tasks 9, 10).
+- `Apartment::LiveTenancy` module name used consistently across Tasks 4, 5, 9, 10.
+- `_apartment_with_live_tenant` callback name used identically in concern (Task 4) and railtie test assertion (Task 5).
+- `around_action` arity (passing a symbol, not a block with `yield`) is consistent in the concern and the test expectation.
+- `stream_payload` helper defined in Task 6 reused unchanged in Tasks 7 and 8.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to `docs/plans/live-tenant-propagation/plan.md`. Two execution options:**
+
+**1. Inline Execution (recommended for this plan)** — Tasks are linearly dependent (Task 2 must land before Task 3, etc.) and context-coupled (each step references the previous file state). Per `~/.claude/rules/subagent-vs-inline.md`, inline beats subagent orchestration for sequential plan execution. **REQUIRED SUB-SKILL:** `superpowers:executing-plans`, batched execution with checkpoints between tasks for human review.
+
+**2. Subagent-Driven** — A fresh subagent per task with two-stage review. Higher overhead but stronger per-task isolation. **REQUIRED SUB-SKILL:** `superpowers:subagent-driven-development`. Worth it if you'd rather review each task's diff in isolation before the next one starts.
+
+Which approach?

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -163,7 +163,12 @@ The Railtie emits a boot-time warning when `isolation_level` is `:thread`.
 
 Two caveats apply at `:fiber`:
 
-- `ActionController::Live` spawns a child OS thread and copies execution state via `IsolatedExecutionState.share_with`. The copy reads the parent's `Thread#active_support_execution_state`, which is empty under `:fiber` (state lives on `Fiber.current`). Live actions that depend on tenant inheritance must wrap themselves in an explicit `Apartment::Tenant.switch`.
+- **`ActionController::Live`**: works out of the box. Apartment v4 auto-includes `Apartment::LiveTenancy` into `ActionController::Live`; every Live controller picks up an `around_action` that re-establishes the request's tenant inside the OS thread Rails spawns for streaming. No user code changes required for the standard case. Three caveats:
+  - **User-spawned threads or fibers inside a Live action** (`Thread.new { ... }`, `Async { ... }`, raw `Fiber.new`) are not covered by the around_action wrap. Wrap them in `Apartment::Tenant.switch(Apartment::Tenant.current) { ... }` explicitly — same contract `:fiber` isolation imposes everywhere else.
+  - **Custom elevator subclasses** that override `Apartment::Elevators::Generic#call` without calling `super` will not populate `request.env[Apartment::ENV_TENANT_KEY]`. The around_action falls through to a plain `yield` (no switch), and the Live action runs with the default tenant. Either call `super` from your override, or set `env[Apartment::ENV_TENANT_KEY] = tenant_name` yourself after resolving the tenant.
+  - **App-defined `around_action`s registered on `ApplicationController`** (or any superclass) run *before* `Apartment::LiveTenancy`'s wrap in the callback chain — they execute against the default tenant. If your app callback hits the DB, declare it on the Live controller itself (so it nests inside the Apartment wrap), or wrap its body in `Apartment::Tenant.switch(request.env[Apartment::ENV_TENANT_KEY]) { ... }`.
+
+  See [`docs/designs/rails-boundary-tenancy.md`](designs/rails-boundary-tenancy.md) for the mechanism.
 - Child fibers spawned inside a request (`Fiber.new { ... }.resume`) get their own attribute store and do not inherit the parent fiber's `CurrentAttributes` — see [rails/rails#48279](https://github.com/rails/rails/issues/48279) (closed as "not planned"). Use `Apartment::Tenant.switch` inside the child fiber, not before it.
 
 ### Pinned Model Connections

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -36,6 +36,11 @@ require_relative 'apartment/errors'
 require_relative 'apartment/tenant_validator'
 
 module Apartment # rubocop:disable Metrics/ModuleLength
+  # Rack env key used to carry the resolved tenant across execution boundaries
+  # (notably the OS thread spawned by ActionController::Live#process). The
+  # elevator writes this; Apartment::LiveTenancy reads it.
+  ENV_TENANT_KEY = 'apartment.tenant'
+
   class << self # rubocop:disable Metrics/ClassLength
     attr_reader :config, :pool_manager, :pool_reaper
     attr_writer :adapter

--- a/lib/apartment/concerns/live_tenancy.rb
+++ b/lib/apartment/concerns/live_tenancy.rb
@@ -21,9 +21,9 @@ module Apartment
 
     private
 
-    def _apartment_with_live_tenant
+    def _apartment_with_live_tenant(&)
       tenant = request.env[Apartment::ENV_TENANT_KEY]
-      tenant ? Apartment::Tenant.switch(tenant) { yield } : yield
+      tenant ? Apartment::Tenant.switch(tenant, &) : yield
     end
   end
 end

--- a/lib/apartment/concerns/live_tenancy.rb
+++ b/lib/apartment/concerns/live_tenancy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module Apartment
+  # Re-establishes the request's tenant inside the OS thread that
+  # ActionController::Live spawns for streaming responses. Auto-included
+  # into ActionController::Live by the Apartment Railtie; every controller
+  # that includes ActionController::Live picks up this around_action via
+  # ActiveSupport::Concern composition.
+  #
+  # See docs/designs/rails-boundary-tenancy.md for the mechanism and why
+  # an around_action (not a prepend on Live#process or new_controller_thread)
+  # is the only correct hook on Rails < 8.1.2.
+  module LiveTenancy
+    extend ActiveSupport::Concern
+
+    included do
+      around_action :_apartment_with_live_tenant
+    end
+
+    private
+
+    def _apartment_with_live_tenant
+      tenant = request.env[Apartment::ENV_TENANT_KEY]
+      tenant ? Apartment::Tenant.switch(tenant) { yield } : yield
+    end
+  end
+end

--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -29,6 +29,7 @@ module Apartment
         return @app.call(env) if database.nil?
         return handle_tenant_not_found(database, request) unless tenant_valid?(database)
 
+        env[Apartment::ENV_TENANT_KEY] = database
         Apartment::Tenant.switch(database) { @app.call(env) }
       end
 

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -68,6 +68,30 @@ module Apartment
       responses['Apartment::TenantNotFound'] = :not_found unless responses.key?('Apartment::TenantNotFound')
     end
 
+    # Auto-include Apartment::LiveTenancy into ActionController::Live so every
+    # controller that includes Live picks up the around_action that re-establishes
+    # the request's tenant inside the OS thread Live spawns for streaming.
+    #
+    # The :action_controller_live load hook only exists on Rails main (will ship
+    # in 8.2+); we force-require Live and include unconditionally so the fix
+    # lands on Rails 7.2 / 8.0 / 8.1 — exactly the versions where Rails' own
+    # share_with propagation is buggy under :fiber. On Rails 8.1.2+,
+    # share_with(context) already carries the tenant; the around_action runs as
+    # a redundant no-op same-tenant switch.
+    #
+    # See docs/designs/rails-boundary-tenancy.md.
+    initializer 'apartment.live_tenancy' do
+      next unless defined?(ActionController::Base) # non-ActionPack apps skip
+
+      require 'action_controller/metal/live'
+      # Concern-into-Concern composition: this queues Apartment::LiveTenancy's
+      # `included do around_action ... end` block to fire on every class that
+      # subsequently includes ActionController::Live. Module#include is
+      # idempotent at the Ruby level, so re-running this initializer (e.g., on
+      # test reload) does not double-queue the around_action.
+      ActionController::Live.include(Apartment::LiveTenancy)
+    end
+
     # In test environments, clean up apartment's tenant pools before Rails'
     # fixture setup iterates shards. See docs/designs/v4-test-fixtures-compatibility.md.
     if Rails.env.test?

--- a/spec/dummy/app/controllers/streaming_controller.rb
+++ b/spec/dummy/app/controllers/streaming_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Minimal ActionController::Live action used by
+# spec/integration/v4/live_streaming_spec.rb to verify that queries
+# executed inside the streaming thread route to the tenant the request
+# entered with. The action queries User.count once, writes a single SSE
+# data frame with the tenant name plus row count, and closes the stream.
+class StreamingController < ApplicationController
+  include ActionController::Live
+
+  def show
+    response.headers['Content-Type'] = 'text/event-stream'
+    response.headers['Cache-Control'] = 'no-cache'
+
+    payload = { tenant: Apartment::Tenant.current, user_count: User.count }
+    response.stream.write("data: #{payload.to_json}\n\n")
+  ensure
+    response.stream.close
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,5 +2,6 @@
 
 Dummy::Application.routes.draw do
   get '/tenant_info' => 'tenants#show'
+  get '/stream' => 'streaming#show'
   root to: 'tenants#show'
 end

--- a/spec/integration/v4/live_streaming_spec.rb
+++ b/spec/integration/v4/live_streaming_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+# Live streaming + tenant propagation requires the dummy Rails app + real
+# PostgreSQL (the dummy app's database.yml is PG-only). Modeled on
+# request_lifecycle_spec.rb.
+#
+# Run via:
+#   DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql \
+#     rspec spec/integration/v4/live_streaming_spec.rb
+
+require 'spec_helper'
+require_relative 'support'
+
+ENV['RAILS_ENV'] ||= 'test'
+
+LIVE_STREAMING_DUMMY_AVAILABLE = begin
+  require_relative('../../dummy/config/environment')
+  require('rack/test')
+  require('json')
+  true
+rescue LoadError, StandardError => e
+  raise if ENV['REQUEST_LIFECYCLE_REQUIRED']
+
+  warn "[live_streaming_spec] Skipping: #{e.message}"
+  false
+end
+
+RSpec.describe(
+  'ActionController::Live tenant propagation', :integration, :request_lifecycle,
+  skip: (LIVE_STREAMING_DUMMY_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires dummy Rails app + PostgreSQL')
+) do
+  include Rack::Test::Methods
+
+  def app
+    Rails.application
+  end
+
+  def test_tenants = %w[acme widgets]
+
+  def establish_apartment!
+    load(Rails.root.join('config/initializers/apartment.rb'))
+    Apartment.activate!
+    Apartment::Tenant.init
+  end
+
+  def stream_payload(response)
+    JSON.parse(response.body.sub(/\Adata:\s*/, '').strip)
+  end
+
+  before do
+    establish_apartment!
+
+    test_tenants.each do |tenant|
+      Apartment.adapter.create(tenant)
+    rescue Apartment::TenantExists
+      nil
+    end
+
+    [Apartment.config.default_tenant, *test_tenants].each do |tenant|
+      Apartment::Tenant.switch(tenant) do
+        ActiveRecord::Base.connection.create_table(:users, force: true) do |t|
+          t.string(:name)
+        end
+      end
+    end
+
+    Apartment::Tenant.switch('acme') do
+      User.create!(name: 'A')
+      User.create!(name: 'B')
+      User.create!(name: 'C')
+    end
+    Apartment::Tenant.switch('widgets') { User.create!(name: 'X') }
+  end
+
+  after { Apartment::Current.reset }
+
+  after(:all) do
+    establish_apartment!
+    test_tenants.each do |tenant|
+      Apartment.adapter.drop(tenant)
+    rescue StandardError
+      nil
+    end
+    Apartment::Tenant.switch(Apartment.config.default_tenant) do
+      ActiveRecord::Base.connection.drop_table(:users, if_exists: true)
+    end
+  ensure
+    Apartment.clear_config
+    Apartment::Current.reset
+  end
+
+  shared_examples 'propagates tenant into the Live stream' do
+    it 'streams the acme tenant (3 users) inside response.stream.write' do
+      header 'Host', 'acme.example.com'
+      get '/stream'
+      expect(last_response).to(be_ok)
+      data = stream_payload(last_response)
+      expect(data['tenant']).to(eq('acme'))
+      expect(data['user_count']).to(eq(3))
+    end
+
+    it 'streams the widgets tenant (1 user) inside response.stream.write' do
+      header 'Host', 'widgets.example.com'
+      get '/stream'
+      expect(last_response).to(be_ok)
+      data = stream_payload(last_response)
+      expect(data['tenant']).to(eq('widgets'))
+      expect(data['user_count']).to(eq(1))
+    end
+  end
+
+  context 'under :thread isolation' do
+    around do |example|
+      original = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :thread
+      example.run
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = original
+    end
+
+    include_examples 'propagates tenant into the Live stream'
+  end
+end

--- a/spec/integration/v4/live_streaming_spec.rb
+++ b/spec/integration/v4/live_streaming_spec.rb
@@ -25,9 +25,12 @@ rescue LoadError, StandardError => e
   false
 end
 
+SKIP_LIVE_STREAMING_REASON =
+  LIVE_STREAMING_DUMMY_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires dummy Rails app + PostgreSQL'
+
 RSpec.describe(
   'ActionController::Live tenant propagation', :integration, :request_lifecycle,
-  skip: (LIVE_STREAMING_DUMMY_AVAILABLE && V4IntegrationHelper.postgresql? ? false : 'requires dummy Rails app + PostgreSQL')
+  skip: SKIP_LIVE_STREAMING_REASON
 ) do
   include Rack::Test::Methods
 
@@ -118,7 +121,7 @@ RSpec.describe(
       ActiveSupport::IsolatedExecutionState.isolation_level = original
     end
 
-    include_examples 'propagates tenant into the Live stream'
+    it_behaves_like 'propagates tenant into the Live stream'
   end
 
   context 'under :fiber isolation' do
@@ -130,7 +133,7 @@ RSpec.describe(
       ActiveSupport::IsolatedExecutionState.isolation_level = original
     end
 
-    include_examples 'propagates tenant into the Live stream'
+    it_behaves_like 'propagates tenant into the Live stream'
 
     it '(negative control) leaks tenant when the elevator does not stash the env key' do
       # Simulate a custom elevator that omits the env stash — alias-swap
@@ -155,8 +158,8 @@ RSpec.describe(
       end
 
       begin
-        header 'Host', 'acme.example.com'
-        get '/stream'
+        header('Host', 'acme.example.com')
+        get('/stream')
         data = stream_payload(last_response)
 
         # Without the env stash, the around_action falls through to a plain
@@ -169,8 +172,8 @@ RSpec.describe(
         expect(data['tenant']).not_to(eq('acme'))
       ensure
         Apartment::Elevators::Generic.class_eval do
-          alias_method :call, :_original_call_for_neg_ctrl
-          remove_method :_original_call_for_neg_ctrl
+          alias_method(:call, :_original_call_for_neg_ctrl)
+          remove_method(:_original_call_for_neg_ctrl)
         end
       end
     end

--- a/spec/integration/v4/live_streaming_spec.rb
+++ b/spec/integration/v4/live_streaming_spec.rb
@@ -175,4 +175,35 @@ RSpec.describe(
       end
     end
   end
+
+  context 'with thread-pool reuse across requests under :fiber' do
+    around do |example|
+      original = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+      example.run
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = original
+    end
+
+    it 'does not leak tenant state between consecutive Live requests' do
+      header 'Host', 'acme.example.com'
+      get '/stream'
+      acme_data = stream_payload(last_response)
+
+      header 'Host', 'widgets.example.com'
+      get '/stream'
+      widgets_data = stream_payload(last_response)
+
+      header 'Host', 'acme.example.com'
+      get '/stream'
+      acme_data_again = stream_payload(last_response)
+
+      expect(acme_data['tenant']).to(eq('acme'))
+      expect(acme_data['user_count']).to(eq(3))
+      expect(widgets_data['tenant']).to(eq('widgets'))
+      expect(widgets_data['user_count']).to(eq(1))
+      expect(acme_data_again['tenant']).to(eq('acme'))
+      expect(acme_data_again['user_count']).to(eq(3))
+    end
+  end
 end

--- a/spec/integration/v4/live_streaming_spec.rb
+++ b/spec/integration/v4/live_streaming_spec.rb
@@ -120,4 +120,59 @@ RSpec.describe(
 
     include_examples 'propagates tenant into the Live stream'
   end
+
+  context 'under :fiber isolation' do
+    around do |example|
+      original = ActiveSupport::IsolatedExecutionState.isolation_level
+      ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
+      example.run
+    ensure
+      ActiveSupport::IsolatedExecutionState.isolation_level = original
+    end
+
+    include_examples 'propagates tenant into the Live stream'
+
+    it '(negative control) leaks tenant when the elevator does not stash the env key' do
+      # Simulate a custom elevator that omits the env stash — alias-swap
+      # Generic#call to a variant that does not set Apartment::ENV_TENANT_KEY.
+      # The Subdomain elevator inherits Generic#call, so this hits both.
+      Apartment::Elevators::Generic.class_eval do
+        alias_method :_original_call_for_neg_ctrl, :call
+        define_method(:call) do |env|
+          request = Rack::Request.new(env)
+          begin
+            database = @processor.call(request)
+          rescue Apartment::TenantNotFound => e
+            return handle_tenant_not_found(e.tenant || request.host, request)
+          end
+          return @app.call(env) if database.nil?
+          return handle_tenant_not_found(database, request) unless send(:tenant_valid?, database)
+
+          # NOTE: deliberately omitting `env[Apartment::ENV_TENANT_KEY] = database`
+          # — this is what the test reproduces.
+          Apartment::Tenant.switch(database) { @app.call(env) }
+        end
+      end
+
+      begin
+        header 'Host', 'acme.example.com'
+        get '/stream'
+        data = stream_payload(last_response)
+
+        # Without the env stash, the around_action falls through to a plain
+        # yield and the spawned thread sees no captured tenant — on all
+        # currently-released Rails versions (7.2 through 8.1.3), share_with
+        # reads from Thread.current, which is empty under :fiber. The
+        # streamed tenant is NOT 'acme' — the original leak reproduces.
+        # Rails main has share_with(context) which reads Fiber.current, but
+        # that has not landed in a stable release yet.
+        expect(data['tenant']).not_to(eq('acme'))
+      ensure
+        Apartment::Elevators::Generic.class_eval do
+          alias_method :call, :_original_call_for_neg_ctrl
+          remove_method :_original_call_for_neg_ctrl
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/apartment_constants_spec.rb
+++ b/spec/unit/apartment_constants_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Apartment do
+  describe 'ENV_TENANT_KEY' do
+    it 'is the canonical Rack env key for cross-thread tenant lookup' do
+      expect(Apartment::ENV_TENANT_KEY).to eq('apartment.tenant')
+    end
+
+    it 'is frozen' do
+      expect(Apartment::ENV_TENANT_KEY).to be_frozen
+    end
+  end
+end

--- a/spec/unit/apartment_constants_spec.rb
+++ b/spec/unit/apartment_constants_spec.rb
@@ -2,14 +2,14 @@
 
 require 'spec_helper'
 
-RSpec.describe Apartment do
+RSpec.describe(Apartment) do
   describe 'ENV_TENANT_KEY' do
     it 'is the canonical Rack env key for cross-thread tenant lookup' do
-      expect(Apartment::ENV_TENANT_KEY).to eq('apartment.tenant')
+      expect(Apartment::ENV_TENANT_KEY).to(eq('apartment.tenant'))
     end
 
     it 'is frozen' do
-      expect(Apartment::ENV_TENANT_KEY).to be_frozen
+      expect(Apartment::ENV_TENANT_KEY).to(be_frozen)
     end
   end
 end

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -65,6 +65,34 @@ RSpec.describe(Apartment::Elevators::Generic) do
     end
   end
 
+  describe 'env stash' do
+    let(:captured) { [] }
+    let(:capture_app) { ->(env) { captured << env[Apartment::ENV_TENANT_KEY]; [200, {}, []] } }
+
+    before do
+      allow(Apartment::Tenant).to(receive(:switch).and_yield)
+    end
+
+    it 'writes Apartment::ENV_TENANT_KEY on env before invoking the app' do
+      elevator = described_class.new(capture_app, ->(_req) { 'acme' })
+      env = Rack::MockRequest.env_for('http://example.com')
+
+      elevator.call(env)
+
+      expect(env[Apartment::ENV_TENANT_KEY]).to(eq('acme'))
+      expect(captured).to(eq(['acme']))
+    end
+
+    it 'does not set ENV_TENANT_KEY when no tenant is resolved' do
+      elevator = described_class.new(capture_app, ->(_req) {})
+      env = Rack::MockRequest.env_for('http://example.com')
+
+      elevator.call(env)
+
+      expect(env).not_to(have_key(Apartment::ENV_TENANT_KEY))
+    end
+  end
+
   describe '#parse_tenant_name' do
     it 'raises NotImplementedError by default' do
       elevator = described_class.new(inner_app)

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -67,7 +67,12 @@ RSpec.describe(Apartment::Elevators::Generic) do
 
   describe 'env stash' do
     let(:captured) { [] }
-    let(:capture_app) { ->(env) { captured << env[Apartment::ENV_TENANT_KEY]; [200, {}, []] } }
+    let(:capture_app) do
+      lambda { |env|
+        captured << env[Apartment::ENV_TENANT_KEY]
+        [200, {}, []]
+      }
+    end
 
     before do
       allow(Apartment::Tenant).to(receive(:switch).and_yield)

--- a/spec/unit/elevators/subdomain_spec.rb
+++ b/spec/unit/elevators/subdomain_spec.rb
@@ -51,4 +51,18 @@ RSpec.describe(Apartment::Elevators::Subdomain) do
       expect(elevator.instance_variable_get(:@excluded_subdomains)).to(be_frozen)
     end
   end
+
+  describe 'env stash inheritance from Generic#call' do
+    let(:capture_app) { ->(_env) { [200, {}, []] } }
+
+    before do
+      allow(Apartment::Tenant).to(receive(:switch).and_yield)
+    end
+
+    it 'writes Apartment::ENV_TENANT_KEY via super into Generic#call' do
+      env = env_for('acme.example.com')
+      described_class.new(capture_app).call(env)
+      expect(env[Apartment::ENV_TENANT_KEY]).to(eq('acme'))
+    end
+  end
 end

--- a/spec/unit/live_tenancy_spec.rb
+++ b/spec/unit/live_tenancy_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'action_controller'
+require 'action_controller/metal/live'
+
+RSpec.describe Apartment::LiveTenancy do
+  # A minimal controller-like host that records around_action registration
+  # and exposes the private callback method for direct invocation.
+  let(:controller_class) do
+    Class.new do
+      attr_accessor :request
+
+      def self.registered_around_actions
+        @registered_around_actions ||= []
+      end
+
+      def self.around_action(name)
+        registered_around_actions << name
+      end
+
+      include Apartment::LiveTenancy
+    end
+  end
+
+  describe 'when included' do
+    it 'registers an around_action callback' do
+      expect(controller_class.registered_around_actions)
+        .to(include(:_apartment_with_live_tenant))
+    end
+  end
+
+  describe '#_apartment_with_live_tenant' do
+    let(:instance) { controller_class.new }
+    let(:env) { {} }
+
+    before do
+      instance.request = double('Request', env: env)
+    end
+
+    context 'when env carries Apartment::ENV_TENANT_KEY' do
+      before { env[Apartment::ENV_TENANT_KEY] = 'acme' }
+
+      it 'wraps the block in Apartment::Tenant.switch with the env tenant' do
+        expect(Apartment::Tenant).to(receive(:switch).with('acme').and_yield)
+        result = instance.send(:_apartment_with_live_tenant) { 42 }
+        expect(result).to(eq(42))
+      end
+    end
+
+    context 'when env has no tenant key' do
+      it 'yields without calling Apartment::Tenant.switch' do
+        expect(Apartment::Tenant).not_to(receive(:switch))
+        result = instance.send(:_apartment_with_live_tenant) { 'plain' }
+        expect(result).to(eq('plain'))
+      end
+    end
+
+    context 'when the block raises' do
+      before { env[Apartment::ENV_TENANT_KEY] = 'acme' }
+
+      it 'propagates the exception (switch handles restore via its own ensure)' do
+        allow(Apartment::Tenant).to(receive(:switch).with('acme').and_yield)
+        expect do
+          instance.send(:_apartment_with_live_tenant) { raise('boom') }
+        end.to(raise_error('boom'))
+      end
+    end
+  end
+end

--- a/spec/unit/live_tenancy_spec.rb
+++ b/spec/unit/live_tenancy_spec.rb
@@ -4,15 +4,17 @@ require 'spec_helper'
 require 'action_controller'
 require 'action_controller/metal/live'
 
-RSpec.describe Apartment::LiveTenancy do
+RSpec.describe(Apartment::LiveTenancy) do
   # A minimal controller-like host that records around_action registration
-  # and exposes the private callback method for direct invocation.
+  # and exposes the private callback method for direct invocation. The class
+  # instance variable below is intentional — this is a test stub, not a
+  # production class.
   let(:controller_class) do
     Class.new do
       attr_accessor :request
 
       def self.registered_around_actions
-        @registered_around_actions ||= []
+        @registered_around_actions ||= [] # rubocop:disable ThreadSafety/ClassInstanceVariable
       end
 
       def self.around_action(name)

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -189,6 +189,44 @@ if railtie_loaded
       end
     end
 
+    describe 'apartment.live_tenancy initializer' do
+      before do
+        require 'action_controller'
+        require 'action_controller/metal/live'
+      end
+
+      it 'is registered on the railtie by name' do
+        names = Apartment::Railtie.initializers.map(&:name)
+        expect(names).to(include('apartment.live_tenancy'))
+      end
+
+      it 'queues the around_action on classes that subsequently include ActionController::Live' do
+        # Concern-into-Concern composition: including Apartment::LiveTenancy
+        # into ActionController::Live (itself a Concern) queues the
+        # around_action to fire on every class that subsequently includes Live.
+        # Module#include? against a Module returns false here — the assertion
+        # has to be on a fresh class, not on Live itself.
+        initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.live_tenancy' }
+        initializer.run
+
+        fresh_controller = Class.new(ActionController::Base) { include ActionController::Live }
+        callbacks = fresh_controller._process_action_callbacks.map(&:filter)
+
+        expect(callbacks).to(include(:_apartment_with_live_tenant))
+      end
+
+      it 'is idempotent — re-running does not register the around_action twice' do
+        initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.live_tenancy' }
+        initializer.run
+        initializer.run
+
+        fresh_controller = Class.new(ActionController::Base) { include ActionController::Live }
+        callbacks = fresh_controller._process_action_callbacks.map(&:filter)
+
+        expect(callbacks.count(:_apartment_with_live_tenant)).to(eq(1))
+      end
+    end
+
     describe 'TenantNotFound rescue_responses mapping' do
       # Unit specs do not boot a Rails::Application, so railtie initializers
       # never run on their own — invoke the initializer block directly.

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -209,7 +209,9 @@ if railtie_loaded
         initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.live_tenancy' }
         initializer.run
 
+        # rubocop:disable Rails/ApplicationController -- ApplicationController is not loaded in this spec process
         fresh_controller = Class.new(ActionController::Base) { include ActionController::Live }
+        # rubocop:enable Rails/ApplicationController
         callbacks = fresh_controller._process_action_callbacks.map(&:filter)
 
         expect(callbacks).to(include(:_apartment_with_live_tenant))
@@ -220,7 +222,9 @@ if railtie_loaded
         initializer.run
         initializer.run
 
+        # rubocop:disable Rails/ApplicationController -- ApplicationController is not loaded in this spec process
         fresh_controller = Class.new(ActionController::Base) { include ActionController::Live }
+        # rubocop:enable Rails/ApplicationController
         callbacks = fresh_controller._process_action_callbacks.map(&:filter)
 
         expect(callbacks.count(:_apartment_with_live_tenant)).to(eq(1))


### PR DESCRIPTION
Reviewed with Claude Code plus an AI-agent panel (Codex, Gemini, Cursor); their input is folded in below.

## Summary

Closes #304. Alternative approach to #411, which the panel and I rejected as a model contradiction — propagating fiber-isolated state through `Thread#thread_variable_set` plus a parallel fallback path in `ConnectionHandling#connection_pool`.

- The elevator stashes the resolved tenant on `request.env[Apartment::ENV_TENANT_KEY]` — a Rack-native cross-boundary carrier.
- A new `Apartment::LiveTenancy` concern adds an `around_action` that reads the env stash and re-enters `Apartment::Tenant.switch` from inside the spawned thread (after Rails' `share_with` has done its work).
- The Apartment Railtie auto-includes the concern into `ActionController::Live` via `ActiveSupport::Concern` composition. Every Live controller picks up the wrap with no user opt-in.
- A design rubric for similar Rails-boundary cases lives in `docs/designs/rails-boundary-tenancy.md`. It tightens what Bucket 1 (auto-handle in core) permits — specifically forbidding the pointer-mirroring an earlier draft of mine attempted (mirror `Fiber.current.active_support_execution_state` onto `Thread.current` to coax Rails' broken `share_with` into working). ActiveStorage (#314) is explicitly out of scope and lands in Bucket 3 (companion gem).

## Why not the obvious places

- Prepending `ActionController::Live#new_controller_thread` and calling `Tenant.switch` inside the spawn (the #411 site): `share_with` runs inside the spawn block and overwrites whatever the prepend sets. No-op by construction.
- Prepending `ActionController::Live#process` and wrapping `super(name)`: the wrap is on the parent fiber; the work runs on the spawned thread. Doesn't reach.
- Pointer-mirroring `Thread.current.active_support_execution_state` to `Fiber.current.active_support_execution_state`: contradicts the fiber-isolation model. Closed by the spec's Bucket 1 criterion 5.
- `Thread#thread_variable_set` (the mechanism in #411): same model contradiction, plus a parallel state channel in `connection_pool` that competes with `Apartment::Current`.

`around_action` is the only hook that runs inside the spawned thread, after `share_with`, using only public Rails API.

## Rails version coverage

Verified against actionpack-8.1.3: Live#process still calls `share_with(Thread.current, except: ...)` — the `share_with(context)` refactor on rails/rails main has not landed in a stable release. The around_action is load-bearing on every currently-released Rails version (7.2 / 8.0 / 8.1.x). Once `share_with(context)` ships in a stable Rails, the around_action becomes a same-tenant no-op (cheap; safe).

## Test plan

- [ ] Verify CI passes across Rails 7.2 / 8.0 / 8.1 × SQLite / PostgreSQL / MySQL. rails-main remains the existing `continue-on-error` canary — it fails on a pre-existing `apartment.rescue_responses` frozen-hash issue, not introduced here.
- [ ] Verify `spec/integration/v4/live_streaming_spec.rb` passes the load-bearing `:fiber` examples, including the negative-control case (alias-swaps `Generic#call` to omit the env stash; asserts the leak reproduces).
- [ ] Verify the thread-pool reuse test passes: three consecutive `acme -> widgets -> acme` requests under `:fiber` show no state bleed.
- [ ] Verify existing v4 integration suite (147 examples) shows no regressions.
- [ ] Verify rubocop is clean across all changed Ruby files.
- [ ] Review the three documented caveats in the upgrading guide (nested user threads/fibers inside a Live action, custom elevator subclasses that skip `super`, app-defined `around_action`s on `ApplicationController` that hit the DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)