### PR TITLE
Restore Apartment::Tenant.default_tenant reader (v4 migration ergonomics)

### DIFF
--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -88,6 +88,8 @@ end
 
 v4 also adds the identity-axis guards for runtime (non-test) code: `require_tenant!` / `require_default_tenant!`, predicates `in_tenant?` / `in_default_tenant?`, `with_default_tenant { }`, and `cache_namespace`. See [Tenant-Aware Caching](./caching.md). The explicitness-axis methods `inside_tenant?` / `assert_inside_tenant!` were **renamed** to `tenant_switched?` / `assert_tenant_switched!` with no aliases.
 
+v4 relocated the configured default tenant to `Apartment.config.default_tenant`, but `Apartment::Tenant.default_tenant` remains available as a reader (it returns `Apartment.config&.default_tenant`). Code that read the default tenant on v3 keeps working unchanged.
+
 See [Testing with Apartment v4](./testing.md) for recipe-level guidance on strict discipline, cross-pool transaction visibility, and pinned-model cleanup.
 
 ### Models

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -37,12 +37,20 @@ module Apartment
 
       # Current tenant name.
       def current
-        Current.tenant || Apartment.config&.default_tenant
+        Current.tenant || default_tenant
+      end
+
+      # The configured default tenant name (nil if Apartment is not configured).
+      # v4 relocated this value to Apartment.config.default_tenant; this reader
+      # restores the v3 Apartment::Tenant.default_tenant accessor so consumers
+      # that read the default tenant need not branch on the apartment version.
+      def default_tenant
+        Apartment.config&.default_tenant
       end
 
       # Reset to default tenant.
       def reset
-        switch!(Apartment.config&.default_tenant)
+        switch!(default_tenant)
       end
 
       # Predicate: was a tenant explicitly entered? (Explicitness axis.)
@@ -76,13 +84,13 @@ module Apartment
       # and false when no default_tenant is configured and no tenant is active.
       def in_tenant?
         c = current.to_s
-        !c.empty? && c != Apartment.config&.default_tenant.to_s
+        !c.empty? && c != default_tenant.to_s
       end
 
       # Predicate: is the effective tenant the default tenant?
       # (Identity axis.) False when no default_tenant is configured.
       def in_default_tenant?
-        default = Apartment.config&.default_tenant
+        default = default_tenant
         !default.nil? && current.to_s == default.to_s
       end
 
@@ -99,7 +107,7 @@ module Apartment
       # the normalized default name on success. Raises DefaultTenantNotConfigured
       # when no default_tenant is configured (a nil keyspace is a silent leak).
       def require_default_tenant!
-        default = Apartment.config&.default_tenant
+        default = default_tenant
         raise(Apartment::DefaultTenantNotConfigured) if default.nil?
         return default.to_s if current.to_s == default.to_s
 
@@ -127,7 +135,7 @@ module Apartment
       def with_default_tenant
         raise(ArgumentError, 'Apartment::Tenant.with_default_tenant requires a block') unless block_given?
 
-        default = Apartment.config&.default_tenant
+        default = default_tenant
         raise(Apartment::DefaultTenantNotConfigured) if default.nil?
 
         previous = Current.tenant

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe(Apartment::Tenant) do
     end
   end
 
+  describe '.default_tenant' do
+    it 'returns the configured default tenant' do
+      expect(described_class.default_tenant).to(eq('public'))
+    end
+
+    it 'is independent of the current tenant context' do
+      described_class.switch!('tenant1')
+      expect(described_class.default_tenant).to(eq('public'))
+    end
+
+    it 'returns nil when no config is set' do
+      Apartment.clear_config
+      expect(described_class.default_tenant).to(be_nil)
+    end
+  end
+
   describe '.reset' do
     it 'sets tenant to default_tenant' do
       Apartment::Current.tenant = 'tenant1'


### PR DESCRIPTION
## Summary

Re-expose `Apartment::Tenant.default_tenant` as a thin reader over `Apartment.config&.default_tenant`, and route the six internal `tenant.rb` reads of the default tenant through it.

This is **ergonomic feedback on the v4 alpha**, not a defect. v4 consolidated the default-tenant value onto `Apartment.config.default_tenant` and dropped both the v3 `Apartment::Tenant.default_tenant` accessor and the `Apartment.default_tenant` module accessor. The consolidation is reasonable — but with no reader left on `Apartment::Tenant`, any consumer that reads the default tenant and supports both v3 and v4 has to version-detect:

```ruby
default =
  if Apartment::Tenant.respond_to?(:default_tenant)
    Apartment::Tenant.default_tenant            # v3
  else
    Apartment.config.default_tenant             # v4
  end
```

Restoring the reader collapses that to one line on both majors. The alpha felt like the right moment to raise it, before the surface freezes.

## What this changes

- **Adds** `Apartment::Tenant.default_tenant` → `Apartment.config&.default_tenant` (safe-nav, consistent with the sibling readers `current` / `reset` / the identity guards, which all tolerate an unconfigured `Apartment.config`). Returns `nil` when Apartment is not configured.
- **DRYs** the six existing `Apartment.config&.default_tenant` reads in `lib/apartment/tenant.rb` (`current`, `reset`, `in_tenant?`, `in_default_tenant?`, `require_default_tenant!`, `with_default_tenant`) through the new reader, so it is genuinely used internally rather than dead public API. Behavior is unchanged — the existing specs for those methods cover the routed paths.
- **Docs:** a one-line note in `docs/upgrading-to-v4.md` that the reader remains available.

## Deliberate non-goals

- **The `Apartment.default_tenant` module accessor is not restored.** `Apartment::Tenant.default_tenant` is the accessor v3 consumers actually called and is sufficient to collapse the version branch; re-adding the module-level one would widen the surface against the config-consolidation direction. Happy to add it if you'd prefer symmetry.
- No deprecation, no behavior change, no config change.

If the team would rather keep the default-tenant value solely on the config object, this is easy to decline — it's a convenience reader, not a fix.

## Test Plan

- [x] New specs: `Apartment::Tenant.default_tenant` returns the configured value, is independent of the current tenant context, and returns `nil` with no config (`spec/unit/tenant_spec.rb`).
- [x] Full unit suite: `bundle exec rspec spec/unit/` — 861 examples, 0 failures (the routed `current`/`reset`/guard specs exercise the DRY'd reads).
- [x] `bundle exec rubocop lib/apartment/tenant.rb spec/unit/tenant_spec.rb` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
