### PR TITLE
Ship Apartment RuboCop cops (block-form switching discipline)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,25 @@ plugins:
   - rubocop-rake
   - rubocop-rspec
 
+# Apartment's own shipped cops. require uses a repo-relative path because the
+# gem's lib is not on RuboCop's load path when linting in-repo; downstream apps
+# use `require: rubocop/apartment` (the installed gem's lib is on the load path).
+require:
+  - ./lib/rubocop/apartment
+
+inherit_from:
+  - config/default.yml
+
+Apartment/NoDirectCurrentWrite:
+  Exclude:
+    - lib/apartment/**/*
+    - spec/**/*
+
+Apartment/PreferBlockSwitch:
+  Exclude:
+    - lib/apartment/**/*
+    - spec/**/*
+
 Gemspec/RequiredRubyVersion:
   Exclude:
     - 'ros-apartment.gemspec'

--- a/README.md
+++ b/README.md
@@ -373,6 +373,28 @@ If tenant switching raises unexpected errors, verify that `tenants_provider` ret
 
 See the [upgrade guide](docs/upgrading-to-v4.md) for a complete list of breaking changes and migration steps.
 
+## RuboCop cops
+
+Apartment ships two optional RuboCop cops that enforce the block-form
+tenant-switching discipline. Enable them in your application's `.rubocop.yml`:
+
+```yaml
+require: rubocop/apartment
+inherit_gem:
+  ros-apartment: config/default.yml
+```
+
+- **`Apartment/NoDirectCurrentWrite`** (error) — bans assigning
+  `Apartment::Current.tenant` / `.previous_tenant` directly. Change tenant context
+  with `Apartment::Tenant.switch(tenant) { ... }` (or `with_default_tenant` for
+  global work), which guarantees a restore via `ensure`.
+- **`Apartment/PreferBlockSwitch`** (warning) — nudges `Apartment::Tenant.switch!`
+  toward the block form. `reset` is not flagged.
+
+Both match the qualified `Apartment::` receiver only. Scope them to your
+application code with the standard `Exclude:` keys if needed. See
+[`docs/designs/rubocop-cops.md`](docs/designs/rubocop-cops.md) for the rationale.
+
 ## Contributing
 
 1. Check [existing issues](https://github.com/rails-on-services/apartment/issues) and [discussions](https://github.com/rails-on-services/apartment/discussions)

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,9 @@
+Apartment/NoDirectCurrentWrite:
+  Description: 'Use the block-form switch instead of writing Apartment::Current directly.'
+  Enabled: true
+  Severity: error
+
+Apartment/PreferBlockSwitch:
+  Description: 'Prefer the block-form Apartment::Tenant.switch over switch!.'
+  Enabled: true
+  Severity: warning

--- a/docs/designs/rubocop-cops.md
+++ b/docs/designs/rubocop-cops.md
@@ -86,6 +86,15 @@ with_default_tenant for global work)."`
 No autocorrect: the fix wraps surrounding code in a block, which a cop cannot
 synthesize safely.
 
+Covers plain assignment (`=`) and operator assignment (`||=`, `&&=`, `+=` — these
+parse as `or_asgn`/`and_asgn`/`op_asgn` around a reader send, so the cop adds
+`on_or_asgn`/`on_and_asgn`/`on_op_asgn` handlers alongside `on_send`). `||=` is the
+idiomatic "set tenant if unset" and was the most plausible bypass of an
+`=`-only matcher. **Documented limitations** (deliberately not chased — they signal
+deliberate evasion, not ordinary style): multiple assignment, safe navigation
+(`&.tenant=`), dynamic dispatch (`public_send(:tenant=, …)`), the bulk mutators
+`Apartment::Current.set(…)` / `.reset`, and aliased receivers.
+
 #### `Apartment/PreferBlockSwitch` (warning, no autocorrect)
 
 Flags `Apartment::Tenant.switch!(…)`. Does **not** flag `reset` (the sanctioned

--- a/docs/designs/rubocop-cops.md
+++ b/docs/designs/rubocop-cops.md
@@ -1,0 +1,208 @@
+# Apartment RuboCop cops
+
+**Status:** Designed, pending implementation
+**Scope:** Two shippable custom cops + packaging, config, docs, specs
+**Related:** [[tenant-aware-caching]] (the block-form discipline these cops enforce), `lib/apartment/tenant.rb`
+
+## TL;DR
+
+Ship two custom RuboCop cops in the gem so downstream apps can enforce the
+block-form tenant-switching discipline. `Apartment/NoDirectCurrentWrite` (error)
+bans assigning `Apartment::Current.tenant` / `.previous_tenant` directly;
+`Apartment/PreferBlockSwitch` (warning) nudges `Apartment::Tenant.switch!` toward
+the block form `switch(tenant) { … }`. Neither is a deprecation or an API change —
+the goal is to make the anti-patterns visible (and, for direct writes, blocking) at
+lint time. Apartment's own suite exempts `lib/apartment/` (the legitimate writers)
+and `spec/`.
+
+## Motivation
+
+The block form `Apartment::Tenant.switch(tenant) { … }` is the only context change
+with a guaranteed `ensure` restore — every correctness argument in the gem leans on
+it. Two ways to subvert it remain reachable:
+
+- **Raw `Apartment::Current.tenant = "x"`** — bypasses the primitive entirely; no
+  restore, no guard. There is no legitimate reason for application code to do this.
+- **`Apartment::Tenant.switch!("x")`** — sets context with no block and no restore;
+  documented as "discouraged" but nothing enforces it.
+
+Linting is the right altitude: a documented "always use the block form" discipline
+is exactly the kind of rule a cop encodes, and shipping the cops lets every
+consumer opt in rather than re-deriving the rule. This is deliberately *not* a
+runtime deprecation of `switch!` (still used by `reset` and in tests) — only a
+lint-time nudge, plus a hard stop on raw `Current` writes.
+
+## Design
+
+### Packaging — shipped in the gem
+
+```
+lib/rubocop/apartment.rb                               # entry point: requires both cops
+lib/rubocop/cop/apartment/no_direct_current_write.rb   # RuboCop::Cop::Apartment::NoDirectCurrentWrite
+lib/rubocop/cop/apartment/prefer_block_switch.rb       # RuboCop::Cop::Apartment::PreferBlockSwitch
+config/default.yml                                     # cop defaults (Enabled/Severity/Description)
+spec/unit/rubocop/cop/apartment/
+  no_direct_current_write_spec.rb
+  prefer_block_switch_spec.rb
+```
+
+- **Ship via gemspec**: `s.files` currently globs `git ls-files -- lib`; `config/`
+  is outside `lib/`, so add `config/default.yml` (and `config/**/*.yml`) to
+  `s.files`. The `lib/rubocop/**` files ship automatically.
+- **Zeitwerk ignore**: `lib/apartment.rb` builds the loader with
+  `Zeitwerk::Loader.for_gem`, rooted at `lib/`. Add
+  `loader.ignore("#{__dir__}/rubocop")` so Zeitwerk does not try to autoload the
+  cops as `Rubocop::…` (wrong casing vs `RuboCop`). Same rationale and pattern as
+  the existing `cli.rb` / `cli` ignores. The cops load only via RuboCop's
+  `require:`, never through Apartment's autoloader.
+
+### The two cops
+
+Both match the **qualified** receiver only (`Apartment::Current`,
+`Apartment::Tenant`, with or without leading `::`). Downstream app code always
+qualifies; matching the qualified form avoids false positives on unrelated
+`Current` / `Tenant` constants. Apartment's own bare `Current.tenant =` / `switch!`
+live in `lib/apartment/`, which is exempted by config (below).
+
+#### `Apartment/NoDirectCurrentWrite` (error, no autocorrect)
+
+Flags assignment to `Apartment::Current.tenant=` and
+`Apartment::Current.previous_tenant=`.
+
+```ruby
+# bad — flagged
+Apartment::Current.tenant = "acme"
+Apartment::Current.previous_tenant = nil
+
+# good
+Apartment::Tenant.switch("acme") { … }   # routed work
+Apartment::Tenant.with_default_tenant { … }   # pinned/global work
+```
+
+Message: `"Don't assign Apartment::Current.%<attr>s directly; change tenant
+context with the block form Apartment::Tenant.switch(tenant) { … } (or
+with_default_tenant for global work)."`
+
+No autocorrect: the fix wraps surrounding code in a block, which a cop cannot
+synthesize safely.
+
+#### `Apartment/PreferBlockSwitch` (warning, no autocorrect)
+
+Flags `Apartment::Tenant.switch!(…)`. Does **not** flag `reset` (the sanctioned
+unguarded path) or the block-form `switch`.
+
+```ruby
+# warned
+Apartment::Tenant.switch!("acme")
+
+# good
+Apartment::Tenant.switch("acme") { … }
+```
+
+Message: `"Prefer the block form Apartment::Tenant.switch(tenant) { … }; switch!
+sets context with no guaranteed restore."`
+
+Warning severity: visible in editors and review, does not fail CI. The intended
+"soft but effective" nudge, not a gate.
+
+### Config & enforcement boundaries
+
+`config/default.yml` ships the defaults so a consumer gets turnkey behavior:
+
+```yaml
+Apartment/NoDirectCurrentWrite:
+  Description: 'Use the block form switch instead of writing Apartment::Current directly.'
+  Enabled: true
+  Severity: error
+
+Apartment/PreferBlockSwitch:
+  Description: 'Prefer the block form Apartment::Tenant.switch over switch!.'
+  Enabled: true
+  Severity: warning
+```
+
+**The shipped cops are generic** — they carry no knowledge of apartment's directory
+layout and flag the qualified bad forms wherever they appear. *Both* exemptions are
+expressed in **apartment's own `.rubocop.yml`**, not in cop logic: the gem's
+legitimate writers live in `lib/apartment/`, and its test scaffolding in `spec/`.
+
+```yaml
+require:
+  - rubocop/apartment
+inherit_from:
+  - config/default.yml            # apartment's own relative path to its shipped defaults
+Apartment/NoDirectCurrentWrite:
+  Exclude:
+    - lib/apartment/**/*          # the sanctioned primitives (switch/switch!/with_default_tenant/reset)
+    - spec/**/*                   # scaffolding + Current self-tests
+Apartment/PreferBlockSwitch:
+  Exclude:
+    - lib/apartment/**/*          # reset legitimately calls switch!
+    - spec/**/*                   # switch! self-tests live here
+```
+
+Keeping the `lib/apartment/` exemption in config (not cop logic) means the shipped
+cop never false-exempts a downstream app that happens to have a `lib/apartment/`
+path of its own.
+
+**Net internal effect today:** ~0 violations (the only `lib` writers are in
+`lib/apartment/`, excluded; specs excluded). The value is the shipped tool plus a
+preventative guard against future non-core `lib` code.
+
+**Downstream opt-in** (e.g. an application):
+
+```yaml
+require: rubocop/apartment
+inherit_gem:
+  ros-apartment: config/default.yml
+```
+
+### Testing
+
+Cop specs use RuboCop's `expect_offense` / `expect_no_offenses` RSpec matchers
+(available via the `rubocop` test support, already a dev dependency). Each cop:
+
+- flags the qualified bad form (with the correct highlight range and message);
+- ignores the block form and, for `PreferBlockSwitch`, ignores `reset`;
+- ignores unrelated `Current` / `Tenant` constants (e.g. a non-Apartment
+  `Current.tenant = …`);
+- respects `# rubocop:disable Apartment/<Cop>`.
+
+Plus one smoke spec asserting `config/default.yml` loads and registers both cops
+under the `Apartment` department with the expected severities.
+
+The cop specs live under `spec/unit/rubocop/` and run in the normal unit suite
+(`bundle exec rspec spec/unit/`); they require no database.
+
+### Docs
+
+A short **"RuboCop cops"** section in `README.md`: the downstream `require` +
+`inherit_gem` recipe, a one-line statement of what each cop enforces and why, and a
+pointer to this design doc. No design-grade prose in the README — just the opt-in
+recipe.
+
+## Alternatives considered
+
+- **Internal-only cop (outside `lib/`).** Simpler — no Zeitwerk ignore, no gemspec
+  change, no downstream docs — but the cop couldn't be reused by consumers, who
+  would re-implement it. Rejected: the primary value is downstream enforcement.
+- **Ship only the write ban; defer `PreferBlockSwitch`.** Considered, since the
+  `switch!` nudge is softer and was less settled. Folded in because it shares all
+  the cop infrastructure and is the "soft but effective" mechanism the maintainer
+  wanted; warning severity keeps it from gating CI.
+- **Police `spec/` too.** Would force ~60 `Current.tenant =` setups to block-form
+  and flag ~70 `switch!` calls; some specs irreducibly test `Current`/`switch!`
+  directly and would need inline disables. Rejected as scope creep (a large
+  mechanical refactor unrelated to the cop), and consistent with the repo already
+  excluding `spec/` from Metrics cops. A future PR may convert non-`Current` specs.
+- **Hand-configured downstream (no shipped `config/default.yml`).** Avoids the
+  gemspec change but makes consumers write `Enabled`/`Severity` by hand. Rejected:
+  shipping the config is the conventional rubocop-extension experience for one
+  gemspec line.
+- **Runtime deprecation of `switch!`.** Explicitly out of scope — `switch!` is
+  still used by `reset` and is not being removed. The cop is lint-time only.
+
+## Scope guardrails
+
+Branch off `main`. No spec refactor. No `switch!` deprecation or API change. No
+autocorrect on either cop.

--- a/docs/plans/rubocop-cops/plan.md
+++ b/docs/plans/rubocop-cops/plan.md
@@ -1,0 +1,538 @@
+# Apartment RuboCop Cops Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship two custom RuboCop cops in the gem — `Apartment/NoDirectCurrentWrite` (error, bans raw `Apartment::Current` writes) and `Apartment/PreferBlockSwitch` (warning, nudges `switch!` toward the block form) — so downstream apps can enforce the block-form tenant-switching discipline.
+
+**Architecture:** Cops live under `lib/rubocop/cop/apartment/` and ship via the gem (`s.files` extended to include `config/`). A `lib/rubocop/apartment.rb` entry point requires both; `config/default.yml` carries their defaults. `lib/rubocop` is Zeitwerk-ignored (it would map to the wrong-cased `Rubocop` constant). The cops are generic (match the qualified `Apartment::Current` / `Apartment::Tenant` receiver only); both exemptions (`lib/apartment/`, `spec/`) live in apartment's own `.rubocop.yml`, not in cop logic.
+
+**Tech Stack:** Ruby, RuboCop 1.86 + rubocop-ast (node-pattern matchers, `RuboCop::Cop::Base`), RSpec with `RuboCop::RSpec::ExpectOffense`. Cop specs need no database.
+
+**Design spec:** `docs/designs/rubocop-cops.md`
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `lib/apartment.rb` | Modify | Add `loader.ignore("#{__dir__}/rubocop")` (Zeitwerk) |
+| `lib/rubocop/cop/apartment/no_direct_current_write.rb` | Create | The error cop |
+| `lib/rubocop/cop/apartment/prefer_block_switch.rb` | Create | The warning cop |
+| `lib/rubocop/apartment.rb` | Create | Entry point: requires both cops |
+| `config/default.yml` | Create | Cop defaults (Enabled/Severity/Description) |
+| `ros-apartment.gemspec` | Modify | Ship `config/` in `s.files` |
+| `.rubocop.yml` | Modify | Load the cops, inherit defaults, add internal Excludes |
+| `README.md` | Modify | Downstream opt-in recipe |
+| `spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb` | Create | Cop spec (standalone) |
+| `spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb` | Create | Cop spec (standalone) |
+| `spec/unit/rubocop/apartment_spec.rb` | Create | Entry-point + config smoke spec |
+
+**Why cop specs are standalone (no `spec_helper`):** `.rspec` does not auto-require `spec_helper`, and `spec_helper.rb` does `require 'apartment'` (triggering Zeitwerk). Cop specs `require 'rubocop'` + the cop file directly, so they never load Apartment. The full suite (`spec/unit/`) still loads Apartment via other specs — which is why the Zeitwerk ignore (Task 1) must land before any `lib/rubocop` file exists.
+
+---
+
+## Task 1: Zeitwerk ignore for `lib/rubocop`
+
+Add the ignore first, before any `lib/rubocop` file exists, so the full suite keeps loading Apartment cleanly once the cop files land.
+
+**Files:**
+- Modify: `lib/apartment.rb` (after the `cli` ignores, ~line 26)
+
+- [ ] **Step 1: Add the ignore line**
+
+In `lib/apartment.rb`, immediately after the line `loader.ignore("#{__dir__}/apartment/cli")`, add:
+
+```ruby
+
+# RuboCop cops live under lib/rubocop and load only via RuboCop's `require:`
+# (config), never through Apartment's autoloader. Ignore avoids Zeitwerk mapping
+# lib/rubocop to a `Rubocop` constant (wrong casing vs RuboCop) — same rationale
+# as the cli.rb / cli ignores above.
+loader.ignore("#{__dir__}/rubocop")
+```
+
+(`loader.ignore` of a not-yet-existing path is harmless; the directory arrives in Task 2.)
+
+- [ ] **Step 2: Verify Apartment still loads and the suite is green**
+
+Run: `bundle exec ruby -e "require 'apartment'; puts 'loaded ok'"`
+Expected: `loaded ok` (no Zeitwerk error).
+
+Run: `bundle exec rspec spec/unit/ 2>&1 | tail -3`
+Expected: existing examples pass, 0 failures (pending allowed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/apartment.rb
+git commit -m "Zeitwerk-ignore lib/rubocop ahead of shipping custom cops
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `Apartment/NoDirectCurrentWrite` cop (TDD)
+
+**Files:**
+- Create: `spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb`
+- Create: `lib/rubocop/cop/apartment/no_direct_current_write.rb`
+
+- [ ] **Step 1: Write the failing spec**
+
+Create `spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../../../lib/rubocop/cop/apartment/no_direct_current_write'
+
+RSpec.describe(RuboCop::Cop::Apartment::NoDirectCurrentWrite, :config) do
+  it 'flags a qualified Apartment::Current.tenant write' do
+    expect_offense(<<~RUBY)
+      Apartment::Current.tenant = 'acme'
+                         ^^^^^^ Do not write `Apartment::Current.tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'flags a qualified Apartment::Current.previous_tenant write' do
+    expect_offense(<<~RUBY)
+      Apartment::Current.previous_tenant = nil
+                         ^^^^^^^^^^^^^^^ Do not write `Apartment::Current.previous_tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'flags a cbase (::Apartment) write' do
+    expect_offense(<<~RUBY)
+      ::Apartment::Current.tenant = 'acme'
+                           ^^^^^^ Do not write `Apartment::Current.tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'ignores the block-form switch' do
+    expect_no_offenses("Apartment::Tenant.switch('acme') { :work }")
+  end
+
+  it 'ignores a read of Apartment::Current.tenant' do
+    expect_no_offenses('x = Apartment::Current.tenant')
+  end
+
+  it 'ignores an unrelated Current constant' do
+    expect_no_offenses("Foo::Current.tenant = 'x'")
+    expect_no_offenses("Current.tenant = 'x'")
+  end
+
+  it 'respects an inline disable' do
+    expect_no_offenses(<<~RUBY)
+      Apartment::Current.tenant = 'x' # rubocop:disable Apartment/NoDirectCurrentWrite
+    RUBY
+  end
+end
+```
+
+- [ ] **Step 2: Run the spec to verify it fails**
+
+Run: `bundle exec rspec spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb`
+Expected: FAIL with `LoadError` / `cannot load such file -- .../no_direct_current_write` (the cop file does not exist yet).
+
+- [ ] **Step 3: Implement the cop**
+
+Create `lib/rubocop/cop/apartment/no_direct_current_write.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Apartment
+      # Bans direct assignment to Apartment::Current attributes. Application code
+      # must change tenant context through the block-form switch, which guarantees
+      # restore via ensure.
+      #
+      # @example
+      #   # bad
+      #   Apartment::Current.tenant = 'acme'
+      #
+      #   # good
+      #   Apartment::Tenant.switch('acme') { ... }
+      class NoDirectCurrentWrite < Base
+        MSG = 'Do not write `Apartment::Current.%<attr>s` directly; use the ' \
+              'block-form `Apartment::Tenant.switch(tenant) { ... }`.'
+
+        # @!method current_attr_write?(node)
+        def_node_matcher :current_attr_write?, <<~PATTERN
+          (send (const (const {nil? cbase} :Apartment) :Current) {:tenant= :previous_tenant=} _)
+        PATTERN
+
+        def on_send(node)
+          return unless current_attr_write?(node)
+
+          attr = node.method_name.to_s.delete_suffix('=')
+          # Highlight the attribute selector (`tenant` / `previous_tenant`), not the
+          # whole assignment — stable range, independent of the RHS and any cbase.
+          add_offense(node.loc.selector, message: format(MSG, attr: attr))
+        end
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the spec to verify it passes**
+
+Run: `bundle exec rspec spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb`
+Expected: PASS (7 examples). If a caret line mismatches, RuboCop prints the expected vs actual range/message — align the `^` count to the flagged expression and the annotation to `MSG` exactly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/rubocop/cop/apartment/no_direct_current_write.rb spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb
+git commit -m "Add Apartment/NoDirectCurrentWrite cop (bans raw Apartment::Current writes)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `Apartment/PreferBlockSwitch` cop (TDD)
+
+**Files:**
+- Create: `spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb`
+- Create: `lib/rubocop/cop/apartment/prefer_block_switch.rb`
+
+- [ ] **Step 1: Write the failing spec**
+
+Create `spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../../../lib/rubocop/cop/apartment/prefer_block_switch'
+
+RSpec.describe(RuboCop::Cop::Apartment::PreferBlockSwitch, :config) do
+  it 'flags Apartment::Tenant.switch!' do
+    expect_offense(<<~RUBY)
+      Apartment::Tenant.switch!('acme')
+                        ^^^^^^^ Use the block-form `Apartment::Tenant.switch(tenant) { ... }` instead of `switch!`.
+    RUBY
+  end
+
+  it 'flags a cbase (::Apartment) switch!' do
+    expect_offense(<<~RUBY)
+      ::Apartment::Tenant.switch!('acme')
+                          ^^^^^^^ Use the block-form `Apartment::Tenant.switch(tenant) { ... }` instead of `switch!`.
+    RUBY
+  end
+
+  it 'ignores the block-form switch' do
+    expect_no_offenses("Apartment::Tenant.switch('acme') { :work }")
+  end
+
+  it 'ignores reset' do
+    expect_no_offenses('Apartment::Tenant.reset')
+  end
+
+  it 'ignores switch! on an unrelated receiver' do
+    expect_no_offenses("Foo::Tenant.switch!('x')")
+  end
+
+  it 'respects an inline disable' do
+    expect_no_offenses(<<~RUBY)
+      Apartment::Tenant.switch!('x') # rubocop:disable Apartment/PreferBlockSwitch
+    RUBY
+  end
+end
+```
+
+- [ ] **Step 2: Run the spec to verify it fails**
+
+Run: `bundle exec rspec spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb`
+Expected: FAIL with `LoadError` (cop file missing).
+
+- [ ] **Step 3: Implement the cop**
+
+Create `lib/rubocop/cop/apartment/prefer_block_switch.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Apartment
+      # Nudges callers away from Apartment::Tenant.switch! toward the block-form
+      # switch, which restores context via ensure. reset is intentionally not
+      # flagged (it is the sanctioned unguarded path back to the default tenant).
+      #
+      # @example
+      #   # bad
+      #   Apartment::Tenant.switch!('acme')
+      #
+      #   # good
+      #   Apartment::Tenant.switch('acme') { ... }
+      class PreferBlockSwitch < Base
+        MSG = 'Use the block-form `Apartment::Tenant.switch(tenant) { ... }` ' \
+              'instead of `switch!`.'
+
+        # @!method tenant_bang_switch?(node)
+        def_node_matcher :tenant_bang_switch?, <<~PATTERN
+          (send (const (const {nil? cbase} :Apartment) :Tenant) :switch! ...)
+        PATTERN
+
+        def on_send(node)
+          return unless tenant_bang_switch?(node)
+
+          # Highlight the `switch!` selector — stable range regardless of receiver
+          # prefix or arguments.
+          add_offense(node.loc.selector)
+        end
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the spec to verify it passes**
+
+Run: `bundle exec rspec spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb`
+Expected: PASS (6 examples).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/rubocop/cop/apartment/prefer_block_switch.rb spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb
+git commit -m "Add Apartment/PreferBlockSwitch cop (warning: prefer block-form switch)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Entry point + `config/default.yml` (TDD smoke)
+
+**Files:**
+- Create: `spec/unit/rubocop/apartment_spec.rb`
+- Create: `lib/rubocop/apartment.rb`
+- Create: `config/default.yml`
+
+- [ ] **Step 1: Write the failing smoke spec**
+
+Create `spec/unit/rubocop/apartment_spec.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'rubocop'
+require_relative '../../../lib/rubocop/apartment'
+
+RSpec.describe('rubocop/apartment') do
+  it 'registers both Apartment cops' do
+    names = RuboCop::Cop::Registry.global.cops.map(&:cop_name)
+    expect(names).to(include('Apartment/NoDirectCurrentWrite', 'Apartment/PreferBlockSwitch'))
+  end
+
+  it 'config/default.yml sets the documented severities' do
+    config = RuboCop::ConfigLoader.load_file('config/default.yml')
+    expect(config['Apartment/NoDirectCurrentWrite']['Severity']).to(eq('error'))
+    expect(config['Apartment/PreferBlockSwitch']['Severity']).to(eq('warning'))
+    expect(config['Apartment/NoDirectCurrentWrite']['Enabled']).to(be(true))
+    expect(config['Apartment/PreferBlockSwitch']['Enabled']).to(be(true))
+  end
+end
+```
+
+- [ ] **Step 2: Run the spec to verify it fails**
+
+Run: `bundle exec rspec spec/unit/rubocop/apartment_spec.rb`
+Expected: FAIL with `LoadError` on `../../../lib/rubocop/apartment` (entry point missing).
+
+- [ ] **Step 3: Create the entry point**
+
+Create `lib/rubocop/apartment.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require_relative 'cop/apartment/no_direct_current_write'
+require_relative 'cop/apartment/prefer_block_switch'
+```
+
+- [ ] **Step 4: Create the config**
+
+Create `config/default.yml`:
+
+```yaml
+Apartment/NoDirectCurrentWrite:
+  Description: 'Use the block-form switch instead of writing Apartment::Current directly.'
+  Enabled: true
+  Severity: error
+
+Apartment/PreferBlockSwitch:
+  Description: 'Prefer the block-form Apartment::Tenant.switch over switch!.'
+  Enabled: true
+  Severity: warning
+```
+
+- [ ] **Step 5: Run the spec to verify it passes**
+
+Run: `bundle exec rspec spec/unit/rubocop/apartment_spec.rb`
+Expected: PASS (2 examples). Run from the repo root so `config/default.yml` resolves.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/rubocop/apartment.rb config/default.yml spec/unit/rubocop/apartment_spec.rb
+git commit -m "Add rubocop/apartment entry point and config/default.yml
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Ship `config/` in the gem + wire the repo's own RuboCop
+
+**Files:**
+- Modify: `ros-apartment.gemspec:16`
+- Modify: `.rubocop.yml`
+
+- [ ] **Step 1: Ship `config/` in the gemspec**
+
+In `ros-apartment.gemspec`, replace line 16:
+
+```ruby
+  s.files = %w[ros-apartment.gemspec README.md] + `git ls-files -- lib`.split("\n")
+```
+
+with:
+
+```ruby
+  s.files = %w[ros-apartment.gemspec README.md] + `git ls-files -- lib config`.split("\n")
+```
+
+- [ ] **Step 2: Verify the config ships**
+
+Run: `ruby -e "require 'rubygems'; puts Gem::Specification.load('ros-apartment.gemspec').files.grep(%r{config/})"`
+Expected output includes: `config/default.yml`
+(`config/default.yml` is tracked as of Task 4, so `git ls-files -- config` lists it.)
+
+- [ ] **Step 3: Wire the cops into the repo's own `.rubocop.yml`**
+
+In `.rubocop.yml`, add a `require:` block immediately after the existing `plugins:` block (after the `- rubocop-rspec` line), then the inherit + excludes. Insert:
+
+```yaml
+require:
+  - ./lib/rubocop/apartment
+
+inherit_from:
+  - config/default.yml
+
+Apartment/NoDirectCurrentWrite:
+  Exclude:
+    - lib/apartment/**/*
+    - spec/**/*
+
+Apartment/PreferBlockSwitch:
+  Exclude:
+    - lib/apartment/**/*
+    - spec/**/*
+```
+
+(`require: ./lib/rubocop/apartment` uses a repo-relative path because the gem's `lib` is not on RuboCop's load path when linting in-repo. Downstream apps use `require: rubocop/apartment` — the installed gem's `lib` is on the load path. This distinction goes in the README, Task 6.)
+
+- [ ] **Step 4: Run RuboCop on the repo — expect clean**
+
+Run: `bundle exec rubocop 2>&1 | tail -5`
+Expected: `no offenses detected` (the new cop files pass; the two Apartment cops find 0 violations because `lib/apartment/**/*` and `spec/**/*` are excluded and no other `lib` file writes `Apartment::Current` or calls `switch!`).
+
+If the cop files themselves trip a style cop, autocorrect with `bundle exec rubocop -A lib/rubocop/` and re-inspect the diff (logic unchanged).
+
+- [ ] **Step 5: Confirm the cops are actually loaded (not silently inert)**
+
+Run: `bundle exec rubocop --show-cops Apartment/NoDirectCurrentWrite Apartment/PreferBlockSwitch 2>&1 | grep -E "Apartment/|Enabled|Severity"`
+Expected: both cops listed, `Enabled: true`, severities `error` / `warning`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ros-apartment.gemspec .rubocop.yml
+git commit -m "Ship config/ in gemspec; enable Apartment cops in the repo's own RuboCop
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: README docs + final verification
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Find a placement anchor**
+
+Run: `grep -n "^## " README.md`
+Insert the new section before the last top-level section (e.g. a `## License` / `## Contributing` if present; otherwise append at end).
+
+- [ ] **Step 2: Add the RuboCop section**
+
+Insert this section:
+
+```markdown
+## RuboCop cops
+
+Apartment ships two optional RuboCop cops that enforce the block-form
+tenant-switching discipline. Enable them in your application's `.rubocop.yml`:
+
+```yaml
+require: rubocop/apartment
+inherit_gem:
+  ros-apartment: config/default.yml
+```
+
+- **`Apartment/NoDirectCurrentWrite`** (error) — bans assigning
+  `Apartment::Current.tenant` / `.previous_tenant` directly. Change tenant context
+  with `Apartment::Tenant.switch(tenant) { ... }` (or `with_default_tenant` for
+  global work), which guarantees a restore via `ensure`.
+- **`Apartment/PreferBlockSwitch`** (warning) — nudges `Apartment::Tenant.switch!`
+  toward the block form. `reset` is not flagged.
+
+Both match the qualified `Apartment::` receiver only. Scope them to your
+application code with the standard `Exclude:` keys if needed. See
+`docs/designs/rubocop-cops.md` for the rationale.
+```
+```
+
+(Note: the closing ```` ``` ```` of the inner YAML fence is part of the section content — keep both fence levels when pasting.)
+
+- [ ] **Step 3: Commit the docs**
+
+```bash
+git add README.md
+git commit -m "Docs: README section for the Apartment RuboCop cops
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Final full verification**
+
+Run: `bundle exec rspec spec/unit/ 2>&1 | tail -3`
+Expected: all examples pass, 0 failures (the 15 new cop examples included).
+
+Run: `bundle exec rubocop 2>&1 | tail -3`
+Expected: `no offenses detected`.
+
+Run: `git log --oneline main..HEAD`
+Expected: the design commit plus six task commits. Branch `apartment-rubocop-cops` ready for a PR against `main`.
+
+---
+
+## Notes for the implementer
+
+- **Caret precision in cop specs:** `expect_offense` requires the `^` run to underline the flagged expression exactly and the trailing text to equal the cop's message verbatim. If a spec fails on a range/message mismatch, RuboCop prints expected-vs-actual — align to it; the cop code is the source of truth for the message.
+- **Both cops highlight `node.loc.selector`**, not the whole node — the caret range is the attribute/method token (`tenant`, `previous_tenant`, `switch!`), stable regardless of the RHS value or a `::` (cbase) prefix. `NoDirectCurrentWrite` passes an interpolated `message:` (the attr name varies); `PreferBlockSwitch` omits `message:` so `Base` uses the static `MSG` constant.
+- **Run specs from the repo root** so `config/default.yml` (a relative path in the smoke spec) resolves.
+- **Do not** add the `lib/apartment/` exemption to cop logic — it belongs only in this repo's `.rubocop.yml` (Task 5), so the shipped cop stays generic for downstream apps.
+- **Do not** convert spec-suite `Current.tenant =` / `switch!` sites — `spec/**/*` is excluded by design (out of scope).

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -25,6 +25,12 @@ loader.ignore("#{__dir__}/apartment/tasks")
 loader.ignore("#{__dir__}/apartment/cli.rb")
 loader.ignore("#{__dir__}/apartment/cli")
 
+# RuboCop cops live under lib/rubocop and load only via RuboCop's `require:`
+# (config), never through Apartment's autoloader. Ignore avoids Zeitwerk mapping
+# lib/rubocop to a `Rubocop` constant (wrong casing vs RuboCop) — same rationale
+# as the cli.rb / cli ignores above.
+loader.ignore("#{__dir__}/rubocop")
+
 # Collapse concerns/ so Zeitwerk maps lib/apartment/concerns/model.rb
 # to Apartment::Model (not Apartment::Concerns::Model). Mirrors the
 # Rails convention for app/models/concerns/.

--- a/lib/rubocop/apartment.rb
+++ b/lib/rubocop/apartment.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative 'cop/apartment/no_direct_current_write'
+require_relative 'cop/apartment/prefer_block_switch'

--- a/lib/rubocop/cop/apartment/no_direct_current_write.rb
+++ b/lib/rubocop/cop/apartment/no_direct_current_write.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Apartment
+      # Bans direct assignment to Apartment::Current attributes. Application code
+      # must change tenant context through the block-form switch, which guarantees
+      # restore via ensure.
+      #
+      # @example
+      #   # bad
+      #   Apartment::Current.tenant = 'acme'
+      #
+      #   # good
+      #   Apartment::Tenant.switch('acme') { ... }
+      class NoDirectCurrentWrite < Base
+        MSG = 'Do not write `Apartment::Current.%<attr>s` directly; use the ' \
+              'block-form `Apartment::Tenant.switch(tenant) { ... }`.'
+
+        # @!method current_attr_write?(node)
+        def_node_matcher :current_attr_write?, <<~PATTERN
+          (send (const (const {nil? cbase} :Apartment) :Current) {:tenant= :previous_tenant=} _)
+        PATTERN
+
+        def on_send(node)
+          return unless current_attr_write?(node)
+
+          attr = node.method_name.to_s.delete_suffix('=')
+          # Highlight the attribute selector (`tenant` / `previous_tenant`), not the
+          # whole assignment — stable range, independent of the RHS and any cbase.
+          add_offense(node.loc.selector, message: format(MSG, attr: attr))
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/apartment/no_direct_current_write.rb
+++ b/lib/rubocop/cop/apartment/no_direct_current_write.rb
@@ -7,9 +7,18 @@ module RuboCop
       # must change tenant context through the block-form switch, which guarantees
       # restore via ensure.
       #
+      # Covers plain assignment (`=`) and operator assignment (`||=`, `&&=`, `+=`).
+      # Known syntactic limitations (deliberately not chased — they signal
+      # deliberate evasion and are out of scope for a lint nudge): multiple
+      # assignment (`a, Apartment::Current.tenant = ...`), safe navigation
+      # (`Apartment::Current&.tenant = ...`), dynamic dispatch
+      # (`Apartment::Current.public_send(:tenant=, ...)`), bulk mutators
+      # (`Apartment::Current.set(...)` / `.reset`), and aliased receivers.
+      #
       # @example
       #   # bad
       #   Apartment::Current.tenant = 'acme'
+      #   Apartment::Current.tenant ||= 'acme'
       #
       #   # good
       #   Apartment::Tenant.switch('acme') { ... }
@@ -26,12 +35,42 @@ module RuboCop
           (send (const (const {nil? cbase} :Apartment) :Current) {:tenant= :previous_tenant=} _)
         PATTERN
 
+        # The reader-shaped LHS of an operator-assignment (`tenant ||= x` parses as
+        # an or_asgn around `(send recv :tenant)`, not a `:tenant=` send).
+        # @!method current_attr_lhs?(node)
+        def_node_matcher :current_attr_lhs?, <<~PATTERN
+          (send (const (const {nil? cbase} :Apartment) :Current) {:tenant :previous_tenant})
+        PATTERN
+
         def on_send(node)
           return unless current_attr_write?(node)
 
-          attr = node.method_name.to_s.delete_suffix('=')
-          # Highlight the attribute selector (`tenant` / `previous_tenant`), not the
-          # whole assignment — stable range, independent of the RHS and any cbase.
+          register(node, node.method_name.to_s.delete_suffix('='))
+        end
+
+        # `||=` and `&&=` are or_asgn / and_asgn; `+=` etc. are op_asgn. The LHS is
+        # always the first child (a reader send). RESTRICT_ON_SEND does not apply to
+        # these callbacks, so the matcher does the filtering.
+        def on_or_asgn(node)
+          check_op_assign(node.children.first)
+        end
+        alias on_and_asgn on_or_asgn
+
+        def on_op_asgn(node)
+          check_op_assign(node.children.first)
+        end
+
+        private
+
+        def check_op_assign(lhs)
+          return unless current_attr_lhs?(lhs)
+
+          register(lhs, lhs.method_name.to_s)
+        end
+
+        # Highlight the attribute selector (`tenant` / `previous_tenant`), not the
+        # whole assignment — stable range, independent of the RHS and any cbase.
+        def register(node, attr)
           add_offense(node.loc.selector, message: format(MSG, attr: attr))
         end
       end

--- a/lib/rubocop/cop/apartment/no_direct_current_write.rb
+++ b/lib/rubocop/cop/apartment/no_direct_current_write.rb
@@ -17,6 +17,10 @@ module RuboCop
         MSG = 'Do not write `Apartment::Current.%<attr>s` directly; use the ' \
               'block-form `Apartment::Tenant.switch(tenant) { ... }`.'
 
+        # Only invoke on_send for these setters — keeps the cop off the hot path
+        # (RuboCop would otherwise call on_send for every method call linted).
+        RESTRICT_ON_SEND = %i[tenant= previous_tenant=].freeze
+
         # @!method current_attr_write?(node)
         def_node_matcher :current_attr_write?, <<~PATTERN
           (send (const (const {nil? cbase} :Apartment) :Current) {:tenant= :previous_tenant=} _)

--- a/lib/rubocop/cop/apartment/prefer_block_switch.rb
+++ b/lib/rubocop/cop/apartment/prefer_block_switch.rb
@@ -17,6 +17,10 @@ module RuboCop
         MSG = 'Use the block-form `Apartment::Tenant.switch(tenant) { ... }` ' \
               'instead of `switch!`.'
 
+        # Only invoke on_send for switch! — keeps the cop off the hot path
+        # (RuboCop would otherwise call on_send for every method call linted).
+        RESTRICT_ON_SEND = %i[switch!].freeze
+
         # @!method tenant_bang_switch?(node)
         def_node_matcher :tenant_bang_switch?, <<~PATTERN
           (send (const (const {nil? cbase} :Apartment) :Tenant) :switch! ...)

--- a/lib/rubocop/cop/apartment/prefer_block_switch.rb
+++ b/lib/rubocop/cop/apartment/prefer_block_switch.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Apartment
+      # Nudges callers away from Apartment::Tenant.switch! toward the block-form
+      # switch, which restores context via ensure. reset is intentionally not
+      # flagged (it is the sanctioned unguarded path back to the default tenant).
+      #
+      # @example
+      #   # bad
+      #   Apartment::Tenant.switch!('acme')
+      #
+      #   # good
+      #   Apartment::Tenant.switch('acme') { ... }
+      class PreferBlockSwitch < Base
+        MSG = 'Use the block-form `Apartment::Tenant.switch(tenant) { ... }` ' \
+              'instead of `switch!`.'
+
+        # @!method tenant_bang_switch?(node)
+        def_node_matcher :tenant_bang_switch?, <<~PATTERN
+          (send (const (const {nil? cbase} :Apartment) :Tenant) :switch! ...)
+        PATTERN
+
+        def on_send(node)
+          return unless tenant_bang_switch?(node)
+
+          # Highlight the `switch!` selector — stable range regardless of receiver
+          # prefix or arguments.
+          add_offense(node.loc.selector)
+        end
+      end
+    end
+  end
+end

--- a/ros-apartment.gemspec
+++ b/ros-apartment.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                     'through schema-based or database-based isolation strategies.'
   s.email         = ['ryan@influitive.com', 'brad@influitive.com', 'rui.p.baltazar@gmail.com', 'mauricio@campusesp.com']
 
-  s.files = %w[ros-apartment.gemspec README.md] + `git ls-files -- lib`.split("\n")
+  s.files = %w[ros-apartment.gemspec README.md] + `git ls-files -- lib config`.split("\n")
   s.require_paths = ['lib']
 
   s.homepage = 'https://github.com/rails-on-services/apartment'

--- a/spec/unit/rubocop/apartment_spec.rb
+++ b/spec/unit/rubocop/apartment_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require_relative '../../../lib/rubocop/apartment'
+
+RSpec.describe('rubocop/apartment') do
+  it 'registers both Apartment cops' do
+    names = RuboCop::Cop::Registry.global.cops.map(&:cop_name)
+    expect(names).to(include('Apartment/NoDirectCurrentWrite', 'Apartment/PreferBlockSwitch'))
+  end
+
+  it 'config/default.yml sets the documented severities' do
+    config = RuboCop::ConfigLoader.load_file('config/default.yml')
+    expect(config['Apartment/NoDirectCurrentWrite']['Severity']).to(eq('error'))
+    expect(config['Apartment/PreferBlockSwitch']['Severity']).to(eq('warning'))
+    expect(config['Apartment/NoDirectCurrentWrite']['Enabled']).to(be(true))
+    expect(config['Apartment/PreferBlockSwitch']['Enabled']).to(be(true))
+  end
+end

--- a/spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb
+++ b/spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb
@@ -26,6 +26,27 @@ RSpec.describe(RuboCop::Cop::Apartment::NoDirectCurrentWrite, :config) do
     RUBY
   end
 
+  it 'flags an or-assign (||=) — the idiomatic set-if-unset bypass' do
+    expect_offense(<<~RUBY)
+      Apartment::Current.tenant ||= 'acme'
+                         ^^^^^^ Do not write `Apartment::Current.tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'flags an and-assign (&&=) to previous_tenant' do
+    expect_offense(<<~RUBY)
+      Apartment::Current.previous_tenant &&= 'x'
+                         ^^^^^^^^^^^^^^^ Do not write `Apartment::Current.previous_tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'flags an op-assign (+=) to tenant' do
+    expect_offense(<<~RUBY)
+      Apartment::Current.tenant += 'x'
+                         ^^^^^^ Do not write `Apartment::Current.tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
   it 'ignores the block-form switch' do
     expect_no_offenses("Apartment::Tenant.switch('acme') { :work }")
   end
@@ -37,6 +58,7 @@ RSpec.describe(RuboCop::Cop::Apartment::NoDirectCurrentWrite, :config) do
   it 'ignores an unrelated Current constant' do
     expect_no_offenses("Foo::Current.tenant = 'x'")
     expect_no_offenses("Current.tenant = 'x'")
+    expect_no_offenses("Foo::Current.tenant ||= 'x'")
   end
 
   it 'respects an inline disable' do

--- a/spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb
+++ b/spec/unit/rubocop/cop/apartment/no_direct_current_write_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../../../lib/rubocop/cop/apartment/no_direct_current_write'
+
+RSpec.describe(RuboCop::Cop::Apartment::NoDirectCurrentWrite, :config) do
+  it 'flags a qualified Apartment::Current.tenant write' do
+    expect_offense(<<~RUBY)
+      Apartment::Current.tenant = 'acme'
+                         ^^^^^^ Do not write `Apartment::Current.tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'flags a qualified Apartment::Current.previous_tenant write' do
+    expect_offense(<<~RUBY)
+      Apartment::Current.previous_tenant = nil
+                         ^^^^^^^^^^^^^^^ Do not write `Apartment::Current.previous_tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'flags a cbase (::Apartment) write' do
+    expect_offense(<<~RUBY)
+      ::Apartment::Current.tenant = 'acme'
+                           ^^^^^^ Do not write `Apartment::Current.tenant` directly; use the block-form `Apartment::Tenant.switch(tenant) { ... }`.
+    RUBY
+  end
+
+  it 'ignores the block-form switch' do
+    expect_no_offenses("Apartment::Tenant.switch('acme') { :work }")
+  end
+
+  it 'ignores a read of Apartment::Current.tenant' do
+    expect_no_offenses('x = Apartment::Current.tenant')
+  end
+
+  it 'ignores an unrelated Current constant' do
+    expect_no_offenses("Foo::Current.tenant = 'x'")
+    expect_no_offenses("Current.tenant = 'x'")
+  end
+
+  it 'respects an inline disable' do
+    expect_no_offenses(<<~RUBY)
+      Apartment::Current.tenant = 'x' # rubocop:disable Apartment/NoDirectCurrentWrite
+    RUBY
+  end
+end

--- a/spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb
+++ b/spec/unit/rubocop/cop/apartment/prefer_block_switch_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require_relative '../../../../../lib/rubocop/cop/apartment/prefer_block_switch'
+
+RSpec.describe(RuboCop::Cop::Apartment::PreferBlockSwitch, :config) do
+  it 'flags Apartment::Tenant.switch!' do
+    expect_offense(<<~RUBY)
+      Apartment::Tenant.switch!('acme')
+                        ^^^^^^^ Use the block-form `Apartment::Tenant.switch(tenant) { ... }` instead of `switch!`.
+    RUBY
+  end
+
+  it 'flags a cbase (::Apartment) switch!' do
+    expect_offense(<<~RUBY)
+      ::Apartment::Tenant.switch!('acme')
+                          ^^^^^^^ Use the block-form `Apartment::Tenant.switch(tenant) { ... }` instead of `switch!`.
+    RUBY
+  end
+
+  it 'ignores the block-form switch' do
+    expect_no_offenses("Apartment::Tenant.switch('acme') { :work }")
+  end
+
+  it 'ignores reset' do
+    expect_no_offenses('Apartment::Tenant.reset')
+  end
+
+  it 'ignores switch! on an unrelated receiver' do
+    expect_no_offenses("Foo::Tenant.switch!('x')")
+  end
+
+  it 'respects an inline disable' do
+    expect_no_offenses(<<~RUBY)
+      Apartment::Tenant.switch!('x') # rubocop:disable Apartment/PreferBlockSwitch
+    RUBY
+  end
+end


### PR DESCRIPTION
## Summary

- Adds two shippable custom cops under `lib/rubocop/cop/apartment/` so downstream apps can enforce the block-form tenant-switching discipline:
  - **`Apartment/NoDirectCurrentWrite`** (error) — bans assigning `Apartment::Current.tenant` / `.previous_tenant` directly. The block-form `Apartment::Tenant.switch(tenant) { ... }` / `with_default_tenant { ... }` is the only context change with a guaranteed `ensure` restore.
  - **`Apartment/PreferBlockSwitch`** (warning) — nudges `Apartment::Tenant.switch!` toward the block form. `reset` is intentionally not flagged.
- Both match the qualified `Apartment::` receiver only (no false positives on unrelated `Current` / `Tenant` constants) and highlight the selector for a stable offense range. No autocorrect (the fix wraps surrounding code in a block).
- **Ships in the gem**: `config/` added to `s.files`; `lib/rubocop` is Zeitwerk-ignored (it would map to a wrong-cased `Rubocop` constant — same pattern as the existing `cli.rb` ignore). Entry point `lib/rubocop/apartment.rb` + `config/default.yml` carry the defaults.
- The shipped cops are generic; both exemptions (`lib/apartment/**/*`, `spec/**/*`) live in this repo's own `.rubocop.yml`, so a downstream app never inherits the gem's internal layout.

This is lint-time only — not a deprecation or API change. `switch!` still works (and is still used by `reset`).

## Downstream opt-in

```yaml
require: rubocop/apartment
inherit_gem:
  ros-apartment: config/default.yml
```

## Test Plan

- [x] `Apartment/NoDirectCurrentWrite` spec — flags qualified writes (incl. cbase, `previous_tenant`); ignores block form, reads, unrelated `Current`, and inline disables (7 examples).
- [x] `Apartment/PreferBlockSwitch` spec — flags `switch!` (incl. cbase); ignores block form, `reset`, unrelated receiver, inline disables (6 examples).
- [x] Smoke spec — entry point registers both cops; `config/default.yml` sets the documented severities (error / warning).
- [x] Full unit suite: `bundle exec rspec spec/unit/` — 873 examples, 0 failures.
- [x] `bundle exec rubocop lib/rubocop/ spec/unit/rubocop/` — no offenses.
- [x] Gemspec ships `config/default.yml` and the three cop files (verified via `Gem::Specification.load`).

Design + plan: `docs/designs/rubocop-cops.md`, `docs/plans/rubocop-cops/plan.md`.

> Note: a pre-existing `Lint/RedundantCopDisableDirective` warning in `lib/apartment/patches/connection_handling.rb` is present on `main` (version-sensitive `rubocop-rails`) and is unrelated to this change — intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)