### PR TITLE
Docs: pinned cache namespace is tenant-independent, not "static"

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -78,7 +78,7 @@ TENANT_CACHE = ActiveSupport::Cache::RedisCacheStore.new(
 )
 
 # Pinned store — tenant-INDEPENDENT namespace (a constant, or a per-deploy prefix
-# like "#{BUILD_VERSION}/global"); never a tenant lambda. Global keys only.
+# like "#{BUILD_VERSION}/global"); never resolves Apartment::Tenant.current. Global keys only.
 PINNED_CACHE = ActiveSupport::Cache::RedisCacheStore.new(namespace: 'pinned')
 ```
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -77,7 +77,8 @@ TENANT_CACHE = ActiveSupport::Cache::RedisCacheStore.new(
   namespace: -> { Apartment::Tenant.cache_namespace }
 )
 
-# Pinned store — STATIC namespace, never a tenant lambda. Global keys only.
+# Pinned store — tenant-INDEPENDENT namespace (a constant, or a per-deploy prefix
+# like "#{BUILD_VERSION}/global"); never a tenant lambda. Global keys only.
 PINNED_CACHE = ActiveSupport::Cache::RedisCacheStore.new(namespace: 'pinned')
 ```
 

--- a/docs/designs/tenant-aware-caching.md
+++ b/docs/designs/tenant-aware-caching.md
@@ -145,13 +145,16 @@ Apartment::Tenant.cache_namespace         # => "acme"
 ```
 
 There is no `pinned_cache_namespace` counterpart, and none is needed: a pinned
-namespace must be **tenant-independent** — not derived from `Apartment::Tenant.current`.
-"Tenant-independent" is not the same as "a literal constant": a per-deploy prefix like
-`"#{BUILD_VERSION}/global"` is still pinned, because it never varies by tenant. Two
-corollaries: do not "pin" a routed namespace by substituting `default_tenant` for the
-current tenant (that couples the cache keyspace to a schema name); and if a pinned
-namespace genuinely must be computed from tenant context, wrap that computation in
-`with_default_tenant`.
+namespace must be **tenant-independent** — it must not vary with
+`Apartment::Tenant.current`. That is broader than "a literal constant": a config/env
+value, or a per-deploy prefix like `"#{BUILD_VERSION}/global"`, is still pinned (though a
+deploy prefix cold-starts the whole pinned keyspace on each deploy). Prefer an explicit
+global prefix (`'pinned'`, `"#{BUILD_VERSION}/global"`) over reusing `default_tenant` as
+the namespace: the latter is tenant-independent but ties the global cache layout to the
+default schema's name and overlaps confusingly with default-context routed keys. To
+produce pinned *data* while inside a real tenant, wrap the cache **write/read** in
+`with_default_tenant` (see below) — never the namespace, which ActiveSupport re-evaluates
+on every cache op.
 
 #### `with_default_tenant`
 
@@ -245,7 +248,8 @@ TENANT_CACHE = ActiveSupport::Cache::RedisCacheStore.new(
   namespace: -> { Apartment::Tenant.cache_namespace }
 )
 
-# Pinned store — STATIC namespace, never a tenant lambda. Global keys only.
+# Pinned store — tenant-independent namespace (a constant or per-deploy prefix);
+# never resolves Apartment::Tenant.current. Global keys only.
 PINNED_CACHE = ActiveSupport::Cache::RedisCacheStore.new(namespace: 'pinned')
 ```
 
@@ -278,7 +282,7 @@ a loud one. Default the docs to the first; document the second as the strict opt
   tenant-namespaced store resolves to `acme:key` and misses permanently. Read pinned
   keys from `PINNED_CACHE`. (Per-call `namespace: nil` exists but is store-dependent
   and undercuts the fail-closed story — prefer the explicit store.)
-- **Pinned store fixes shape, not provenance.** A static `PINNED_CACHE` stops
+- **Pinned store fixes shape, not provenance.** A tenant-independent `PINNED_CACHE` stops
   *namespace fragmentation*, but does not stop tenant-derived data from being written
   globally while inside `acme`. Wrap producers of pinned values in
   `with_default_tenant` / assert `require_default_tenant!`.

--- a/docs/designs/tenant-aware-caching.md
+++ b/docs/designs/tenant-aware-caching.md
@@ -144,8 +144,14 @@ teaching "a bang returns a String":
 Apartment::Tenant.cache_namespace         # => "acme"
 ```
 
-There is no `pinned_cache_namespace` counterpart: pinned stores use a *static*
-namespace string, so no helper is needed.
+There is no `pinned_cache_namespace` counterpart, and none is needed: a pinned
+namespace must be **tenant-independent** — not derived from `Apartment::Tenant.current`.
+"Tenant-independent" is not the same as "a literal constant": a per-deploy prefix like
+`"#{BUILD_VERSION}/global"` is still pinned, because it never varies by tenant. Two
+corollaries: do not "pin" a routed namespace by substituting `default_tenant` for the
+current tenant (that couples the cache keyspace to a schema name); and if a pinned
+namespace genuinely must be computed from tenant context, wrap that computation in
+`with_default_tenant`.
 
 #### `with_default_tenant`
 


### PR DESCRIPTION
## Summary

Docs-only. Corrects an imprecise claim in the tenant-aware-caching design about pinned cache namespaces.

`docs/designs/tenant-aware-caching.md` stated *"pinned stores use a static namespace string."* That's too strong: a per-deploy prefix such as `"#{BUILD_VERSION}/global"` is **not** a literal constant, yet it is still pinned — it never varies by tenant. Apps that embed a deploy/build version in their cache namespace hit exactly this case.

This reframes the rule as **tenant-independent** (not derived from `Apartment::Tenant.current`) and adds two corollaries:

- Do **not** "pin" a routed namespace by substituting `default_tenant` for the current tenant — that couples the cache keyspace to a schema name.
- If a pinned namespace genuinely must be computed from tenant context, wrap that computation in `with_default_tenant`.

The wording is mirrored into `docs/caching.md`.

## Not in scope (deliberately)

No `pinned_cache_namespace` helper is added — the gem still **owns the discipline, not the store**. The string-building primitives that exist (`cache_namespace` for routed, `default_tenant` for the default name) are sufficient; the gap was purely the doc wording.

## Backstory

This is the surviving sliver of a larger "reduce multi-tenant downstream friction" investigation. The other two candidates were dropped after review: a `Tenant.each(skip_missing:)` deletion-safe iterator (cut — it duplicates the already-rejected `skip_missing_schemas` footgun in `docs/plans/with-tenants-provider/plan.md`, calls a private fail-safe seam, and returns wrong answers for the multi-server `shard`/`database_config` strategies), and a drop-idempotency contract test (already covered by `spec/integration/v4/tenant_lifecycle_spec.rb` "double drop does not raise"). Reviewed with an AI panel (Codex, Gemini, Cursor, Mistral) that was unanimous on cutting the iterator.

## Test plan

- [x] Docs-only change; no code, no specs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
