### PR TITLE
Railtie: make apartment.rescue_responses ractor-safe (rails/rails#57483)

### DIFF
--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -62,10 +62,26 @@ module Apartment
     # application's own 404 page when no tenant_not_found_handler is configured.
     # rescue_responses has a non-nil default (:internal_server_error), so a
     # key? check — not ||= — is what skips an app's own explicit mapping.
-    initializer 'apartment.rescue_responses' do
+    #
+    # Rails main (post-rails/rails#57483) makes
+    # ActionDispatch::ExceptionWrapper.rescue_responses Ractor-safe by freezing
+    # the underlying hash and merging the engine config
+    # config.action_dispatch.rescue_responses in during action_dispatch.configure.
+    # Older Rails has a mutable hash and no engine-config merge. We do both:
+    # contribute via engine config (picked up by Rails main + harmless on older
+    # Rails) and mutate directly when the hash is still mutable (the
+    # only path that works on Rails ≤ 8.1.x).
+    initializer 'apartment.rescue_responses', before: 'action_dispatch.configure' do |app|
       require 'action_dispatch'
+
+      # Rails main path: engine config merged + refrozen during action_dispatch.configure.
+      app.config.action_dispatch.rescue_responses['Apartment::TenantNotFound'] = :not_found
+
+      # Pre-rails-main path: mutate directly while the hash is still mutable.
       responses = ActionDispatch::ExceptionWrapper.rescue_responses
-      responses['Apartment::TenantNotFound'] = :not_found unless responses.key?('Apartment::TenantNotFound')
+      unless responses.frozen? || responses.key?('Apartment::TenantNotFound')
+        responses['Apartment::TenantNotFound'] = :not_found
+      end
     end
 
     # In test environments, clean up apartment's tenant pools before Rails'

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -191,16 +191,46 @@ if railtie_loaded
 
     describe 'TenantNotFound rescue_responses mapping' do
       # Unit specs do not boot a Rails::Application, so railtie initializers
-      # never run on their own — invoke the initializer block directly.
-      it 'maps Apartment::TenantNotFound to :not_found' do
-        require 'action_dispatch'
-        initializer = Apartment::Railtie.initializers.find { |i| i.name == 'apartment.rescue_responses' }
+      # never run on their own — invoke the initializer block directly with a
+      # fake app whose config exposes config.action_dispatch.rescue_responses
+      # (the engine config that Rails main's action_dispatch.configure merges
+      # in + refreezes during boot).
+      let(:fake_app) do
+        engine_config = Struct.new(:rescue_responses).new({})
+        app_config = Struct.new(:action_dispatch).new(engine_config)
+        Struct.new(:config).new(app_config)
+      end
+      let(:initializer) do
+        Apartment::Railtie.initializers.find { |i| i.name == 'apartment.rescue_responses' }
+      end
+
+      it 'is registered' do
         expect(initializer).not_to(be_nil)
+      end
 
-        initializer.run
-
-        expect(ActionDispatch::ExceptionWrapper.rescue_responses['Apartment::TenantNotFound'])
+      it 'contributes to config.action_dispatch.rescue_responses (Rails-main path)' do
+        initializer.run(fake_app)
+        expect(fake_app.config.action_dispatch.rescue_responses['Apartment::TenantNotFound'])
           .to(eq(:not_found))
+      end
+
+      it 'mutates ExceptionWrapper.rescue_responses directly when the hash is mutable (pre-main path)' do
+        responses = ActionDispatch::ExceptionWrapper.rescue_responses
+        skip 'this Rails freezes the default hash; the direct-mutation path does not apply' if responses.frozen?
+
+        responses.delete('Apartment::TenantNotFound')
+        initializer.run(fake_app)
+        expect(responses['Apartment::TenantNotFound']).to(eq(:not_found))
+      end
+
+      it 'does not raise when ExceptionWrapper.rescue_responses is frozen (Rails-main behavior)' do
+        responses = ActionDispatch::ExceptionWrapper.rescue_responses
+        previous = responses
+        ActionDispatch::ExceptionWrapper.rescue_responses = responses.dup.freeze
+
+        expect { initializer.run(fake_app) }.not_to(raise_error)
+      ensure
+        ActionDispatch::ExceptionWrapper.rescue_responses = previous
       end
     end
   end


### PR DESCRIPTION
## Summary

rails/rails#57483 (merged 2026-05-28) froze `ActionDispatch::ExceptionWrapper.rescue_responses` for Ractor safety and moved the contribution path to `config.action_dispatch.rescue_responses`. Our `apartment.rescue_responses` initializer mutated the runtime hash directly, which now raises `FrozenError` on rails-main and blocks `request_lifecycle_spec` from even loading.

The fix takes both paths so it works across the full appraisal matrix:

- **Rails main (post-#57483)**: contribute via `config.action_dispatch.rescue_responses`, ordered `before: 'action_dispatch.configure'` so the entry lands in the merged + refrozen hash.
- **Pre-main Rails (≤ 8.1.x)**: mutate `ExceptionWrapper.rescue_responses` directly when the hash is still mutable.

Both lines run; only one takes effect per Rails version.

Unit tests cover both paths with a fake-app helper. The mutable-hash test skips on rails-main (the hash is frozen there); the engine-config and no-raise-on-frozen tests run everywhere.

## Test plan

- [x] Verify rails-main canary turns from red to green in CI (the existing pre-existing `request_lifecycle_spec` boot failure is what motivated this PR).
- [x] Verify Rails 7.2 / 8.0 / 8.1 × sqlite/postgresql/mysql2 unit suite stays green.
- [x] Verify Rails 8.1 `request_lifecycle_spec`'s 404 mapping (line 148) still passes — the same end-to-end test ActionDispatch's merge now exercises on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)