### PR TITLE
config.reap_in_test (v4 pool adopter ergonomics, PR 2/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ All options are set in `config/initializers/apartment.rb` inside an `Apartment.c
 
 `pool_overflow_policy`: behavior when a new pool would breach `max_total_connections` and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
 
-`reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the Railtie stops it in test, where fixture transactions make mid-example eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping — that's cleaner than guarding `RAILS_ENV` at boot to avoid silently leaking connections.
+`reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the Railtie stops it in test, where fixture transactions make mid-example eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping — that's cleaner than guarding `RAILS_ENV` at boot to avoid silently leaking connections. It applies to *every* `Rails.env.test?` process, including CI, so enable it only when a real deployment needs it.
 
 ### Observability
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ All options are set in `config/initializers/apartment.rb` inside an `Apartment.c
 
 `pool_overflow_policy`: behavior when a new pool would breach `max_total_connections` and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
 
+`reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the Railtie stops it in test, where fixture transactions make mid-example eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping — that's cleaner than guarding `RAILS_ENV` at boot to avoid silently leaking connections.
+
 ### Observability
 
 Apartment emits `ActiveSupport::Notifications` for the pool lifecycle and ships

--- a/docs/plans/v4-pool-adopter-ergonomics/pr2-reap-in-test.md
+++ b/docs/plans/v4-pool-adopter-ergonomics/pr2-reap-in-test.md
@@ -1,0 +1,120 @@
+# `config.reap_in_test` — Implementation Plan (PR 2)
+
+**Goal:** Add a declarative `config.reap_in_test` so adopters can control the reaper's `Rails.env.test?` auto-stop, removing the need for app-side boot guards.
+
+**Architecture:** New boolean config (default `false` = today's behavior). `Railtie.deactivate_pool_reaper_in_test_env!` gains one guard: skip the stop when `reap_in_test` is `true`. No behavior change at the default.
+
+**Design spec:** `docs/designs/v4-pool-adopter-ergonomics.md` (component A).
+
+**Branch:** `feat/reap-in-test` off `main`.
+
+---
+
+### Task 1: `config.reap_in_test` — default + validation
+
+**Files:** `lib/apartment/config.rb`, `spec/unit/config_spec.rb`
+
+- Add `:reap_in_test` to the `attr_accessor` list; `@reap_in_test = false` in `initialize`.
+- In `validate!`, with the other booleans:
+
+```ruby
+unless [true, false].include?(@reap_in_test)
+  raise(ConfigurationError, "reap_in_test must be true or false, got: #{@reap_in_test.inspect}")
+end
+```
+
+- Specs (`config_spec.rb`):
+
+```ruby
+it { expect(config.reap_in_test).to(be(false)) }   # in the defaults block
+
+it 'raises when reap_in_test is not a boolean' do
+  config.tenant_strategy = :schema
+  config.tenants_provider = -> { [] }
+  config.reap_in_test = 'yes'
+  expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /reap_in_test/))
+end
+
+it 'accepts reap_in_test = true' do
+  config.tenant_strategy = :schema
+  config.tenants_provider = -> { [] }
+  config.reap_in_test = true
+  expect { config.validate! }.not_to(raise_error)
+end
+```
+
+TDD + commit.
+
+---
+
+### Task 2: Railtie guard
+
+**Files:** `lib/apartment/railtie.rb`, `spec/unit/railtie_spec.rb`
+
+- Add the guard (config may be nil when the method is unit-tested in isolation, so use `&.`):
+
+```ruby
+def self.deactivate_pool_reaper_in_test_env!
+  return unless Rails.env.test?
+  return if Apartment.config&.reap_in_test
+  return unless Apartment.pool_reaper
+
+  Apartment.pool_reaper.stop
+  Apartment::Instrumentation.instrument(:reaper_stopped, reason: :test_env)
+end
+```
+
+- Update the method's doc comment to note that `config.reap_in_test = true` keeps the reaper running in test (so a deployment that runs under `RAILS_ENV=test` semantics doesn't silently disable reaping — no boot guard needed).
+
+- Specs (`railtie_spec.rb`, in the existing `.deactivate_pool_reaper_in_test_env!` describe):
+
+```ruby
+it 'leaves the reaper running when config.reap_in_test is true' do
+  reaper = instance_double(Apartment::PoolReaper, stop: nil)
+  allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+  allow(Apartment).to(receive(:config).and_return(instance_double(Apartment::Config, reap_in_test: true)))
+  allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+  Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+  expect(reaper).not_to(have_received(:stop))
+end
+
+it 'stops the reaper when config.reap_in_test is false (default)' do
+  reaper = instance_double(Apartment::PoolReaper, stop: nil)
+  allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+  allow(Apartment).to(receive(:config).and_return(instance_double(Apartment::Config, reap_in_test: false)))
+  allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+  Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+  expect(reaper).to(have_received(:stop))
+end
+```
+
+TDD + commit. The existing deactivate specs (which don't stub `config`) must still pass — `&.` makes a nil config fall through to the stop.
+
+---
+
+### Task 3: Docs
+
+**Files:** `README.md`, `docs/upgrading-to-v4.md`
+
+- README "Pool Settings": add
+
+  > `reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the railtie stops it in test, since fixture transactions make eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping, instead of guarding `RAILS_ENV` at boot.
+
+- `docs/upgrading-to-v4.md` pool-config table: add the `reap_in_test` row (default `false`).
+
+Commit.
+
+---
+
+### Task 4: Verify
+
+- `bundle exec rspec spec/unit/config_spec.rb spec/unit/railtie_spec.rb` — green
+- `bundle exec rspec spec/unit/` — green, no regressions (existing deactivate specs still pass)
+- `bundle exec rubocop lib/apartment/config.rb lib/apartment/railtie.rb spec/unit/config_spec.rb spec/unit/railtie_spec.rb` — clean
+- `bundle exec appraisal rails-7.2-sqlite3 rspec spec/unit/config_spec.rb` and `rails-8.1-sqlite3` — green
+
+Then: adversarial panel review (standard for this series) → address findings → PR `feat/reap-in-test` → `main`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -231,12 +231,18 @@ What to do instead, depending on the call site:
 
 ### Pool reaper
 
-`Apartment::PoolReaper` evicts idle and excess tenant pools on a background timer. In production it bounds memory under high tenant counts; in test suites it's typically a liability — short runs, few tenants, no memory pressure, and an eviction mid-example can orphan transactional-fixture state. **The Railtie stops the reaper automatically when `Rails.env.test?`.** A suite that genuinely needs eviction (long-running parallel tenant churn, large fixtures) can opt back in:
+`Apartment::PoolReaper` evicts idle and excess tenant pools on a background timer. In production it bounds memory under high tenant counts; in test suites it's typically a liability — short runs, few tenants, no memory pressure, and an eviction mid-example can orphan transactional-fixture state. **The Railtie stops the reaper automatically when `Rails.env.test?`.**
+
+A suite (or a deployed process that runs under `Rails.env.test?` semantics) that needs the reaper on should set the config flag — it applies at boot, before the reaper is stopped:
 
 ```ruby
-# spec/rails_helper.rb
-Apartment.pool_reaper&.start
+Apartment.configure do |config|
+  # ...
+  config.reap_in_test = true   # don't auto-stop the reaper under Rails.env.test?
+end
 ```
+
+This applies to **every** `Rails.env.test?` process, including CI — where mid-example eviction can orphan transactional fixtures and surface as intermittent failures. Prefer it only when a real deployment runs test-env semantics; for a one-off local need, `Apartment.pool_reaper&.start` after boot is the manual escape hatch.
 
 The reaper is also defensive against transactional state when it does run. Two guards block eviction of a candidate pool:
 

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -215,6 +215,7 @@ Key config options for pool tuning:
 | `reaper_interval` | nil | Seconds between reap passes; nil derives from `pool_idle_timeout` |
 | `max_total_connections` | nil | Ceiling on live tenant pools; enforced synchronously at create time |
 | `pool_overflow_policy` | `:evict_idle` | At-capacity-with-no-idle-pool behavior: `:evict_idle` (soft) or `:raise` (hard) |
+| `reap_in_test` | `false` | Keep the reaper running under `Rails.env.test?`; `true` avoids a boot guard for deployments that run test-env semantics |
 
 ## Migration Steps
 

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -26,7 +26,7 @@ module Apartment
                   :active_record_log, :sql_query_tags,
                   :shard_key_prefix,
                   :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
-                  :force_separate_pinned_pool, :test_fixture_cleanup
+                  :force_separate_pinned_pool, :test_fixture_cleanup, :reap_in_test
 
     def initialize # rubocop:disable Metrics/AbcSize
       @tenant_strategy = nil
@@ -59,6 +59,7 @@ module Apartment
       @schema_cache_per_tenant = false
       @check_pending_migrations = true
       @force_separate_pinned_pool = false
+      @reap_in_test = false
       @test_fixture_cleanup = true
     end
 
@@ -207,6 +208,11 @@ module Apartment
       unless [true, false].include?(@test_fixture_cleanup)
         raise(ConfigurationError,
               "test_fixture_cleanup must be true or false, got: #{@test_fixture_cleanup.inspect}")
+      end
+
+      unless [true, false].include?(@reap_in_test)
+        raise(ConfigurationError,
+              "reap_in_test must be true or false, got: #{@reap_in_test.inspect}")
       end
 
       unless @tenant_validator.nil? || @tenant_validator == false || @tenant_validator.respond_to?(:call)

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -171,8 +171,13 @@ module Apartment
     # can call Apartment.pool_reaper.start explicitly. Emits :reaper_stopped
     # so an upgrading adopter notices the behavior change without combing
     # release notes.
+    #
+    # Opt out with `config.reap_in_test = true`: a deployment whose processes
+    # can run under Rails.env.test? semantics (and must keep reaping) then needs
+    # no boot guard around RAILS_ENV to avoid silently leaking connections.
     def self.deactivate_pool_reaper_in_test_env!
       return unless Rails.env.test?
+      return if Apartment.config&.reap_in_test
       return unless Apartment.pool_reaper
 
       Apartment.pool_reaper.stop

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.shard_key_prefix).to(eq('apartment')) }
     it { expect(config.force_separate_pinned_pool).to(be(false)) }
     it { expect(config.test_fixture_cleanup).to(be(true)) }
+    it { expect(config.reap_in_test).to(be(false)) }
     it { expect(config.default_tenant_switch_allowed).to(be(true)) }
   end
 
@@ -208,6 +209,20 @@ RSpec.describe(Apartment::Config) do
       config.tenant_strategy = :schema
       config.tenants_provider = -> { [] }
       config.pool_overflow_policy = :raise
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'raises when reap_in_test is not a boolean' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.reap_in_test = 'yes'
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /reap_in_test/))
+    end
+
+    it 'accepts reap_in_test = true' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.reap_in_test = true
       expect { config.validate! }.not_to(raise_error)
     end
 

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -188,15 +188,20 @@ if railtie_loaded
         expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
       end
 
-      it 'leaves the reaper running when config.reap_in_test is true' do
+      it 'leaves the reaper running (and emits no reaper_stopped) when config.reap_in_test is true' do
         reaper = instance_double(Apartment::PoolReaper, stop: nil)
         allow(Apartment).to(receive_messages(pool_reaper: reaper,
                                              config: instance_double(Apartment::Config, reap_in_test: true)))
         allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+        events = []
+        sub = ActiveSupport::Notifications.subscribe('reaper_stopped.apartment') { |e| events << e }
 
         Apartment::Railtie.deactivate_pool_reaper_in_test_env!
 
         expect(reaper).not_to(have_received(:stop))
+        expect(events).to(be_empty)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(sub) if sub
       end
 
       it 'stops the reaper when config.reap_in_test is false' do

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -187,6 +187,28 @@ if railtie_loaded
 
         expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
       end
+
+      it 'leaves the reaper running when config.reap_in_test is true' do
+        reaper = instance_double(Apartment::PoolReaper, stop: nil)
+        allow(Apartment).to(receive_messages(pool_reaper: reaper,
+                                             config: instance_double(Apartment::Config, reap_in_test: true)))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+        Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+        expect(reaper).not_to(have_received(:stop))
+      end
+
+      it 'stops the reaper when config.reap_in_test is false' do
+        reaper = instance_double(Apartment::PoolReaper, stop: nil)
+        allow(Apartment).to(receive_messages(pool_reaper: reaper,
+                                             config: instance_double(Apartment::Config, reap_in_test: false)))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+        Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+        expect(reaper).to(have_received(:stop))
+      end
     end
 
     describe 'TenantNotFound rescue_responses mapping' do


### PR DESCRIPTION
## Summary

Second of three PRs for **v4 pool adopter ergonomics** (design: `docs/designs/v4-pool-adopter-ergonomics.md`, component A; plan: `docs/plans/v4-pool-adopter-ergonomics/pr2-reap-in-test.md`).

The Railtie stops the `PoolReaper` whenever `Rails.env.test?`, with no override but the imperative `Apartment.pool_reaper.start`. Adopters whose deployed processes can run under test-env semantics had to add a boot guard around `RAILS_ENV` to avoid silently leaking connections (the reaper never reaps).

This adds a declarative flag:

- **`config.reap_in_test`** — Boolean, **default `false`** (today's behavior: reaper stopped under `Rails.env.test?`). `deactivate_pool_reaper_in_test_env!` skips the stop when `true`, so reaping can be kept on at boot instead of guarding `RAILS_ENV`. Read via `&.` so the method stays safe when unit-tested without a configured Apartment.

**Zero behavior change at the default.** The flag only matters in the test environment; non-test env is untouched. It applies to *every* `Rails.env.test?` process (including CI), so it's documented as opt-in-only when a real deployment needs it (mid-example eviction can orphan transactional fixtures).

Docs: README pool settings, the upgrade-guide table, and `docs/testing.md` (which now prefers `config.reap_in_test = true` over the imperative `pool_reaper.start`).

Not in this PR: `Tenant.each(release_connection:)` + the iteration guide (PR 3).

## Test Plan

- [x] `config_spec` + `railtie_spec` (default, true/false behavior, validation, no `:reaper_stopped` when opted in) — green
- [x] Full unit suite — 940 examples, 0 failures (existing deactivate specs still pass via the `&.` nil-config fallback)
- [x] Cross-version config_spec on Rails 7.2 + 8.1
- [x] `bundle exec rubocop` — clean
- [x] Adversarial panel review (Codex/Gemini/Cursor/Mistral): no correctness issues; 2 APPROVE / 2 APPROVE-WITH-NITS, docs nits addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)