### PR TITLE
bin/dev/setup-worktree: bundle install when a new worktree has no lockfile

### DIFF
--- a/bin/dev/setup-worktree
+++ b/bin/dev/setup-worktree
@@ -321,8 +321,22 @@ fi
 section "Checking dependencies"
 
 if [ -f "Gemfile" ]; then
-    log_info "Ruby gems should be available (gems are installed globally)"
-    log_info "Run 'bundle install' only if you add new gems to this worktree"
+    if [ -f "Gemfile.lock" ]; then
+        log_info "Gemfile.lock present — gems already resolved"
+    elif ! command -v bundle >/dev/null 2>&1; then
+        log_warn "bundle not on PATH — run 'bundle install' manually before using ruby-lsp/Serena"
+    else
+        # ruby-lsp refuses to initialize without a lockfile (logs the request
+        # to stderr and exits), so Serena's symbolic tools won't work until
+        # we bundle. Gemfile.lock is gitignored here — gem libraries don't
+        # commit it — so every new worktree starts without one.
+        log_info "No Gemfile.lock — running 'bundle install' so ruby-lsp can initialize"
+        if bundle install --quiet; then
+            log_info "bundle install complete"
+        else
+            log_warn "bundle install failed — run it manually before using ruby-lsp/Serena"
+        fi
+    fi
 else
     log_warn "No Gemfile found"
 fi


### PR DESCRIPTION
## Problem

`Gemfile.lock` is gitignored in this repo (gems don't commit a lockfile), so every freshly created git worktree starts without one. `ruby-lsp` refuses to initialize without a lockfile — it logs the request to stderr and exits — which silently breaks editor/LSP tooling in a new worktree until you notice and run `bundle install` by hand. The script previously just printed a "run it yourself" hint.

## Change

Resolve dependencies automatically during worktree setup, with guards so it stays a no-op where it should:

```sh
if [ -f "Gemfile" ]; then
    if [ -f "Gemfile.lock" ]; then
        log_info "Gemfile.lock present — gems already resolved"
    elif ! command -v bundle >/dev/null 2>&1; then
        log_warn "bundle not on PATH — run 'bundle install' manually before using ruby-lsp/Serena"
    else
        log_info "No Gemfile.lock — running 'bundle install' so ruby-lsp can initialize"
        if bundle install --quiet; then
            log_info "bundle install complete"
        else
            log_warn "bundle install failed — run it manually before using ruby-lsp/Serena"
        fi
    fi
else
    log_warn "No Gemfile found"
fi
```

- **Lockfile already present** → nothing to do (repos that commit their lockfile hit this branch; no behavior change for them).
- **`bundle` not on PATH** → warn, leave it to the developer.
- **Otherwise** → `bundle install --quiet`; a failure warns rather than aborting setup.

## Scope & verification

- Dev-tooling script only; no library code touched.
- `bash -n bin/dev/setup-worktree` → OK; `shellcheck -S warning` → clean.
- `git check-ignore Gemfile.lock` → matched by `*.lock`, confirming the no-lockfile premise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)