### PR TITLE
Fix Ruby 3.3.0 SyntaxError in each_tenant_parallel block forwarding

### DIFF
--- a/lib/apartment/tasks/task_helper.rb
+++ b/lib/apartment/tasks/task_helper.rb
@@ -85,13 +85,13 @@ module Apartment
 
       # Parallel execution wrapper. Disables advisory locks for the duration,
       # then delegates to platform-appropriate parallelism strategy.
-      def each_tenant_parallel(&)
+      def each_tenant_parallel(&block)
         with_advisory_locks_disabled do
           case resolve_parallel_strategy
           when :processes
-            each_tenant_in_processes(&)
+            each_tenant_in_processes(&block)
           else
-            each_tenant_in_threads(&)
+            each_tenant_in_threads(&block)
           end
         end
       end

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '3.4.3'
+  VERSION = '3.4.4'
 end


### PR DESCRIPTION
Fixes #339.

## Problem

On **Ruby 3.3.0**, `lib/apartment/tasks/task_helper.rb` fails to parse:

```
$ ruby -c lib/apartment/tasks/task_helper.rb
anonymous block parameter is also used within block (SyntaxError)
```

`each_tenant_parallel` forwards an anonymous block argument `(&)` from **inside** the `with_advisory_locks_disabled do … end` block. Ruby 3.3.0 rejects forwarding an anonymous `&` within a nested block, so `rails db:migrate` — and anything routing through it — can't even parse the file on that interpreter.

This was an upstream Ruby parser bug, **fixed in Ruby 3.3.1**, but 3.3.0 is inside our supported range (`required_ruby_version >= 3.1`).

## Fix

Use an explicit `&block` parameter in the one method that forwards inside a nested block:

```ruby
def each_tenant_parallel(&block)
  with_advisory_locks_disabled do
    case resolve_parallel_strategy
    when :processes
      each_tenant_in_processes(&block)
    else
      each_tenant_in_threads(&block)
    end
  end
end
```

The sibling forwards in `each_tenant` are at statement level (not inside a block), where anonymous `(&)` parses fine on 3.3.0 and RuboCop's `Naming/BlockForwarding` actively requires the anonymous form — so they're intentionally left unchanged. The cop's boundary (explicit only where anonymous is unsafe) lines up exactly with the parser bug's boundary, which is why the fix is minimal and rubocop-clean.

## Version bump

Bumps `VERSION` `3.4.3` → `3.4.4`. The `3-4-stable` publish workflow runs `rake release` on push, so the bump is required for a new gem to be cut when this merges (without it, the release job would re-attempt the already-published 3.4.3).

## Verification

- `ruby -c task_helper.rb` → **`Syntax OK`** on 3.3.0, 3.3.6, 3.4.7, 4.0.2 (was `SyntaxError` on 3.3.0 before).
- `bundle exec rubocop lib/apartment/tasks/task_helper.rb` → no offenses (rubocop 1.86, matching the locked CI version).
- Behavior-preserving: identical block forwarding, only the parameter name changes.

## Context

This supersedes the equivalent fix in #340, which targeted `main` — where `task_helper.rb` was removed during the v4 rewrite (#356), so it could no longer merge there. `main` is unaffected: its surviving `(&)` sites all forward at statement level. Credit to @leogar07 for the original diagnosis in #339 / #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)