### PR TITLE
Specs: include() over match() for simple-literal assertions (RuboCop)

### DIFF
--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe('Apartment error hierarchy') do
       error = described_class.new('public')
       expect(error).to(be_a(Apartment::ApartmentError))
       expect(error.current).to(eq('public'))
-      expect(error.message).to(match(/non-default tenant/))
-      expect(error.message).to(match(/"public"/))
+      expect(error.message).to(include('non-default tenant'))
+      expect(error.message).to(include('"public"'))
     end
   end
 
@@ -94,8 +94,8 @@ RSpec.describe('Apartment error hierarchy') do
       expect(error).to(be_a(Apartment::ApartmentError))
       expect(error.current).to(eq('acme'))
       expect(error.default).to(eq('public'))
-      expect(error.message).to(match(/"public"/))
-      expect(error.message).to(match(/"acme"/))
+      expect(error.message).to(include('"public"'))
+      expect(error.message).to(include('"acme"'))
     end
   end
 
@@ -103,7 +103,7 @@ RSpec.describe('Apartment error hierarchy') do
     it 'is an ApartmentError with a configuration message' do
       error = described_class.new
       expect(error).to(be_a(Apartment::ApartmentError))
-      expect(error.message).to(match(/default_tenant/))
+      expect(error.message).to(include('default_tenant'))
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes 5 `RSpec/MatchWithSimpleRegex` offenses in `spec/unit/errors_spec.rb` — the only file flagged. Each `match(/literal/)` where the pattern is a metacharacter-free string is converted to `include('literal')`:

| Before | After |
|---|---|
| `match(/non-default tenant/)` | `include('non-default tenant')` |
| `match(/"public"/)` (×2) | `include('"public"')` |
| `match(/"acme"/)` | `include('"acme"')` |
| `match(/default_tenant/)` | `include('default_tenant')` |

Equivalent for these literals (regex match-anywhere is the same as a substring check when there are no metacharacters or anchors), and clearer intent.

## Context

These are pre-existing on `main`, not introduced by recent work. The cop (`RSpec/MatchWithSimpleRegex`) is a newer rubocop-rspec cop now firing via `NewCops: enable`. Purely a lint cleanup — no behavior change.

## Test plan

- [x] `bundle exec rspec spec/unit/errors_spec.rb` — 22 examples, 0 failures.
- [x] `bundle exec rubocop spec/unit/errors_spec.rb` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
