### PR TITLE
Self-heal stale-positive tenant drops via a request-path fail-safe (PG schema)

### DIFF
--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -164,9 +164,40 @@ problem.
 The registry is per-process. With several app processes or containers, a
 `Tenant.create` in one process does not reach the others' registries directly —
 but rebuild-on-miss heals it: the first request naming the new tenant on any
-process rebuilds that process's set. A *dropped* tenant lingers in other
-processes' sets until their TTL; a request to it in that window degrades to the
-pre-existing behavior (a database error), not a data leak.
+process rebuilds that process's set.
+
+A *dropped* tenant is a stale **positive** in other processes' sets until their
+TTL. The **request-path fail-safe** bounds that window to a single request per
+process rather than a full TTL: when the elevator switches into a tenant whose
+container the adapter recognizes as gone, it evicts the name locally and routes
+through the not-found handler (a 404), instead of surfacing the pre-existing
+database error (a 500). So a cross-process drop self-heals on the *first*
+request that names it on each process — the same latency profile as a create —
+and the failure during that one request is a 404, not a 500. Mechanics:
+
+- The elevator wraps `Tenant.switch { @app.call }` and rescues only the error
+  classes the adapter declares via `failsafe_error_classes`. On such an error it
+  asks `adapter.tenant_container_gone?(error, name)`, which pairs a cheap
+  error-shape check with an **authoritative existence probe** (for PG schemas,
+  `to_regnamespace` on the default connection). Only a *confirmed*-missing
+  container converts to a 404 and evicts; anything else — a missing table in a
+  live tenant, a connection failure — re-raises unchanged. A confirmed drop also
+  calls `TenantValidator#evict`, so subsequent requests on that process 404
+  without re-querying the gone container.
+- The probe runs on the **default** connection: `Tenant.switch`'s ensure-block
+  has already restored `Current.tenant` before the rescue runs, so the catalog
+  lookup targets the default pool, not the gone tenant.
+- This is engine-specific. PostgreSQL schema strategy implements it; the other
+  adapters inherit a conservative default (`failsafe_error_classes == []`) that
+  disables the rescue, so a drop on those engines still lingers until the TTL
+  until their override lands. The fail-safe never converts an error it cannot
+  positively classify, and degrades to a plain switch when the adapter cannot be
+  resolved.
+
+The fail-safe heals *drops* reactively but it is not cross-process
+*synchronization*: a process that never receives a request for a dropped tenant
+keeps the stale positive until its TTL (harmless — nothing routes to it). Strict,
+immediate, proactive cross-process enforcement is a separate concern (issue #414):
 
 The gem ships **no cache backend**. An app needing strict cross-process
 consistency plugs a custom `tenant_validator` backed by a **dedicated,

--- a/docs/designs/elevator-tenant-validation.md
+++ b/docs/designs/elevator-tenant-validation.md
@@ -193,6 +193,18 @@ and the failure during that one request is a 404, not a 500. Mechanics:
   until their override lands. The fail-safe never converts an error it cannot
   positively classify, and degrades to a plain switch when the adapter cannot be
   resolved.
+- Eviction is best-effort: a `tenant_validator` of `false` or a custom callable
+  with no `#evict` still gets the 404 for a confirmed-gone tenant; only the
+  built-in validator's positive set is updated.
+
+**Limitation — errors during `@app.call`, not deferred body enumeration.** The
+rescue wraps `@app.call`, so it only sees errors raised while the app *builds*
+the response. A lazy/streaming Rack body (`ActionController::Live`, an
+enumerator) is enumerated by the server *after* `@app.call` returns — by which
+point `switch`'s ensure-block has already restored `Current.tenant`, so a query
+during body streaming is outside both the tenant context and this rescue. Such a
+case surfaces as the pre-existing error, not a 404. This matches the broader v4
+streaming caveat; the fail-safe does not change it.
 
 The fail-safe heals *drops* reactively but it is not cross-process
 *synchronization*: a process that never receives a request for a dropped tenant

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -106,7 +106,7 @@ module Apartment
         false
       end
 
-      # Request-path fail-safe contract (issue #414). The elevator wraps the
+      # Request-path fail-safe contract. The elevator wraps the
       # tenant switch; on one of these error classes it asks
       # #tenant_container_gone? whether the tenant's storage actually vanished (a
       # cross-process drop) rather than an app-level failure. An empty list
@@ -215,7 +215,7 @@ module Apartment
 
       private
 
-      # --- Missing-tenant fail-safe seams (issue #414) ------------------------
+      # --- Missing-tenant fail-safe seams -------------------------------------
 
       # Does +error+ look like a missing-container error for this engine?
       # Base: never, so the default adapter classifies nothing.

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -106,6 +106,28 @@ module Apartment
         false
       end
 
+      # Request-path fail-safe contract (issue #414). The elevator wraps the
+      # tenant switch; on one of these error classes it asks
+      # #tenant_container_gone? whether the tenant's storage actually vanished (a
+      # cross-process drop) rather than an app-level failure. An empty list
+      # disables the rescue, so an adapter that does not implement the seams
+      # never converts an error into a 404.
+      def failsafe_error_classes
+        []
+      end
+
+      # Whether +error+, raised while serving +tenant+, means the tenant's
+      # container (schema/database/file) no longer exists — so the validator
+      # should evict the name and the request should 404 instead of surfacing a
+      # 500. Composed from a cheap error-shape check and an authoritative
+      # existence probe, both conservative by default so the base adapter never
+      # reclassifies. Subclasses override the seams.
+      def tenant_container_gone?(error, tenant)
+        return false unless container_error?(unwrap_db_error(error))
+
+        !tenant_container_exists?(tenant)
+      end
+
       # Qualify a pinned model's table_name so it targets the default
       # tenant's tables from any tenant connection. Subclasses must
       # implement when shared_pinned_connection? returns true.
@@ -192,6 +214,28 @@ module Apartment
       end
 
       private
+
+      # --- Missing-tenant fail-safe seams (issue #414) ------------------------
+
+      # Does +error+ look like a missing-container error for this engine?
+      # Base: never, so the default adapter classifies nothing.
+      def container_error?(_error)
+        false
+      end
+
+      # Authoritative check that the tenant's container exists. Base: assume it
+      # does, so an unimplemented adapter never evicts a live tenant.
+      def tenant_container_exists?(_tenant)
+        true
+      end
+
+      # ConnectionHandling wraps non-Apartment errors raised during pool
+      # resolution in Apartment::ApartmentError with the original as #cause; the
+      # schema-strategy query error arrives unwrapped. Inspect the cause when
+      # present so both shapes classify the same.
+      def unwrap_db_error(error)
+        error.is_a?(Apartment::ApartmentError) && error.cause ? error.cause : error
+      end
 
       def grant_tenant_privileges(tenant)
         app_role = Apartment.config.app_role

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -43,7 +43,7 @@ module Apartment
       # surfaces on the first query as ActiveRecord::StatementInvalid
       # (PG::UndefinedTable, 42P01). That is the same shape as a missing table in
       # a *live* schema, so #tenant_container_exists? does the disambiguating
-      # to_regnamespace check. See issue #414.
+      # to_regnamespace check.
       def failsafe_error_classes
         [ActiveRecord::StatementInvalid]
       end

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -38,6 +38,16 @@ module Apartment
         config.merge('schema_search_path' => search_path)
       end
 
+      # The schema-strategy missing-tenant error: a dropped schema is not caught
+      # at switch time (search_path accepts a non-existent schema silently) — it
+      # surfaces on the first query as ActiveRecord::StatementInvalid
+      # (PG::UndefinedTable, 42P01). That is the same shape as a missing table in
+      # a *live* schema, so #tenant_container_exists? does the disambiguating
+      # to_regnamespace check. See issue #414.
+      def failsafe_error_classes
+        [ActiveRecord::StatementInvalid]
+      end
+
       protected
 
       def create_tenant(tenant)
@@ -51,6 +61,27 @@ module Apartment
       end
 
       private
+
+      # Any StatementInvalid is a candidate; the authoritative call is the
+      # existence probe below, so a missing table in a live schema (same 42P01)
+      # correctly re-raises rather than 404ing.
+      def container_error?(error)
+        error.is_a?(ActiveRecord::StatementInvalid)
+      end
+
+      # Authoritative existence check, run on the DEFAULT connection: the
+      # elevator's switch ensure-block has already restored Current.tenant before
+      # the fail-safe rescue runs, so ActiveRecord::Base.connection targets the
+      # default pool rather than the gone tenant. to_regnamespace returns NULL for
+      # a missing schema. If the probe itself errors (e.g. the database is down),
+      # we cannot prove the schema is gone — report it as existing so the original
+      # error re-raises instead of masking infrastructure failure as a 404.
+      def tenant_container_exists?(tenant)
+        conn = ActiveRecord::Base.connection
+        conn.select_value("SELECT to_regnamespace(#{conn.quote(tenant)}) IS NOT NULL")
+      rescue StandardError
+        true
+      end
 
       def grant_privileges(tenant, connection, role_name) # rubocop:disable Metrics/MethodLength
         quoted_schema = connection.quote_table_name(tenant)

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -44,8 +44,14 @@ module Apartment
       # (PG::UndefinedTable, 42P01). That is the same shape as a missing table in
       # a *live* schema, so #tenant_container_exists? does the disambiguating
       # to_regnamespace check.
+      #
+      # ApartmentError is included because ConnectionHandling wraps errors raised
+      # during pool resolution (e.g. the dev-mode pending-migration check, which
+      # queries schema_migrations in the gone schema) as ApartmentError with the
+      # StatementInvalid as #cause; #container_error? then unwraps and classifies
+      # it the same as the query-time case, and re-raises any other ApartmentError.
       def failsafe_error_classes
-        [ActiveRecord::StatementInvalid]
+        [ActiveRecord::StatementInvalid, Apartment::ApartmentError]
       end
 
       protected

--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -67,7 +67,12 @@ module Apartment
         rescue *classes => e
           raise unless adapter.tenant_container_gone?(e, tenant)
 
-          Apartment.tenant_validator.evict(tenant)
+          # Eviction is best-effort: config.tenant_validator may be `false` (a
+          # bare always-valid lambda) or a custom callable with no #evict. The
+          # 404 for a confirmed-gone tenant stands regardless; only the built-in
+          # validator's positive set is memoized.
+          validator = Apartment.tenant_validator
+          validator.evict(tenant) if validator.respond_to?(:evict)
           handle_tenant_not_found(tenant, request)
         end
       end

--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -56,7 +56,7 @@ module Apartment
       # validator), evict the name from this process and route through the
       # not-found path — turning a lingering-drop 500 into a 404. Any other
       # error, including an app-raised one, re-raises untouched. Adapters that
-      # declare no failsafe error classes skip the rescue entirely. See #414.
+      # declare no failsafe error classes skip the rescue entirely.
       def switch_with_failsafe(tenant, request, &)
         adapter = resolve_adapter
         classes = adapter&.failsafe_error_classes
@@ -75,10 +75,12 @@ module Apartment
       # The memoized adapter, or nil when it cannot be resolved (Apartment
       # unconfigured, or no database connection yet). A nil adapter disables the
       # fail-safe — the switch runs plain, preserving today's behavior — so the
-      # elevator never fails trying to *set up* the fail-safe.
+      # elevator never fails trying to *set up* the fail-safe. The rescue is
+      # scoped to the setup-time failures (unconfigured, or no connection yet) —
+      # a genuine bug in adapter resolution is left to surface, not swallowed.
       def resolve_adapter
         Apartment.adapter
-      rescue StandardError
+      rescue Apartment::ApartmentError, ActiveRecord::ConnectionNotEstablished
         nil
       end
 

--- a/lib/apartment/elevators/generic.rb
+++ b/lib/apartment/elevators/generic.rb
@@ -29,7 +29,7 @@ module Apartment
         return @app.call(env) if database.nil?
         return handle_tenant_not_found(database, request) unless tenant_valid?(database)
 
-        Apartment::Tenant.switch(database) { @app.call(env) }
+        switch_with_failsafe(database, request) { @app.call(env) }
       end
 
       def parse_tenant_name(_request)
@@ -47,6 +47,39 @@ module Apartment
         return true if database.to_s == config.default_tenant.to_s
 
         Apartment.tenant_validator.call(database)
+      end
+
+      # Switch into +tenant+ and run the app. In v4 the switch is SQL-free, so a
+      # tenant dropped by another process is not detected until the app's first
+      # query fails inside this block. When that error is one the adapter
+      # recognizes as "the tenant container is gone" (a stale positive in the
+      # validator), evict the name from this process and route through the
+      # not-found path — turning a lingering-drop 500 into a 404. Any other
+      # error, including an app-raised one, re-raises untouched. Adapters that
+      # declare no failsafe error classes skip the rescue entirely. See #414.
+      def switch_with_failsafe(tenant, request, &)
+        adapter = resolve_adapter
+        classes = adapter&.failsafe_error_classes
+        return Apartment::Tenant.switch(tenant, &) if classes.blank?
+
+        begin
+          Apartment::Tenant.switch(tenant, &)
+        rescue *classes => e
+          raise unless adapter.tenant_container_gone?(e, tenant)
+
+          Apartment.tenant_validator.evict(tenant)
+          handle_tenant_not_found(tenant, request)
+        end
+      end
+
+      # The memoized adapter, or nil when it cannot be resolved (Apartment
+      # unconfigured, or no database connection yet). A nil adapter disables the
+      # fail-safe — the switch runs plain, preserving today's behavior — so the
+      # elevator never fails trying to *set up* the fail-safe.
+      def resolve_adapter
+        Apartment.adapter
+      rescue StandardError
+        nil
       end
 
       # Route an unknown tenant through config.tenant_not_found_handler when

--- a/lib/apartment/tenant_validator.rb
+++ b/lib/apartment/tenant_validator.rb
@@ -51,6 +51,16 @@ module Apartment
     end
     alias valid? call
 
+    # Remove a name from the positive set immediately. The request-path
+    # fail-safe (the elevator's missing-tenant rescue) calls this when a switch
+    # hits a container that no longer exists, so this process stops validating a
+    # tenant dropped by another process before its TTL would otherwise heal it.
+    # Mid-rebuild evictions are captured as deltas and re-applied after the swap,
+    # mirroring drop.apartment handling, so the rebuild cannot resurrect the name.
+    def evict(name)
+      apply_lifecycle(:remove, name)
+    end
+
     private
 
     def stale?

--- a/spec/integration/v4/postgresql_schema_spec.rb
+++ b/spec/integration/v4/postgresql_schema_spec.rb
@@ -210,6 +210,19 @@ RSpec.describe('v4 PostgreSQL schema integration', :integration,
       e
     end
 
+    # Wrap a cause in Apartment::ApartmentError, mirroring how ConnectionHandling
+    # re-raises pool-resolution failures (the dropped-schema error can surface
+    # there, wrapped, in dev when check_pending_migrations queries the gone schema).
+    def wrapped_in_apartment_error(cause)
+      begin
+        raise(cause)
+      rescue StandardError
+        raise(Apartment::ApartmentError, 'Failed to resolve connection pool')
+      end
+    rescue Apartment::ApartmentError => e
+      e
+    end
+
     it 'distinguishes a dropped schema (gone) from a live one (a real app error)' do
       Apartment.adapter.create('failsafe_live')
       Apartment.adapter.create('failsafe_gone')
@@ -221,6 +234,21 @@ RSpec.describe('v4 PostgreSQL schema integration', :integration,
       adapter = Apartment.adapter
       expect(adapter.tenant_container_gone?(undefined_table_error, 'failsafe_gone')).to(be(true))
       expect(adapter.tenant_container_gone?(undefined_table_error, 'failsafe_live')).to(be(false))
+    end
+
+    it 'classifies a StatementInvalid wrapped in ApartmentError (pool-resolution path)' do
+      Apartment.adapter.create('failsafe_wrapped')
+      created_tenants << 'failsafe_wrapped'
+      ActiveRecord::Base.connection.execute('DROP SCHEMA "failsafe_wrapped" CASCADE')
+      wrapped = wrapped_in_apartment_error(undefined_table_error)
+
+      expect(wrapped.cause).to(be_a(ActiveRecord::StatementInvalid)) # sanity: cause preserved
+      expect(Apartment.adapter.tenant_container_gone?(wrapped, 'failsafe_wrapped')).to(be(true))
+    end
+
+    it 're-raises an ApartmentError that does not wrap a container error' do
+      bare = Apartment::PendingMigrationError.new('acme')
+      expect(Apartment.adapter.tenant_container_gone?(bare, 'acme')).to(be(false))
     end
 
     it 'returns 404 (TenantNotFound) instead of 500 when the elevator switches to a dropped schema' do

--- a/spec/integration/v4/postgresql_schema_spec.rb
+++ b/spec/integration/v4/postgresql_schema_spec.rb
@@ -241,7 +241,9 @@ RSpec.describe('v4 PostgreSQL schema integration', :integration,
       app = ->(_env) { [200, {}, [ActiveRecord::Base.connection.select_value('SELECT 1 FROM some_table').to_s]] }
       elevator = Apartment::Elevators::Generic.new(app, ->(_req) { 'failsafe_req' })
 
-      expect { elevator.call(Rack::MockRequest.env_for('http://failsafe_req.example.com/')) }
+      # The processor hardcodes the tenant, so the host is irrelevant — keep it a
+      # valid hostname (rack 3.2+ rejects underscores in the registry part).
+      expect { elevator.call(Rack::MockRequest.env_for('http://example.com/')) }
         .to(raise_error(Apartment::TenantNotFound, /failsafe_req/))
       # The stale positive is evicted, so the next request 404s without re-querying the gone schema.
       expect(Apartment.tenant_validator.call('failsafe_req')).to(be(false))

--- a/spec/integration/v4/postgresql_schema_spec.rb
+++ b/spec/integration/v4/postgresql_schema_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'rack'
+require 'rack/mock'
 require_relative 'support'
 
 RSpec.describe('v4 PostgreSQL schema integration', :integration,
@@ -193,6 +195,56 @@ RSpec.describe('v4 PostgreSQL schema integration', :integration,
     Apartment::Tenant.switch('indie_b') do
       names = ActiveRecord::Base.connection.select_values('SELECT name FROM widgets ORDER BY name')
       expect(names).to(eq(%w[beta]))
+    end
+  end
+
+  # Issue #414: a tenant dropped by another process lingers as a stale positive
+  # in this process's validator until its TTL. The switch then proceeds and the
+  # first query hits a missing schema. The fail-safe turns that 500 into a 404.
+  describe 'missing-tenant fail-safe' do
+    # A real StatementInvalid (PG::UndefinedTable / 42P01) from the default
+    # connection — the same error class a dropped-schema query raises.
+    def undefined_table_error
+      ActiveRecord::Base.connection.select_value('SELECT 1 FROM definitely_missing_xyz')
+    rescue ActiveRecord::StatementInvalid => e
+      e
+    end
+
+    it 'distinguishes a dropped schema (gone) from a live one (a real app error)' do
+      Apartment.adapter.create('failsafe_live')
+      Apartment.adapter.create('failsafe_gone')
+      created_tenants.push('failsafe_live', 'failsafe_gone')
+      # Simulate a cross-process drop: remove the schema WITHOUT notifying this
+      # process's validator, so to_regnamespace is the only ground truth.
+      ActiveRecord::Base.connection.execute('DROP SCHEMA "failsafe_gone" CASCADE')
+
+      adapter = Apartment.adapter
+      expect(adapter.tenant_container_gone?(undefined_table_error, 'failsafe_gone')).to(be(true))
+      expect(adapter.tenant_container_gone?(undefined_table_error, 'failsafe_live')).to(be(false))
+    end
+
+    it 'returns 404 (TenantNotFound) instead of 500 when the elevator switches to a dropped schema' do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.default_tenant = 'public'
+        c.tenants_provider = -> { ['failsafe_req'] } # validator sees it as valid (stale positive)
+        c.check_pending_migrations = false
+      end
+      config = V4IntegrationHelper.default_connection_config(tmp_dir: tmp_dir)
+      Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+      Apartment.activate!
+
+      Apartment.adapter.create('failsafe_req')
+      created_tenants << 'failsafe_req'
+      ActiveRecord::Base.connection.execute('DROP SCHEMA "failsafe_req" CASCADE') # out-of-band drop
+
+      app = ->(_env) { [200, {}, [ActiveRecord::Base.connection.select_value('SELECT 1 FROM some_table').to_s]] }
+      elevator = Apartment::Elevators::Generic.new(app, ->(_req) { 'failsafe_req' })
+
+      expect { elevator.call(Rack::MockRequest.env_for('http://failsafe_req.example.com/')) }
+        .to(raise_error(Apartment::TenantNotFound, /failsafe_req/))
+      # The stale positive is evicted, so the next request 404s without re-querying the gone schema.
+      expect(Apartment.tenant_validator.call('failsafe_req')).to(be(false))
     end
   end
 end

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -219,6 +219,18 @@ RSpec.describe(Apartment::Elevators::Generic) do
       expect(elevator.call(env)).to(eq([404, {}, ['gone: acme']]))
     end
 
+    it 'still 404s without evicting when the validator cannot evict (validation disabled / custom callable)' do
+      stub_adapter(gone: true)
+      # config.tenant_validator = false resolves to a bare lambda with no #evict;
+      # the fail-safe must still convert the confirmed drop to a 404, not raise
+      # NoMethodError trying to evict.
+      allow(Apartment).to(receive(:tenant_validator).and_return(->(_name) { true }))
+      allow(Apartment::Tenant).to(receive(:switch).with('acme').and_raise(db_error_class, 'schema gone'))
+      elevator = described_class.new(app, ->(_req) { 'acme' })
+
+      expect { elevator.call(env) }.to(raise_error(Apartment::TenantNotFound, /acme/))
+    end
+
     it 're-raises the original error when the container still exists (not a drop)' do
       stub_adapter(gone: false)
       allow(Apartment::Tenant).to(receive(:switch).with('acme').and_raise(db_error_class, 'real bug'))

--- a/spec/unit/elevators/generic_spec.rb
+++ b/spec/unit/elevators/generic_spec.rb
@@ -166,4 +166,84 @@ RSpec.describe(Apartment::Elevators::Generic) do
       expect(received).to(eq('resolved-name'))
     end
   end
+
+  # The validator can hold a stale positive after another process drops a
+  # tenant; the switch then proceeds and the app's first query blows up. The
+  # fail-safe catches an adapter-classified "container gone" error, evicts the
+  # name from this process, and routes through the not-found path — turning a
+  # lingering-drop 500 into a 404. See issue #414.
+  describe 'missing-tenant fail-safe' do
+    let(:app) { ->(_env) { [200, {}, ['ok']] } }
+    let(:env) { Rack::MockRequest.env_for('http://acme.example.com/') }
+    # Stand-in for an adapter-specific "container gone" error class.
+    let(:db_error_class) { Class.new(StandardError) }
+    let(:validator) { instance_double(Apartment::TenantValidator, call: true, evict: nil) }
+
+    before do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.default_tenant = 'public'
+        c.tenants_provider = -> { %w[acme] }
+      end
+      allow(Apartment).to(receive(:tenant_validator).and_return(validator))
+    end
+
+    def stub_adapter(gone:)
+      adapter = instance_double(Apartment::Adapters::AbstractAdapter,
+                                failsafe_error_classes: [db_error_class])
+      allow(adapter).to(receive(:tenant_container_gone?).and_return(gone))
+      allow(Apartment).to(receive(:adapter).and_return(adapter))
+      adapter
+    end
+
+    it 'evicts and routes through the not-found path on a confirmed missing container' do
+      stub_adapter(gone: true)
+      allow(Apartment::Tenant).to(receive(:switch).with('acme').and_raise(db_error_class, 'schema gone'))
+      elevator = described_class.new(app, ->(_req) { 'acme' })
+
+      expect { elevator.call(env) }.to(raise_error(Apartment::TenantNotFound, /acme/))
+      expect(validator).to(have_received(:evict).with('acme'))
+    end
+
+    it 'returns the tenant_not_found_handler response on a confirmed missing container' do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.default_tenant = 'public'
+        c.tenants_provider = -> { %w[acme] }
+        c.tenant_not_found_handler = ->(tenant, _request) { [404, {}, ["gone: #{tenant}"]] }
+      end
+      stub_adapter(gone: true)
+      allow(Apartment::Tenant).to(receive(:switch).with('acme').and_raise(db_error_class, 'schema gone'))
+      elevator = described_class.new(app, ->(_req) { 'acme' })
+
+      expect(elevator.call(env)).to(eq([404, {}, ['gone: acme']]))
+    end
+
+    it 're-raises the original error when the container still exists (not a drop)' do
+      stub_adapter(gone: false)
+      allow(Apartment::Tenant).to(receive(:switch).with('acme').and_raise(db_error_class, 'real bug'))
+      elevator = described_class.new(app, ->(_req) { 'acme' })
+
+      expect { elevator.call(env) }.to(raise_error(db_error_class, 'real bug'))
+      expect(validator).not_to(have_received(:evict))
+    end
+
+    it 'does not classify errors outside the adapter failsafe set' do
+      adapter = stub_adapter(gone: true)
+      allow(Apartment::Tenant).to(receive(:switch).with('acme').and_raise(RuntimeError, 'unrelated'))
+      elevator = described_class.new(app, ->(_req) { 'acme' })
+
+      expect { elevator.call(env) }.to(raise_error(RuntimeError, 'unrelated'))
+      expect(adapter).not_to(have_received(:tenant_container_gone?))
+    end
+
+    it 'leaves the happy path unwrapped when the adapter declares no failsafe errors' do
+      adapter = instance_double(Apartment::Adapters::AbstractAdapter, failsafe_error_classes: [])
+      allow(Apartment).to(receive(:adapter).and_return(adapter))
+      allow(Apartment::Tenant).to(receive(:switch).with('acme').and_yield)
+      elevator = described_class.new(app, ->(_req) { 'acme' })
+
+      expect(elevator.call(env)).to(eq([200, {}, ['ok']]))
+    end
+  end
 end

--- a/spec/unit/tenant_validator_spec.rb
+++ b/spec/unit/tenant_validator_spec.rb
@@ -119,6 +119,38 @@ RSpec.describe(Apartment::TenantValidator) do
     end
   end
 
+  describe '#evict' do
+    it 'removes a tenant from the positive set so it no longer validates' do
+      configure(-> { %w[acme widgets] })
+      # A long rebuild interval keeps rebuild-on-miss from immediately
+      # re-adding the name from the (still-listing) provider, isolating the
+      # eviction's effect — the fail-safe relies on this to 404 a just-dropped
+      # tenant in the window before a rebuild reconciles with the source.
+      validator = build_validator(rebuild_interval: 3600)
+      expect(validator.call('widgets')).to(be(true))
+      validator.evict('widgets')
+      expect(validator.call('widgets')).to(be(false))
+    end
+
+    it 'preserves an eviction that lands mid-rebuild' do
+      provider_running = Queue.new
+      finish_provider = Queue.new
+      configure(lambda {
+        provider_running << true
+        finish_provider.pop
+        %w[acme widgets] # the provider snapshot still lists widgets
+      })
+      validator = build_validator(rebuild_interval: 3600)
+      builder = Thread.new { validator.call('acme') }
+      provider_running.pop # the rebuild is inside provider.call
+      validator.evict('widgets')
+      finish_provider << true
+      builder.join
+
+      expect(validator.call('widgets')).to(be(false))
+    end
+  end
+
   describe 'fail-open on source error' do
     it 'allows any name when tenants_provider raises' do
       configure(-> { raise(StandardError, 'provider down') })


### PR DESCRIPTION
## What

Closes the drop half of the `TenantValidator` cross-process gap (#414) for the PostgreSQL schema strategy. In multi-process deployments the validator's positive set can hold a tenant another process has dropped, until its TTL; the switch then proceeds (v4 switch is SQL-free) and the app's first query surfaces a missing-schema error as a **500** — a regression from the "unknown tenant → 404" goal.

The elevator now wraps the switch and, on an adapter-declared error class, asks the adapter whether the tenant's container is actually gone. A confirmed drop **evicts the name** from this process's validator and routes through the not-found handler (**404**); anything else — a missing table in a live tenant, a connection failure — re-raises unchanged. This bounds drop-staleness to **one request per process** (the same profile as create healing) instead of a full TTL.

## How

- **`TenantValidator#evict(name)`** — public eviction; handles the mid-rebuild delta case so a rebuild can't resurrect the name.
- **`Generic#switch_with_failsafe`** — reactive rescue scoped to `adapter.failsafe_error_classes`; on a confirmed drop, evict + not-found path; degrades to a plain switch when the adapter can't be resolved (unconfigured / no DB), preserving today's behavior.
- **`AbstractAdapter` contract** — `failsafe_error_classes` + `tenant_container_gone?` composing `container_error?` (cheap shape check) and `tenant_container_exists?` (authoritative probe). Conservative defaults: an empty class list disables the rescue, so unimplemented engines never reclassify.
- **`PostgresqlSchemaAdapter` override** — `StatementInvalid` candidate confirmed by a `to_regnamespace` probe on the **default** connection (`switch`'s ensure-block has restored `Current.tenant` before the rescue runs). This is the only authoritative way to tell a dropped schema from a missing table in a live one — both surface as `42P01`.

## Design decision

This is **Option A** (reactive rescue) from the issue thread. In v4 the dropped-tenant error always fires inside `@app.call` (switch is SQL-free, connection is lazy), so there is no switch-time signal — catching it requires wrapping `@app.call`, kept safe by the strict classifier (only a `to_regnamespace`-confirmed missing schema converts to a 404). The PG silent-`public`-fallback hazard does **not** arise on the default search_path (tenant-only; `public` is the default_tenant, not in the path), so a rescue-only fail-safe is sufficient here.

## Scope

PostgreSQL **schema** strategy only. MySQL, PG-database, and SQLite inherit the conservative default (`failsafe_error_classes == []` → no rescue), so their behavior is **unchanged** pending per-engine overrides (`NoDatabaseError` for the db-per-tenant engines, `File.exist?` for SQLite) — tracked as follow-ups on #414. The opt-in cross-process transport seam remains deferred.

## Testing

- Unit: `TenantValidator#evict` (incl. mid-rebuild), elevator fail-safe (confirmed-gone → evict + 404, handler variant, not-gone → re-raise, non-failsafe error untouched, no-failsafe-classes happy path), abstract-adapter contract. Full unit suite: **820 examples, 0 failures**.
- Integration (**verified against local PostgreSQL**): adapter-level `to_regnamespace` disambiguation (dropped schema → gone; live schema + missing-table error → not gone) and end-to-end elevator flow (request to a dropped schema → `TenantNotFound`/404 + stale positive evicted). Request-lifecycle / switching / lifecycle suites green.
- Rubocop clean on all changed files.

Relates to #414. Caching concern split out to #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)