### PR TITLE
Fix order-dependent integration failures on Rails 8.0 PG (#423)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_DB: apartment_postgresql_test
+          POSTGRES_DB: apartment_v4_test
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/spec/config/postgresql.yml.erb
+++ b/spec/config/postgresql.yml.erb
@@ -1,14 +1,14 @@
 connections:
   postgresql:
     adapter: postgresql
-    database: apartment_postgresql_test
+    database: apartment_v4_test
     username: postgres
     min_messages: WARNING
     host: localhost
     port: 5432
 <% if defined?(JRUBY_VERSION) %>
     driver: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/apartment_postgresql_test
+    url: jdbc:postgresql://localhost:5432/apartment_v4_test
     timeout: 5000
     pool: 5
 <% else %>

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,6 +1,6 @@
 test:
   adapter: postgresql
-  database: apartment_postgresql_test
+  database: <%= ENV.fetch('APARTMENT_TEST_PG_DB', 'apartment_v4_test') %>
   host: <%= ENV.fetch('PGHOST', '127.0.0.1') %>
   port: <%= ENV.fetch('PGPORT', '5432') %>
   username: <%= ENV.fetch('PGUSER', ENV.fetch('USER', nil)) %>

--- a/spec/integration/v4/support.rb
+++ b/spec/integration/v4/support.rb
@@ -191,6 +191,13 @@ if V4_INTEGRATION_AVAILABLE
       new_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
       ActiveRecord::Base.connection_handler = new_handler
 
+      # Defensively re-create the primary test database before each example.
+      # A sibling :database_name / RBAC spec may have run DROP DATABASE on it
+      # without restoring it; without this, the next spec's first query fails
+      # with ActiveRecord::NoDatabaseError. Idempotent (no-op when the DB
+      # already exists), and a no-op for SQLite.
+      V4IntegrationHelper.ensure_test_database! unless V4IntegrationHelper.sqlite?
+
       # Re-establish the default connection on the fresh handler.
       default_config = V4IntegrationHelper.default_connection_config
       ActiveRecord::Base.establish_connection(default_config) if default_config

--- a/spec/integration/v4/support/rbac_helper.rb
+++ b/spec/integration/v4/support/rbac_helper.rb
@@ -119,10 +119,10 @@ module RbacHelper
       END $$;
     SQL
     connection.execute("GRANT #{ROLES[:app_user]} TO #{ROLES[:db_manager]}")
-    # GRANT CREATE ON DATABASE so db_manager can create schemas.
-    # This runs here (not in CI provisioning) because the test database
-    # (apartment_v4_test) may not exist at CI role-provisioning time.
-    # The CI database (apartment_postgresql_test) differs from the test database.
+    # GRANT CREATE ON DATABASE so db_manager can create schemas. Runs here
+    # (not in CI provisioning) and grants on whatever database is currently
+    # connected, so it stays correct regardless of how the test database is
+    # provisioned or named.
     db_name = connection.current_database
     connection.execute("GRANT CREATE ON DATABASE #{connection.quote_table_name(db_name)} TO #{ROLES[:db_manager]}")
     # db_manager needs full access to the public schema for migrate_primary


### PR DESCRIPTION
Fixes #423.

The v4 integration suite was flaky-by-seed on PostgreSQL: cross-spec state pollution produced order-dependent failures. Two structural causes, both fixed at the shared-infrastructure layer. (CI had been green via the #422 `check_pending_migrations = false` workaround; this addresses the underlying causes.)

## Unify the integration test database

The dummy app used a different database (`apartment_postgresql_test`) than the rest of the suite (`apartment_v4_test`). Once a dummy-app spec boots, the parallel migrator's worker threads inherit the dummy's database via the ambient `ActiveRecord::Base` pool and build tenant pools against the wrong database — where the tenant schemas don't exist — so `CREATE TABLE schema_migrations` fails with `PG::InvalidSchemaName: no schema has been selected to create in`.

- `spec/dummy/config/database.yml` now reads `APARTMENT_TEST_PG_DB` (default `apartment_v4_test`), matching the integration helper.
- CI provisions `apartment_v4_test`.
- `spec/config/postgresql.yml.erb` matches, so `rake db:load_credentials` can't reintroduce the split.

This is a test-only concern: in production the adapter is built from `ActiveRecord::Base.connection_db_config` (`lib/apartment.rb`), so the ambient pool and the adapter's base config share one source and can't diverge. The patch's `base_config_override` behavior is deliberately left untouched — it inherits the current role's host/port for read-replica routing.

## Defensively ensure the primary test database exists

A sibling `:database_name` / RBAC spec can `DROP DATABASE` the primary without restoring it; the per-example `ConnectionHandler` swap re-establishes a connection but never re-verifies the database exists, so the next spec fails with `ActiveRecord::NoDatabaseError`. The `:integration` around hook now calls `ensure_test_database!` (idempotent; no-op for SQLite).

## Intentionally not changed

`check_pending_migrations = false` in the integration specs stays. They build tenant tables via fixtures, not migrations, so the gate must be off; the gate itself is covered by deterministic unit tests (`config_spec`, `errors_spec`, `connection_handling_spec`). Un-masking it would add per-tenant teardown to ~24 specs for no functional gain.

## Verification

- Full `spec/integration/v4` green across multiple seeds on **Rails 8.0 and 8.1 PG** — 147 examples, 0 failures.
- `rubocop` clean on changed Ruby files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)