### PR TITLE
Connection-pool hardening: tenant_pool_size, admission control, reaper_interval

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,13 @@
 AllCops:
   NewCops: enable
+  # Pin both targets to the gemspec floor (activerecord/activesupport >= 7.2,
+  # required_ruby_version >= 3.3). RuboCop-rails otherwise auto-detects
+  # TargetRailsVersion from a Gemfile.lock, which is gitignored and absent in CI's
+  # rubocop job (it runs under an appraisal BUNDLE_GEMFILE, no root lock). Detection
+  # then silently falls back to Rails 5.0, where `Rails.env.local?` (7.1+) trips
+  # Rails/UnknownEnv. Pinning makes linting deterministic across local and CI.
+  TargetRubyVersion: 3.3
+  TargetRailsVersion: 7.2
   Exclude:
     - vendor/bundle/**/*
     - gemfiles/**/*.gemfile

--- a/README.md
+++ b/README.md
@@ -99,11 +99,15 @@ All options are set in `config/initializers/apartment.rb` inside an `Apartment.c
 
 ### Pool Settings
 
-`tenant_pool_size`: connections per tenant pool (default: 5).
+`tenant_pool_size`: max connections per tenant pool. Default `nil` — each tenant pool inherits the app's base pool size (`DB_POOL_SIZE` / `pool:` in `database.yml`). Set it to size tenant pools independently of the app pool (e.g. to bound total connections across many schema-per-tenant pools).
 
-`pool_idle_timeout`: seconds before an idle tenant pool is eligible for reaping (default: 300).
+`pool_idle_timeout`: seconds an idle tenant pool must exceed before it is eligible for reaping (default: 300).
 
-`max_total_connections`: hard cap across all tenant pools; nil for unlimited (default: nil).
+`reaper_interval`: seconds between background reap passes. Default `nil` — derives from `pool_idle_timeout`. Set it lower to reap more often without shrinking the idle window.
+
+`max_total_connections`: ceiling on the number of live tenant pools; `nil` for unlimited (default: `nil`). Enforced synchronously at pool-creation time (see `pool_overflow_policy`) and trimmed continuously by the background reaper. Total backend connections ≈ `max_total_connections × tenant_pool_size`.
+
+`pool_overflow_policy`: behavior when a new pool would breach `max_total_connections` and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
 
 ### Elevator (Request Tenant Detection)
 

--- a/docs/designs/pool-admission-control.md
+++ b/docs/designs/pool-admission-control.md
@@ -1,0 +1,133 @@
+# Pool Admission Control (max_total_connections as a real ceiling)
+
+## TLDR
+
+`max_total_connections` was background GC, not a ceiling: `PoolManager#fetch_or_create`
+always registered a new pool, and the cap was enforced only later by the
+`PoolReaper`, which skips in-use/pinned pools. A create-heavy fan-out could exceed
+`max_total × pool_size` indefinitely. Fix: **synchronous admission control** — when a
+new pool would breach the cap, `fetch_or_create` evicts the LRU *idle* pool inline
+before establishing the new one. When no pool can be evicted (all pinned/in-use), a
+`pool_overflow_policy` decides: **`:evict_idle`** (default, soft cap — allow the pool,
+emit `:cap_unmet`) or **`:raise`** (`PoolCapacityReached`, hard fail). The reaper keeps
+running as the steady-state trimmer.
+
+## Problem
+
+`PoolManager#fetch_or_create` uses `Concurrent::Map#compute_if_absent`: a new tenant
+key always creates and registers a pool. Nothing checks `max_total` on that path. The
+ceiling lives in `PoolReaper#evict_lru`, which runs on a timer and **skips protected
+pools** (pinned by fixtures, or with a leased connection / open transaction).
+
+So with a burst of distinct tenants — or pools held in-use faster than the reaper
+evicts — pool count grows past `max_total` and stays there until enough pools go idle.
+For a large schema-per-tenant adopter this means total backend connections
+(`pool count × tenant_pool_size`) can blow past the budget a PgBouncer / RDS Proxy or
+the database itself is sized for. The cap that was supposed to protect that budget does
+nothing on the hot path.
+
+## Design
+
+### Admission seam in `fetch_or_create`
+
+When a cap is configured, `PoolManager` routes cold creates through a serialized
+admission path:
+
+1. **Hot path unchanged.** An existing pool returns lock-free (a `Concurrent::Map`
+   read + timestamp touch). No cap logic on reuse.
+2. **Cold path serialized.** Under a per-manager `@create_mutex`, double-check the key,
+   then call `admission_controller.admit!(tenant_key)`, then establish + register the
+   pool. The capacity check, the eviction, and the insert are atomic with respect to
+   other creators, so the count is a true upper bound: only the create path adds pools,
+   and it never adds while at capacity (except the documented soft-overflow case).
+
+`admit!` is the `PoolReaper` itself — it already owns eviction policy, the
+pinned/in-use protection predicates, and AR-handler deregistration. Reusing it keeps a
+single eviction implementation (`evict_tenant`) for both the timer and admission paths.
+`PoolManager` stays a cache; the reaper stays the eviction authority; the manager asks
+the authority to make room.
+
+```
+admit!(incoming):
+  return unless max_total
+  while pool_count >= max_total:
+    break unless evict_one_idle_evictable(exclude: incoming)   # LRU, skip pinned/in-use/default
+  return if pool_count < max_total
+  apply_overflow_policy(incoming)
+```
+
+`admit!` drains to strictly below the cap (so the incoming pool lands at exactly
+`max_total`), absorbing any prior soft-overflow at the same time.
+
+### Overflow policy (the no-idle-pool case)
+
+When every other pool is pinned or in-use, eviction can't free a slot. The policy
+decides what happens then. Eviction of an idle pool when one *is* available is **not**
+policy-dependent — it always happens; the policy only governs saturation.
+
+| Policy | At capacity, an idle pool exists | At capacity, all pinned/in-use |
+|---|---|---|
+| `:evict_idle` (default) | Evict LRU idle, admit new | **Soft cap** — admit anyway, emit `:cap_unmet` |
+| `:raise` | Evict LRU idle, admit new | **Hard fail** — raise `PoolCapacityReached` |
+
+### Recommendation — default `:evict_idle`
+
+**Prioritize request availability; make the hard ceiling opt-in.** `:evict_idle` never
+blocks or fails a request: it bounds steady-state growth (every admission evicts before
+it adds) and only exceeds the cap transiently when *every* pool is genuinely busy — a
+self-correcting condition the reaper trims as soon as work finishes. This matches the
+existing reaper, which already emits `:cap_unmet` rather than killing in-use pools.
+
+Adopters who must not exceed a backend connection budget under any condition (a fixed
+PgBouncer ceiling) opt into `:raise` and shed load at the edge. The cost of `:raise` is
+that a saturation spike surfaces as request errors instead of a transient overshoot.
+
+### Request-path latency trade-off
+
+Serializing cold creates under `@create_mutex` means concurrent first-touches of
+*different* tenants run one at a time, and `establish_connection` (DB I/O) is held under
+the lock. This is deliberate: a hard count bound requires serializing the check-and-add.
+It applies only when `max_total_connections` is set (opt-in), only to cold creates (once
+per tenant per worker), never to the hot reuse path. The alternative — a lock-free check
+— can't bound the count because two creators can both observe headroom and both add.
+
+## Alternatives considered
+
+- **Enforce in the reaper only (status quo).** Eventually-consistent; cannot bound a
+  burst. This is the bug.
+- **Admission in `ConnectionHandling` before `fetch_or_create`.** The size-check and the
+  create aren't atomic across request threads, so the count can overshoot by the number
+  of concurrent cold creates. Rejected for a non-atomic bound.
+- **`:block` policy (wait for a pool to free, then evict).** Considered and **deferred.**
+  It needs a wait-timeout config and condition-variable signaling, holds `@create_mutex`
+  while parked (stalling all other cold creates), and buys little over the two shipped
+  policies: `:evict_idle` already prevents unbounded growth, and `:raise` already gives a
+  hard ceiling with simpler, more predictable failure semantics than a bounded wait that
+  ends in a raise anyway. No adopter has asked for blocking back-pressure. Adding it later
+  is localized: a third `when` in `apply_overflow_policy` plus a timeout config. Revisit
+  if an adopter needs to throttle (not fail) at saturation.
+- **Evict a single pool per admission (no drain loop).** Keeps net growth flat but never
+  recovers from a prior overshoot inline. The drain loop converges without waiting for the
+  reaper, at negligible cost (pool count is small).
+
+## Configuration
+
+- `pool_overflow_policy` — `:evict_idle` (default) or `:raise`. Only meaningful with
+  `max_total_connections` set.
+
+## Scope / out of scope
+
+- In scope: synchronous admission, the two policies, reuse of the reaper's eviction.
+- Out of scope: `:block` (deferred, above); the libpq `options` search_path change
+  (issue #438); per-tenant pool sizing (issue A, shipped separately).
+
+## Testing
+
+- `admit!` at capacity evicts the LRU idle pool; below capacity and unconfigured-cap are
+  no-ops.
+- All-in-use saturation: `:evict_idle` allows overflow + emits `:cap_unmet`; `:raise`
+  raises `PoolCapacityReached`.
+- `fetch_or_create` calls `admit!` on cold create only (not on warm reuse); the count
+  stays `<= max_total` across a create fan-out with idle pools, without running the
+  reaper.
+- No regression to the reaper timer path (idle + LRU eviction specs unchanged).

--- a/docs/designs/pool-admission-control.md
+++ b/docs/designs/pool-admission-control.md
@@ -1,8 +1,8 @@
-# Pool Admission Control (max_total_connections as a real ceiling)
+# Pool Admission Control (enforcing max_total_connections at create time)
 
 ## TLDR
 
-`max_total_connections` was background GC, not a ceiling: `PoolManager#fetch_or_create`
+`max_total_connections` was background GC, not an enforced bound: `PoolManager#fetch_or_create`
 always registered a new pool, and the cap was enforced only later by the
 `PoolReaper`, which skips in-use/pinned pools. A create-heavy fan-out could exceed
 `max_total × pool_size` indefinitely. Fix: **synchronous admission control** — when a
@@ -85,11 +85,19 @@ that a saturation spike surfaces as request errors instead of a transient oversh
 ### Request-path latency trade-off
 
 Serializing cold creates under `@create_mutex` means concurrent first-touches of
-*different* tenants run one at a time, and `establish_connection` (DB I/O) is held under
-the lock. This is deliberate: a hard count bound requires serializing the check-and-add.
-It applies only when `max_total_connections` is set (opt-in), only to cold creates (once
-per tenant per worker), never to the hot reuse path. The alternative — a lock-free check
-— can't bound the count because two creators can both observe headroom and both add.
+*different* tenants run one at a time. The whole create block is held under the lock —
+not just `establish_connection`, but the pending-migration check and any per-tenant
+schema-cache file load that follow it in `ConnectionHandling`. This is deliberate: a hard
+count bound requires serializing the check-and-add. It applies only when
+`max_total_connections` is set (opt-in), only to cold creates (once per tenant per
+worker), never to the hot reuse path. The alternative — a lock-free check — can't bound
+the count because two creators can both observe headroom and both add. The widest case is
+a deploy cold-start burst, where many workers cold-create concurrently; size
+`max_total_connections` and the worker count with that window in mind.
+
+Blast radius of `:raise`: `PoolCapacityReached` propagates out of the create path, so it
+surfaces as a 500 in a web request or a failed job — intentional load-shedding, not a
+silent drop. `:evict_idle` (default) never fails a request.
 
 ## Alternatives considered
 
@@ -120,6 +128,30 @@ per tenant per worker), never to the hot reuse path. The alternative — a lock-
 - In scope: synchronous admission, the two policies, reuse of the reaper's eviction.
 - Out of scope: `:block` (deferred, above); the libpq `options` search_path change
   (issue #438); per-tenant pool sizing (issue A, shipped separately).
+
+## Known limitations & shared races
+
+- **`:evict_idle` is a tight soft cap, not a hard ceiling.** It bounds steady-state
+  growth (every admission evicts before it adds) but, when *every* pool is pinned or
+  in use, it admits the new pool and emits `:cap_unmet` rather than blocking or
+  failing. The count can therefore transiently exceed `max_total` under genuine
+  saturation. Adopters who need a hard ceiling (a fixed PgBouncer / RDS Proxy budget)
+  must set `pool_overflow_policy: :raise`.
+- **Eviction is best-effort (TOCTOU).** `admit!` reuses the reaper's `protected_pool?`
+  → `evict_tenant` sequence, which checks pinned/in-use then removes as separate steps.
+  A pool can become in-use in the sub-millisecond window between. This is the same
+  race the background reaper already has (see `docs/testing.md`, "Pool lifecycle in
+  tests") — admission adds a request-thread trigger but no new race class. Cost of an
+  unlucky race is an in-flight query error on that pool, not cross-tenant data loss
+  (pool config is tenant-specific; disconnect fails closed).
+- **Do not resolve tenant pools from eviction hooks or admission-time subscribers.**
+  `@create_mutex` is non-reentrant; a custom `on_evict` callback or `:evict`/`:cap_unmet`
+  subscriber that calls `ActiveRecord::Base.connection_pool` for an uncached tenant on
+  the creating thread would self-deadlock. The shipped paths don't do this.
+- **Cap accounting trusts `PoolManager`'s count.** A pool that AR registers but
+  `PoolManager` never stores (a post-`establish_connection` failure in
+  `ConnectionHandling`) would undercount toward the cap. `ConnectionHandling`
+  deregisters the shard on such failures so the count stays honest.
 
 ## Testing
 

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -210,9 +210,11 @@ Key config options for pool tuning:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `tenant_pool_size` | 5 | Connections per tenant pool |
-| `pool_idle_timeout` | 300 | Seconds before idle pool eviction |
-| `max_total_connections` | nil | Hard cap across all tenant pools |
+| `tenant_pool_size` | nil | Max connections per tenant pool; nil inherits the app's base pool size |
+| `pool_idle_timeout` | 300 | Seconds an idle pool must exceed before it is eligible for reaping |
+| `reaper_interval` | nil | Seconds between reap passes; nil derives from `pool_idle_timeout` |
+| `max_total_connections` | nil | Ceiling on live tenant pools; enforced synchronously at create time |
+| `pool_overflow_policy` | `:evict_idle` | At-capacity-with-no-idle-pool behavior: `:evict_idle` (soft) or `:raise` (hard) |
 
 ## Migration Steps
 
@@ -385,7 +387,7 @@ Ensure these names match exactly what `Apartment::Tenant.create` received (case-
 
 ### Connection pool sizing
 
-Each tenant gets `tenant_pool_size` connections (default: 5). For apps with many tenants, set `max_total_connections` to cap total database connections:
+By default (`tenant_pool_size = nil`) each tenant pool inherits the app's base pool size. For apps with many tenants, set `tenant_pool_size` to size tenant pools independently and `max_total_connections` to bound the live pool count — total backend connections ≈ `max_total_connections × tenant_pool_size`:
 
 ```ruby
 Apartment.configure do |config|
@@ -394,7 +396,7 @@ Apartment.configure do |config|
 end
 ```
 
-Idle pools are evicted after `pool_idle_timeout` seconds (default: 300). The `PoolReaper` runs in the background and never evicts the default tenant's pool.
+`max_total_connections` is enforced synchronously at pool-creation time: a new pool that would breach the cap first evicts the least-recently-used *idle* pool inline. When every pool is pinned or in use, `pool_overflow_policy` decides — `:evict_idle` (default) allows the pool and emits a `cap_unmet` notification; `:raise` raises `Apartment::PoolCapacityReached`. Idle pools are also reaped in the background after `pool_idle_timeout` seconds (on the `reaper_interval` cadence, which defaults to `pool_idle_timeout`). The `PoolReaper` never evicts the default tenant's pool.
 
 ### Thread safety
 

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -158,16 +158,7 @@ module Apartment # rubocop:disable Metrics/ModuleLength
       @built_in_tenant_validator&.shutdown
       @built_in_tenant_validator = nil
       @config = new_config
-      @pool_manager = PoolManager.new
-      @pool_reaper = PoolReaper.new(
-        pool_manager: @pool_manager,
-        interval: new_config.pool_idle_timeout,
-        idle_timeout: new_config.pool_idle_timeout,
-        max_total: new_config.max_total_connections,
-        default_tenant: new_config.default_tenant,
-        shard_key_prefix: new_config.shard_key_prefix
-      )
-      @pool_reaper.start
+      setup_pools!(new_config)
       @config
     end
 
@@ -261,6 +252,25 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     def built_in_tenant_validator
       @built_in_tenant_validator ||
         BUILT_IN_VALIDATOR_MUTEX.synchronize { @built_in_tenant_validator ||= TenantValidator.new }
+    end
+
+    # Build the pool manager + reaper for a freshly-validated config and start
+    # the background reaper. When max_total_connections is set, wire the reaper
+    # as the pool manager's admission controller so cold creates are bounded
+    # synchronously; otherwise the manager keeps its lock-free create path.
+    def setup_pools!(new_config)
+      @pool_manager = PoolManager.new
+      @pool_reaper = PoolReaper.new(
+        pool_manager: @pool_manager,
+        interval: new_config.reaper_interval,
+        idle_timeout: new_config.pool_idle_timeout,
+        max_total: new_config.max_total_connections,
+        default_tenant: new_config.default_tenant,
+        shard_key_prefix: new_config.shard_key_prefix,
+        overflow_policy: new_config.pool_overflow_policy
+      )
+      @pool_manager.admission_controller = @pool_reaper if new_config.max_total_connections
+      @pool_reaper.start
     end
 
     # Safely tear down old state. Stops the reaper first (so it doesn't

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -59,11 +59,11 @@ lib/apartment/
 
 ### pool_manager.rb — Pool Cache
 
-`Concurrent::Map` storing connection pools by tenant key. Monotonic clock timestamps for idle/LRU tracking. `stats_for` returns `{ seconds_idle: N }`. `clear` disconnects all pools before clearing.
+`Concurrent::Map` storing connection pools by tenant key. Monotonic clock timestamps for idle/LRU tracking. `stats_for` returns `{ seconds_idle: N }`. `clear` disconnects all pools before clearing. When `max_total_connections` is set, `Apartment.configure` wires an `admission_controller` (the reaper) so cold creates route through a serialized, capacity-bounded path; otherwise the lock-free `compute_if_absent` fast path is used. See `docs/designs/pool-admission-control.md`.
 
-### pool_reaper.rb — Pool Eviction
+### pool_reaper.rb — Pool Eviction + Admission
 
-Background `Concurrent::TimerTask` instance that evicts idle and excess tenant pools. Created by `Apartment.configure`, stored as `Apartment.pool_reaper`. Deregisters evicted pools from AR's ConnectionHandler. Default tenant is never evicted.
+Background `Concurrent::TimerTask` that evicts idle and excess tenant pools, and also serves as the pool manager's synchronous admission controller (`admit!`) when a cap is configured — evicting the LRU idle pool inline before a new one is established, applying `pool_overflow_policy` (`:evict_idle` / `:raise`) when no idle pool can be freed. A single `evict_tenant` primitive backs the timer (idle/LRU) and admission paths. Reap cadence (`interval`/`reaper_interval`) is decoupled from the idle window (`idle_timeout`/`pool_idle_timeout`). Created by `Apartment.configure`, stored as `Apartment.pool_reaper`. Deregisters evicted pools from AR's ConnectionHandler. Default tenant is never evicted.
 
 ### adapters/abstract_adapter.rb — Base Adapter
 

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -30,7 +30,8 @@ module Apartment
           strategy: Apartment.config.tenant_strategy,
           adapter_name: effective_base['adapter']
         )
-        resolve_connection_config(tenant, base_config: effective_base)
+        config = resolve_connection_config(tenant, base_config: effective_base)
+        apply_tenant_pool_size(config)
       end
 
       # Resolve a tenant-specific connection config hash.
@@ -257,6 +258,19 @@ module Apartment
       # Connection config with string keys (used by subclasses to build tenant configs).
       def base_config
         connection_config.transform_keys(&:to_s)
+      end
+
+      # Cap the tenant pool's max checkout size to Apartment.config.tenant_pool_size
+      # when configured. Defaults to nil — the tenant pool inherits the base/default
+      # pool's `pool:` (the app's DB_POOL_SIZE), preserving pre-4.0.0.alpha3 behavior.
+      # Set tenant_pool_size to size each per-tenant pool independently of the app pool
+      # (e.g. to bound total connections across many schema-per-tenant pools). The config
+      # is string-keyed here; HashConfig symbolizes it and reads `:pool` for the size.
+      def apply_tenant_pool_size(config)
+        size = Apartment.config.tenant_pool_size
+        return config unless size
+
+        config.merge('pool' => size)
       end
 
       # Connection config for pinned models on the separate-pool path.

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -16,7 +16,8 @@ module Apartment
 
     attr_accessor :tenants_provider, :default_tenant,
                   :default_tenant_switch_allowed,
-                  :tenant_pool_size, :pool_idle_timeout, :max_total_connections,
+                  :tenant_pool_size, :pool_idle_timeout, :reaper_interval,
+                  :max_total_connections, :pool_overflow_policy,
                   :seed_after_create, :seed_data_file,
                   :schema_load_strategy, :schema_file,
                   :parallel_migration_threads,
@@ -33,9 +34,11 @@ module Apartment
       @default_tenant = nil
       @default_tenant_switch_allowed = true
       @excluded_models = []
-      @tenant_pool_size = 5
+      @tenant_pool_size = nil
       @pool_idle_timeout = 300
+      @reaper_interval = nil
       @max_total_connections = nil
+      @pool_overflow_policy = :evict_idle
       @seed_after_create = false
       @seed_data_file = nil
       @schema_load_strategy = nil
@@ -117,6 +120,9 @@ module Apartment
     def apply_defaults!
       # PostgreSQL's default schema is 'public'; avoid forcing every user to set it.
       @default_tenant ||= 'public' if @tenant_strategy == :schema
+      # Reap on the idle-timeout cadence unless an explicit interval decouples
+      # the two (reap more often without shrinking the idle window).
+      @reaper_interval = @pool_idle_timeout if @reaper_interval.nil?
     end
 
     # Validate configuration completeness and consistency.
@@ -144,17 +150,30 @@ module Apartment
 
       @postgres_config&.validate!
 
-      unless @tenant_pool_size.is_a?(Integer) && @tenant_pool_size.positive?
-        raise(ConfigurationError, "tenant_pool_size must be a positive integer, got: #{@tenant_pool_size.inspect}")
+      if @tenant_pool_size && (!@tenant_pool_size.is_a?(Integer) || @tenant_pool_size < 1)
+        raise(ConfigurationError,
+              "tenant_pool_size must be a positive integer or nil, got: #{@tenant_pool_size.inspect}")
       end
 
       unless @pool_idle_timeout.is_a?(Numeric) && @pool_idle_timeout.positive?
         raise(ConfigurationError, "pool_idle_timeout must be a positive number, got: #{@pool_idle_timeout.inspect}")
       end
 
+      # nil is valid pre-apply_defaults! (it derives from pool_idle_timeout); a
+      # set value must be a positive number.
+      if @reaper_interval && (!@reaper_interval.is_a?(Numeric) || !@reaper_interval.positive?)
+        raise(ConfigurationError, "reaper_interval must be a positive number or nil, got: #{@reaper_interval.inspect}")
+      end
+
       if @max_total_connections && (!@max_total_connections.is_a?(Integer) || @max_total_connections < 1)
         raise(ConfigurationError,
               "max_total_connections must be a positive integer or nil, got: #{@max_total_connections.inspect}")
+      end
+
+      unless %i[evict_idle raise].include?(@pool_overflow_policy)
+        raise(ConfigurationError,
+              'pool_overflow_policy must be :evict_idle or :raise, ' \
+              "got: #{@pool_overflow_policy.inspect}")
       end
 
       unless [nil, :schema_rb, :sql].include?(@schema_load_strategy)

--- a/lib/apartment/errors.rb
+++ b/lib/apartment/errors.rb
@@ -33,6 +33,26 @@ module Apartment
   # Raised when the tenant connection pool is exhausted.
   class PoolExhausted < ApartmentError; end
 
+  # Raised when admitting a new tenant pool would exceed max_total_connections
+  # and no idle pool can be evicted to make room, under the :raise overflow
+  # policy. Distinct from PoolExhausted (a single pool's connections) — this is
+  # the process-wide pool-count ceiling. See docs/designs/pool-admission-control.md.
+  class PoolCapacityReached < ApartmentError
+    attr_reader :max_total, :current
+
+    def initialize(max_total: nil, current: nil)
+      @max_total = max_total
+      @current = current
+      super(
+        "Tenant pool capacity reached: #{current.inspect} pools open, " \
+        "max_total_connections is #{max_total.inspect}, and no idle pool could " \
+        'be evicted to admit another (all pinned or in use). Raise ' \
+        'max_total_connections, reduce concurrent tenants, or set ' \
+        'pool_overflow_policy to :evict_idle to allow soft overflow.'
+      )
+    end
+  end
+
   # Raised when schema loading fails during tenant creation.
   class SchemaLoadError < ApartmentError; end
 

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -32,6 +32,13 @@ module Apartment
         pool_key = "#{tenant}:#{role}"
 
         Apartment.pool_manager.fetch_or_create(pool_key) do
+          # RE-ENTRANCY: when max_total_connections is set, this block runs under
+          # PoolManager's @create_mutex (non-reentrant). Nothing here may resolve
+          # ActiveRecord::Base.connection_pool for the current tenant — it would
+          # re-enter fetch_or_create and self-deadlock. `super` resolves the
+          # default pool (bypasses the patch), and check_pending_migrations? /
+          # schema-cache load operate on the explicit `pool`, so all are safe.
+          # Keep it that way if you add work to this block.
           # Resolve base config from the current role's default pool when available.
           # Falls back to nil (adapter uses its own base_config) when the default pool
           # is not accessible — e.g., in worker threads during parallel migration where
@@ -63,9 +70,20 @@ module Apartment
             shard: shard_key
           )
 
-          raise(Apartment::PendingMigrationError, tenant) if check_pending_migrations?(pool)
+          # establish_connection has registered the shard in AR's ConnectionHandler.
+          # If a post-establish check raises, the pool is returned to neither the
+          # caller nor PoolManager — it would be orphaned: live in AR but invisible
+          # to the reaper and to max_total accounting (a connection leak that also
+          # undercounts the cap). Deregister it before re-raising so AR and the
+          # manager stay consistent. The next request re-establishes cleanly.
+          begin
+            raise(Apartment::PendingMigrationError, tenant) if check_pending_migrations?(pool)
 
-          load_tenant_schema_cache(tenant, pool) if cfg.schema_cache_per_tenant
+            load_tenant_schema_cache(tenant, pool) if cfg.schema_cache_per_tenant
+          rescue StandardError
+            Apartment.deregister_shard(pool_key)
+            raise
+          end
 
           pool
         end
@@ -80,7 +98,7 @@ module Apartment
 
       def check_pending_migrations?(pool)
         return false unless Apartment.config.check_pending_migrations
-        return false unless defined?(Rails) && Rails.env.local? # rubocop:disable Rails/UnknownEnv
+        return false unless defined?(Rails) && Rails.env.local?
         return false if Apartment::Current.migrating
 
         pool.migration_context.needs_migration?

--- a/lib/apartment/pool_manager.rb
+++ b/lib/apartment/pool_manager.rb
@@ -4,17 +4,25 @@ require 'concurrent'
 
 module Apartment
   class PoolManager
+    # Set by Apartment.configure to the PoolReaper when max_total_connections is
+    # configured. nil (no cap) keeps the lock-free compute_if_absent fast path.
+    attr_accessor :admission_controller
+
     def initialize
       @pools = Concurrent::Map.new
       @timestamps = Concurrent::Map.new
+      @create_mutex = Mutex.new
+      @admission_controller = nil
     end
 
     # Fetch an existing pool or create one via the block.
     # Timestamp is updated after pool creation to avoid orphaned timestamps if the block raises.
+    # When an admission controller is wired (a cap is configured), cold creates
+    # go through the bounded path so the pool count cannot exceed max_total.
     def fetch_or_create(tenant_key, &)
-      pool = @pools.compute_if_absent(tenant_key, &)
-      touch(tenant_key)
-      pool
+      return fetch_or_admit(tenant_key, &) if @admission_controller
+
+      touch_and_return(tenant_key, @pools.compute_if_absent(tenant_key, &))
     end
 
     def get(tenant_key)
@@ -118,6 +126,32 @@ module Apartment
     end
 
     private
+
+    # Capacity-bounded creation path. Serializes cold creates so the admission
+    # controller's capacity check + eviction + insert is atomic across creators;
+    # the new pool is only inserted after admit! confirms (or makes) room. The
+    # hot path (existing pool) stays lock-free in fetch_or_create. Establishing
+    # the connection under the lock is deliberate: it serializes only cold
+    # creates (once per tenant per worker) — the price of a hard count bound.
+    def fetch_or_admit(tenant_key)
+      existing = @pools[tenant_key]
+      return touch_and_return(tenant_key, existing) if existing
+
+      @create_mutex.synchronize do
+        cached = @pools[tenant_key]
+        return touch_and_return(tenant_key, cached) if cached
+
+        @admission_controller.admit!(tenant_key)
+        pool = yield
+        @pools[tenant_key] = pool
+        touch_and_return(tenant_key, pool)
+      end
+    end
+
+    def touch_and_return(tenant_key, pool)
+      touch(tenant_key)
+      pool
+    end
 
     def touch(tenant_key)
       @timestamps[tenant_key] = monotonic_now

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -124,8 +124,7 @@ module Apartment
         next if default_tenant_pool?(tenant)
         next if protected_pool?(tenant, eviction_reason: :idle)
 
-        evict_tenant(tenant, reason: :idle)
-        count += 1
+        count += 1 if evict_tenant(tenant, reason: :idle)
       rescue StandardError => e
         warn "[Apartment::PoolReaper] Failed to evict tenant #{tenant}: #{e.class}: #{e.message}"
       end
@@ -137,7 +136,12 @@ module Apartment
     # ConnectionHandler (which disconnects the pool), instrument, and fire the
     # on_evict hook. The +reason+ flows into the :evict event payload.
     def evict_tenant(tenant, reason:)
-      pool = @pool_manager.remove(tenant)
+      # The timer (no lock) and admission (under @create_mutex) use different
+      # locks, so both can target the same idle tenant. The loser's remove
+      # returns nil — bail before firing a duplicate :evict event or calling
+      # on_evict with a nil pool.
+      return nil unless (pool = @pool_manager.remove(tenant))
+
       deregister_from_ar_handler(tenant)
       Instrumentation.instrument(:evict, tenant: tenant, reason: reason)
       @on_evict&.call(tenant, pool)
@@ -201,8 +205,7 @@ module Apartment
         next if default_tenant_pool?(tenant)
         next if protected_pool?(tenant, eviction_reason: :lru)
 
-        evict_tenant(tenant, reason: :lru)
-        evicted += 1
+        evicted += 1 if evict_tenant(tenant, reason: :lru)
       rescue StandardError => e
         warn "[Apartment::PoolReaper] Failed to evict tenant #{tenant}: #{e.class}: #{e.message}"
       end

--- a/lib/apartment/pool_reaper.rb
+++ b/lib/apartment/pool_reaper.rb
@@ -7,7 +7,13 @@ module Apartment
   # Evicts idle and excess tenant pools on a background timer.
   # Complementary to ActiveRecord's ConnectionPool::Reaper which handles
   # intra-pool connection reaping — this handles inter-pool (tenant) eviction.
-  class PoolReaper
+  class PoolReaper # rubocop:disable Metrics/ClassLength
+    # Reap cadence (seconds) and the idle window (seconds) a pool must exceed
+    # before it is eligible for idle eviction. Decoupled so a deployment can
+    # reap frequently without shrinking the idle window. Exposed for
+    # introspection and wiring assertions.
+    attr_reader :interval, :idle_timeout
+
     # True when Rails' transactional-fixture machinery has pinned the pool
     # (ConnectionPool#pin_connection!, Rails 7.1+). Evicting or discarding a
     # pinned pool strands the fixture transaction; teardown then errors or
@@ -24,7 +30,8 @@ module Apartment
     end
 
     def initialize(pool_manager:, interval:, idle_timeout:, max_total: nil,
-                   default_tenant: nil, shard_key_prefix: nil, on_evict: nil)
+                   default_tenant: nil, shard_key_prefix: nil, on_evict: nil,
+                   overflow_policy: :evict_idle)
       raise(ArgumentError, 'interval must be a positive number') unless interval.is_a?(Numeric) && interval.positive?
       unless idle_timeout.is_a?(Numeric) && idle_timeout.positive?
         raise(ArgumentError, 'idle_timeout must be a positive number')
@@ -40,8 +47,27 @@ module Apartment
       @default_tenant = default_tenant
       @shard_key_prefix = shard_key_prefix
       @on_evict = on_evict
+      @overflow_policy = overflow_policy
       @mutex = Mutex.new
       @timer = nil
+    end
+
+    # Synchronously enforce max_total before a new tenant pool is admitted.
+    # Called by {PoolManager#fetch_or_create} under its creation lock (so the
+    # capacity check, eviction, and insert are atomic w.r.t. other creators).
+    # Evicts LRU idle (non-protected, non-default) pools until there is room for
+    # one more; if none can be freed, applies the overflow policy. A no-op when
+    # no cap is configured. See docs/designs/pool-admission-control.md.
+    def admit!(incoming_tenant_key)
+      return unless @max_total
+
+      loop do
+        break if @pool_manager.stats[:total_pools] < @max_total
+        break unless evict_one_for_admission(incoming_tenant_key)
+      end
+      return if @pool_manager.stats[:total_pools] < @max_total
+
+      apply_overflow_policy
     end
 
     def start
@@ -98,15 +124,55 @@ module Apartment
         next if default_tenant_pool?(tenant)
         next if protected_pool?(tenant, eviction_reason: :idle)
 
-        pool = @pool_manager.remove(tenant)
-        deregister_from_ar_handler(tenant)
-        Instrumentation.instrument(:evict, tenant: tenant, reason: :idle)
-        @on_evict&.call(tenant, pool)
+        evict_tenant(tenant, reason: :idle)
         count += 1
       rescue StandardError => e
         warn "[Apartment::PoolReaper] Failed to evict tenant #{tenant}: #{e.class}: #{e.message}"
       end
       count
+    end
+
+    # Single eviction primitive shared by the timer paths (idle/LRU) and the
+    # synchronous admission path: drop from the manager, deregister from AR's
+    # ConnectionHandler (which disconnects the pool), instrument, and fire the
+    # on_evict hook. The +reason+ flows into the :evict event payload.
+    def evict_tenant(tenant, reason:)
+      pool = @pool_manager.remove(tenant)
+      deregister_from_ar_handler(tenant)
+      Instrumentation.instrument(:evict, tenant: tenant, reason: reason)
+      @on_evict&.call(tenant, pool)
+      pool
+    end
+
+    # Evict the single LRU evictable pool to make room for an incoming one,
+    # skipping the incoming key, the default tenant, and pinned/in-use pools.
+    # Returns the evicted tenant key, or nil if nothing is evictable.
+    def evict_one_for_admission(incoming_tenant_key)
+      @pool_manager.lru_tenants(count: @pool_manager.stats[:total_pools]).each do |tenant|
+        next if tenant == incoming_tenant_key
+        next if default_tenant_pool?(tenant)
+        next if protected_pool?(tenant, eviction_reason: :admission)
+
+        evict_tenant(tenant, reason: :admission)
+        return tenant
+      rescue StandardError => e
+        warn "[Apartment::PoolReaper] Failed to evict tenant #{tenant} for admission: #{e.class}: #{e.message}"
+      end
+      nil
+    end
+
+    # Applied when the cap can't be met by eviction (every other pool is pinned
+    # or in use). :evict_idle degrades to a soft cap — allow the new pool, surface
+    # the breach via :cap_unmet. :raise fails the admission so the caller sheds
+    # load. See docs/designs/pool-admission-control.md.
+    def apply_overflow_policy
+      current = @pool_manager.stats[:total_pools]
+      case @overflow_policy
+      when :raise
+        raise(Apartment::PoolCapacityReached.new(max_total: @max_total, current: current))
+      else
+        Instrumentation.instrument(:cap_unmet, max_total: @max_total, current: current, unevicted: 1)
+      end
     end
 
     def evict_lru
@@ -135,10 +201,7 @@ module Apartment
         next if default_tenant_pool?(tenant)
         next if protected_pool?(tenant, eviction_reason: :lru)
 
-        pool = @pool_manager.remove(tenant)
-        deregister_from_ar_handler(tenant)
-        Instrumentation.instrument(:evict, tenant: tenant, reason: :lru)
-        @on_evict&.call(tenant, pool)
+        evict_tenant(tenant, reason: :lru)
         evicted += 1
       rescue StandardError => e
         warn "[Apartment::PoolReaper] Failed to evict tenant #{tenant}: #{e.class}: #{e.message}"

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha2'
+  VERSION = '4.0.0.alpha3'
 end

--- a/spec/integration/v4/memory_stability_spec.rb
+++ b/spec/integration/v4/memory_stability_spec.rb
@@ -185,4 +185,69 @@ RSpec.describe('v4 Memory stability integration', :integration,
                              "Expected #{expected_pools} pools after 200 switches, got #{final_pools}")
     end
   end
+
+  # ── Synchronous admission control: hard bound without the reaper ────
+  context 'synchronous admission control',
+          skip: (if V4IntegrationHelper.sqlite?
+                   'SQLite pool-per-tenant less meaningful with single-writer lock'
+                 else
+                   false
+                 end) do
+    let(:tmp_dir) { Dir.mktmpdir('apartment_admission') }
+    let(:tenants) { Array.new(12) { |i| "admit_#{i}" } }
+
+    before do
+      V4IntegrationHelper.ensure_test_database!
+      config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+      V4IntegrationHelper.create_test_table!
+
+      Apartment.configure do |c|
+        c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+        c.tenants_provider = -> { tenants }
+        c.default_tenant = V4IntegrationHelper.default_tenant
+        c.max_total_connections = 4
+        c.check_pending_migrations = false
+      end
+
+      Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+      Apartment.activate!
+
+      tenants.each do |t|
+        Apartment.adapter.create(t)
+        Apartment::Tenant.switch(t) do
+          V4IntegrationHelper.create_test_table!('widgets', connection: ActiveRecord::Base.connection)
+        end
+      end
+    end
+
+    after do
+      V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter)
+      Apartment.clear_config
+      Apartment::Current.reset
+      FileUtils.rm_rf(tmp_dir)
+    end
+
+    it 'never exceeds max_total_connections during a cold fan-out, with the reaper stopped' do
+      stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+
+      # Setup primed 12 pools: each schema-creating switch held a sticky lease,
+      # so admission (default :evict_idle) correctly soft-overflowed rather than
+      # evicting in-use pools. Start the bounded fan-out from a clean slate so
+      # every switch is a cold create that exercises admission, and stop the
+      # timer so the bound is enforced by admission alone, not background GC.
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+      Apartment.reset_tenant_pools!
+      Apartment.pool_reaper.stop
+
+      tenants.each do |t|
+        Apartment::Tenant.switch(t) { Widget.create!(name: 'x') }
+        # Release the sticky lease so each just-used pool is idle and evictable
+        # for the next admission (mirrors the request/job boundary).
+        ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
+        count = Apartment.pool_manager.stats[:total_pools]
+        expect(count).to(be <= 4, "expected <= 4 pools after switching #{t}, got #{count}")
+      end
+    end
+  end
 end

--- a/spec/integration/v4/tenant_pool_size_spec.rb
+++ b/spec/integration/v4/tenant_pool_size_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+
+# tenant_pool_size sizes each per-tenant pool independently of the app's
+# default pool. Defaults to nil (inherit the base pool); when set, the created
+# tenant ConnectionPool's max checkout size must reflect it. See issue A and
+# AbstractAdapter#apply_tenant_pool_size.
+RSpec.describe('v4 tenant_pool_size', :integration,
+               skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
+  include V4IntegrationHelper
+
+  let(:tmp_dir) { Dir.mktmpdir('apartment_pool_size') }
+  let(:tenant) { 'pool_size_acme' }
+
+  before do
+    V4IntegrationHelper.ensure_test_database!
+    config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+    V4IntegrationHelper.create_test_table!
+
+    Apartment.configure do |c|
+      c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+      c.tenants_provider = -> { [tenant] }
+      c.default_tenant = V4IntegrationHelper.default_tenant
+      c.tenant_pool_size = 3
+      c.check_pending_migrations = false
+    end
+
+    Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+    Apartment.activate!
+    Apartment.adapter.create(tenant)
+  end
+
+  after do
+    V4IntegrationHelper.cleanup_tenants!([tenant], Apartment.adapter)
+    Apartment.clear_config
+    Apartment::Current.reset
+    FileUtils.rm_rf(tmp_dir)
+  end
+
+  it 'sizes the created tenant pool to tenant_pool_size' do
+    role = ActiveRecord::Base.current_role
+    Apartment::Tenant.switch(tenant) do
+      ActiveRecord::Base.connection.execute('SELECT 1')
+    end
+
+    pool = Apartment.pool_manager.peek("#{tenant}:#{role}")
+    expect(pool).not_to(be_nil)
+    expect(pool.size).to(eq(3))
+  end
+end

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -95,6 +95,28 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter, :isolate_pinned_models) do
       result = adapter.validated_connection_config('acme', base_config_override: nil)
       expect(result).to(eq('adapter' => 'postgresql', 'database' => 'acme', 'host' => 'localhost'))
     end
+
+    context 'tenant_pool_size' do
+      it 'does not inject a pool size when tenant_pool_size is nil (inherit base pool)' do
+        reconfigure(tenant_pool_size: nil)
+        result = adapter.validated_connection_config('acme')
+        expect(result).not_to(have_key('pool'))
+      end
+
+      it 'injects pool when tenant_pool_size is set' do
+        reconfigure(tenant_pool_size: 3)
+        result = adapter.validated_connection_config('acme')
+        expect(result).to(include('pool' => 3))
+      end
+
+      it 'overrides a pool size carried by the base config' do
+        reconfigure(tenant_pool_size: 2)
+        result = adapter.validated_connection_config(
+          'acme', base_config_override: { 'adapter' => 'postgresql', 'pool' => 25 }
+        )
+        expect(result).to(include('pool' => 2))
+      end
+    end
   end
 
   describe '#resolve_connection_config' do

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -278,6 +278,50 @@ RSpec.describe(Apartment) do
       described_class.clear_config
       expect(described_class.pool_reaper).to(be_nil)
     end
+
+    it 'wires reaper_interval and pool_idle_timeout independently' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.pool_idle_timeout = 300
+        config.reaper_interval = 30
+      end
+      reaper = described_class.pool_reaper
+      expect(reaper.interval).to(eq(30))
+      expect(reaper.idle_timeout).to(eq(300))
+    end
+
+    it 'defaults the reaper interval to pool_idle_timeout for back-compat' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.pool_idle_timeout = 120
+      end
+      reaper = described_class.pool_reaper
+      expect(reaper.interval).to(eq(120))
+      expect(reaper.idle_timeout).to(eq(120))
+    end
+  end
+
+  describe 'pool admission control wiring' do
+    after { described_class.clear_config }
+
+    it 'leaves the pool manager uncapped when max_total_connections is nil' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+      end
+      expect(described_class.pool_manager.admission_controller).to(be_nil)
+    end
+
+    it 'wires the reaper as the admission controller when a cap is set' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.max_total_connections = 5
+      end
+      expect(described_class.pool_manager.admission_controller).to(eq(described_class.pool_reaper))
+    end
   end
 
   describe '.configure teardown protection' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.tenants_provider).to(be_nil) }
     it { expect(config.default_tenant).to(be_nil) }
     it { expect(config.excluded_models).to(eq([])) }
-    it { expect(config.tenant_pool_size).to(eq(5)) }
+    it { expect(config.tenant_pool_size).to(be_nil) }
     it { expect(config.pool_idle_timeout).to(eq(300)) }
+    it { expect(config.reaper_interval).to(be_nil) }
     it { expect(config.max_total_connections).to(be_nil) }
+    it { expect(config.pool_overflow_policy).to(eq(:evict_idle)) }
     it { expect(config.seed_after_create).to(be(false)) }
     it { expect(config.seed_data_file).to(be_nil) }
     it { expect(config.parallel_migration_threads).to(eq(0)) }
@@ -153,6 +155,20 @@ RSpec.describe(Apartment::Config) do
       expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /tenant_pool_size/))
     end
 
+    it 'allows tenant_pool_size to be nil (inherit the base pool size)' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_pool_size = nil
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'allows tenant_pool_size to be a positive integer' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_pool_size = 3
+      expect { config.validate! }.not_to(raise_error)
+    end
+
     it 'raises when pool_idle_timeout is not a positive number' do
       config.tenant_strategy = :schema
       config.tenants_provider = -> { [] }
@@ -167,10 +183,59 @@ RSpec.describe(Apartment::Config) do
       expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_total_connections/))
     end
 
+    it 'raises when reaper_interval is not a positive number' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.reaper_interval = 0
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /reaper_interval/))
+    end
+
+    it 'allows reaper_interval to be nil (defaults to pool_idle_timeout)' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.reaper_interval = nil
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'raises when pool_overflow_policy is unknown' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.pool_overflow_policy = :block
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /pool_overflow_policy/))
+    end
+
+    it 'accepts :raise as a pool_overflow_policy' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.pool_overflow_policy = :raise
+      expect { config.validate! }.not_to(raise_error)
+    end
+
     it 'passes with valid minimal configuration' do
       config.tenant_strategy = :schema
       config.tenants_provider = -> { [] }
       expect { config.validate! }.not_to(raise_error)
+    end
+
+    context 'reaper_interval defaulting' do
+      before do
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+      end
+
+      it 'defaults reaper_interval to pool_idle_timeout when not set' do
+        config.pool_idle_timeout = 120
+        config.apply_defaults!
+        expect(config.reaper_interval).to(eq(120))
+      end
+
+      it 'preserves an explicit reaper_interval distinct from pool_idle_timeout' do
+        config.pool_idle_timeout = 300
+        config.reaper_interval = 30
+        config.apply_defaults!
+        expect(config.reaper_interval).to(eq(30))
+        expect(config.pool_idle_timeout).to(eq(300))
+      end
     end
 
     context 'default_tenant auto-defaulting' do

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -154,6 +154,33 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
                  )).to(be_nil)
         end
       end
+
+      it 'deregisters the shard when a post-establish step raises (no orphaned pool)' do
+        # Drive a failure *after* establish_connection has registered the shard by
+        # making the per-tenant schema-cache load blow up. Without the rescue in
+        # ConnectionHandling the pool would be left live in AR but untracked by
+        # PoolManager — a leak that also undercounts max_total.
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { %w[acme widgets] }
+          config.default_tenant = 'public'
+          config.check_pending_migrations = false
+          config.schema_cache_per_tenant = true
+        end
+        Apartment.adapter = mock_adapter
+        allow(Apartment::SchemaCache).to(receive(:cache_path_for).and_raise(StandardError, 'cache boom'))
+
+        Apartment::Current.tenant = 'acme'
+        role = ActiveRecord::Base.current_role
+        shard_key = :"#{Apartment.config.shard_key_prefix}_acme:#{role}"
+
+        expect { ActiveRecord::Base.connection_pool }.to(raise_error(Apartment::ApartmentError))
+
+        expect(ActiveRecord::Base.connection_handler.retrieve_connection_pool(
+                 'ActiveRecord::Base', role: role, shard: shard_key
+               )).to(be_nil)
+        expect(Apartment.pool_manager.tracked?("acme:#{role}")).to(be(false))
+      end
     end
 
     context 'pool usability' do

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -37,6 +37,60 @@ RSpec.describe(Apartment::PoolManager) do
     end
   end
 
+  describe '#fetch_or_create with an admission controller' do
+    # A fake admission controller that records the keys it was asked to admit
+    # and can be told to evict a specific tenant inline (mirroring the reaper).
+    def controller(&admit)
+      admit ||= ->(_key) {}
+      ctrl = Object.new
+      ctrl.define_singleton_method(:admit!, &admit)
+      ctrl
+    end
+
+    it 'calls admit! before building a pool on the cold path' do
+      seen = []
+      manager.admission_controller = controller { |key| seen << key }
+
+      manager.fetch_or_create('acme') { 'pool_acme' }
+      expect(seen).to(eq(['acme']))
+    end
+
+    it 'does not call admit! when reusing an existing pool (hot path)' do
+      manager.fetch_or_create('acme') { 'pool_acme' }
+      seen = []
+      manager.admission_controller = controller { |key| seen << key }
+
+      result = manager.fetch_or_create('acme') { 'should_not_build' }
+      expect(result).to(eq('pool_acme'))
+      expect(seen).to(be_empty)
+    end
+
+    it 'evicts inline so the count stays within cap across a cold fan-out' do
+      # admit! removes the LRU pool whenever two are already tracked, capping at 2.
+      mgr = manager
+      manager.admission_controller = controller do |_key|
+        mgr.remove(mgr.lru_tenants(count: 1).first) if mgr.stats[:total_pools] >= 2
+      end
+
+      5.times { |i| manager.fetch_or_create("t#{i}") { "p#{i}" } }
+      expect(manager.stats[:total_pools]).to(be <= 2)
+    end
+
+    it 'does not store a pool and re-raises when the block raises under admission' do
+      manager.admission_controller = controller
+      expect { manager.fetch_or_create('bad') { raise('boom') } }
+        .to(raise_error(RuntimeError, 'boom'))
+      expect(manager.tracked?('bad')).to(be(false))
+    end
+
+    it 'propagates an admit! raise without building the pool' do
+      manager.admission_controller = controller { |_key| raise(Apartment::PoolCapacityReached.new(max_total: 1)) }
+      expect { manager.fetch_or_create('acme') { 'pool_acme' } }
+        .to(raise_error(Apartment::PoolCapacityReached))
+      expect(manager.tracked?('acme')).to(be(false))
+    end
+  end
+
   describe '#get' do
     it 'returns the pool for an existing tenant' do
       manager.fetch_or_create('tenant_a') { 'pool_a' }

--- a/spec/unit/pool_reaper_spec.rb
+++ b/spec/unit/pool_reaper_spec.rb
@@ -496,4 +496,118 @@ RSpec.describe(Apartment::PoolReaper) do
       expect(pool_manager.tracked?('stale')).to(be(false))
     end
   end
+
+  describe '#admit! (synchronous admission control)' do
+    # A pool with a leased connection — the reaper's in-use guard must protect
+    # it from admission eviction just as it protects it from timer eviction.
+    def in_use_pool(leased: true, open_tx: 0)
+      pool = Object.new
+      conn = Object.new
+      conn.define_singleton_method(:in_use?) { leased }
+      conn.define_singleton_method(:open_transactions) { open_tx }
+      pool.define_singleton_method(:connections) { [conn] }
+      pool
+    end
+
+    def stamp(tenant, seconds_ago)
+      pool_manager.instance_variable_get(:@timestamps)[tenant] =
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - seconds_ago
+    end
+
+    let(:reaper) do
+      described_class.new(
+        pool_manager: pool_manager,
+        interval: 0.05,
+        idle_timeout: 999,
+        max_total: 2,
+        default_tenant: 'public',
+        on_evict: on_evict
+      )
+    end
+
+    it 'is a no-op below capacity' do
+      pool_manager.fetch_or_create('a') { 'pool_a' }
+      reaper.admit!('incoming')
+      expect(disconnect_calls).to(be_empty)
+      expect(pool_manager.tracked?('a')).to(be(true))
+    end
+
+    it 'is a no-op when no cap is configured' do
+      uncapped = described_class.new(
+        pool_manager: pool_manager, interval: 0.05, idle_timeout: 999, on_evict: on_evict
+      )
+      3.times { |i| pool_manager.fetch_or_create("t#{i}") { "p#{i}" } }
+      uncapped.admit!('incoming')
+      expect(disconnect_calls).to(be_empty)
+    end
+
+    it 'evicts the LRU idle pool to make room when at capacity' do
+      pool_manager.fetch_or_create('old') { 'pool_old' }
+      stamp('old', 300)
+      pool_manager.fetch_or_create('recent') { 'pool_recent' }
+      stamp('recent', 10)
+
+      reaper.admit!('incoming')
+
+      expect(disconnect_calls).to(include('old'))
+      expect(pool_manager.tracked?('old')).to(be(false))
+      expect(pool_manager.tracked?('recent')).to(be(true))
+      expect(pool_manager.stats[:total_pools]).to(be < 2)
+    end
+
+    it 'drains prior overflow until strictly below the cap' do
+      4.times do |i|
+        pool_manager.fetch_or_create("t#{i}") { "p#{i}" }
+        stamp("t#{i}", 300 - i)
+      end
+      reaper.admit!('incoming')
+      expect(pool_manager.stats[:total_pools]).to(be < 2)
+    end
+
+    it 'never evicts the default tenant to make room' do
+      pool_manager.fetch_or_create('public') { 'pool_public' }
+      stamp('public', 9999)
+      pool_manager.fetch_or_create('evictable') { 'pool_e' }
+      stamp('evictable', 100)
+
+      reaper.admit!('incoming')
+
+      expect(pool_manager.tracked?('public')).to(be(true))
+      expect(disconnect_calls).not_to(include('public'))
+      expect(disconnect_calls).to(include('evictable'))
+    end
+
+    context 'when all evictable pools are in use (saturation)' do
+      before do
+        pool_manager.fetch_or_create('busy_a') { in_use_pool(leased: true) }
+        pool_manager.fetch_or_create('busy_b') { in_use_pool(leased: true) }
+        stamp('busy_a', 300)
+        stamp('busy_b', 200)
+      end
+
+      it 'with :evict_idle (default) allows overflow and emits cap_unmet' do
+        events = Concurrent::Array.new
+        ActiveSupport::Notifications.subscribe('cap_unmet.apartment') { |e| events << e }
+
+        expect { reaper.admit!('incoming') }.not_to(raise_error)
+        expect(disconnect_calls).to(be_empty)
+
+        cap_event = events.last
+        expect(cap_event).not_to(be_nil)
+        expect(cap_event.payload).to(include(max_total: 2))
+      ensure
+        ActiveSupport::Notifications.unsubscribe('cap_unmet.apartment')
+      end
+
+      it 'with :raise raises PoolCapacityReached and evicts nothing' do
+        raising = described_class.new(
+          pool_manager: pool_manager, interval: 0.05, idle_timeout: 999,
+          max_total: 2, default_tenant: 'public', overflow_policy: :raise, on_evict: on_evict
+        )
+        expect { raising.admit!('incoming') }
+          .to(raise_error(Apartment::PoolCapacityReached, /capacity/))
+        expect(disconnect_calls).to(be_empty)
+      end
+    end
+  end
 end

--- a/spec/unit/pool_reaper_spec.rb
+++ b/spec/unit/pool_reaper_spec.rb
@@ -610,4 +610,20 @@ RSpec.describe(Apartment::PoolReaper) do
       end
     end
   end
+
+  describe 'eviction race (timer vs admission target the same tenant)' do
+    it 'fires no :evict event and no on_evict when the pool was already removed' do
+      events = Concurrent::Array.new
+      ActiveSupport::Notifications.subscribe('evict.apartment') { |e| events << e }
+
+      # 'ghost' is absent from the manager — a racing evictor already removed it.
+      result = reaper.send(:evict_tenant, 'ghost', reason: :idle)
+
+      expect(result).to(be_nil)
+      expect(disconnect_calls).not_to(include('ghost'))
+      expect(events.any? { |e| e.payload[:tenant] == 'ghost' }).to(be(false))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('evict.apartment')
+    end
+  end
 end


### PR DESCRIPTION
## TLDR

Three connection-pool fixes for safe schema-per-tenant rollout: a dead config now works, a documented ceiling is now actually enforced, and the reaper cadence is no longer welded to the idle window. Full unit suite green (913 examples); integration verified on SQLite, PostgreSQL, and MySQL; RuboCop clean.

## A — `tenant_pool_size` now sizes tenant pools

It was declared, defaulted, and validated, but never applied — `ConnectionHandling` copied the default pool's `configuration_hash` and only merged `schema_search_path`, so every tenant pool inherited the app's `DB_POOL_SIZE`.

- `AbstractAdapter#validated_connection_config` injects `pool:` into the resolved tenant config (the one funnel every adapter shares).
- **Back-compat: default changed `5` → `nil`.** A tenant pool inherits the app's base pool unless `tenant_pool_size` is set. Defaulting to `5` would have silently capped existing adopters' tenant pools.

## B — `max_total_connections` is a real ceiling

Previously background GC only: `fetch_or_create` always registered a new pool, and the cap was enforced lazily by `PoolReaper#evict_lru`, which skips in-use/pinned pools. A create-heavy fan-out could exceed `max_total × pool_size` indefinitely.

- **Synchronous admission control.** When a cap is set, `PoolManager` routes cold creates through a serialized path that evicts the LRU **idle** pool inline before establishing a new one. The hot reuse path stays lock-free.
- The `PoolReaper` doubles as the admission controller, reusing its eviction + pinned/in-use protection via a single shared `evict_tenant` primitive (timer and admission share one implementation).
- New **`pool_overflow_policy`** for the all-pools-busy case: `:evict_idle` (default — soft cap, allow + emit `cap_unmet`, prioritizes availability) or `:raise` (`Apartment::PoolCapacityReached`, hard fail).
- `:block` was considered and **deferred** (rationale in the design note): it needs a wait-timeout + condition-variable signaling, stalls other creates while parked, and adds little over the two shipped policies.

Design + trade-offs: `docs/designs/pool-admission-control.md`.

## C — `reaper_interval` decoupled from `pool_idle_timeout`

The reaper was built with `interval:` and `idle_timeout:` both set to `pool_idle_timeout`, so you couldn't reap more frequently without shrinking the idle window.

- New `reaper_interval` config, defaulting to `pool_idle_timeout` via `apply_defaults!` (back-compat), threaded into `PoolReaper`. Added `interval`/`idle_timeout` readers for introspection.

## New / changed config

| Option | Before | After |
|---|---|---|
| `tenant_pool_size` | default `5` (inert) | default `nil` = inherit base pool; set to cap each tenant pool |
| `reaper_interval` | — | new; default `nil` → derives from `pool_idle_timeout` |
| `max_total_connections` | background-GC only | enforced synchronously at create time |
| `pool_overflow_policy` | — | new; `:evict_idle` (default) / `:raise` |

## Testing

- **Unit:** full suite, 913 examples, 0 failures. New coverage for pool-size injection, `admit!` (below-cap no-op, LRU idle eviction, overflow-drain, default-tenant protection, saturation under both policies), `fetch_or_create` admission wiring (cold vs hot path, re-raise semantics), config defaults/validation, and configure-time wiring.
- **Integration:** `tenant_pool_size` asserts real `pool.size`; a new `memory_stability` context proves the cap holds **synchronously** (reaper stopped) across a cold fan-out. Verified on SQLite, PostgreSQL, and MySQL.
- RuboCop clean on all changed files.

## Out of scope

The libpq `options` search_path change (#438); deferred `:block` overflow policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)