### PR TITLE
Tenant.each(release_connection:) + cross-tenant iteration guide (v4 pool adopter ergonomics, PR 3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,22 @@ tenant's keyspace. Guard routed work with `Apartment::Tenant.require_tenant!`
 `require_default_tenant!`. See [Tenant-Aware Caching](docs/caching.md) for the
 routed-vs-pinned model and the two-store recipe.
 
+## Iterating across tenants
+
+v4 keys a connection pool per `"tenant:role"`, so *switching* into a tenant creates a pool. Pick the lightest primitive for the work — the question is **does the block touch per-tenant-schema data?**
+
+| Need | Use | v4 cost |
+|---|---|---|
+| Names only (enqueue a job, build a list) | `Apartment.tenant_names.each { ... }` | No switch, no pool created |
+| Per-tenant-schema work (read/write tenant tables) | `Apartment::Tenant.each(release_connection: true) { ... }` | One pool per tenant; released between iterations |
+| Global/pinned data only | Don't switch — read it in the default context | A switch routes pinned/global models *through* the tenant pool |
+
+Rules of thumb:
+
+- **Enqueueing jobs?** Don't switch — pass the tenant as a job argument (`Job.perform_async(tenant: name)`) and let your worker middleware switch when the job runs. Switching only to enqueue spins up a pool for nothing.
+- **Only need global/pinned data?** Don't switch. Under shared pinned connections a `switch` resolves pinned and excluded models through the *current tenant's* pool, so reading global data inside a switch still creates a tenant pool.
+- **Large fan-out doing real per-tenant work?** Pass `release_connection: true` to `Tenant.each` — it releases the connection after each tenant so the reaper can evict finished tenants' pools mid-run. It only matters for blocks that hold a connection (raw `ActiveRecord::Base.connection`, an open transaction, a long operation); modern query methods (`create!`, `where`, …) check the connection back in themselves (Rails 7.2+).
+
 ## Convenience Methods
 
 `Apartment.tenant_names` returns the current tenant list (delegates to `config.tenants_provider.call`). Preserves the v3 API so existing call sites work without changes.

--- a/README.md
+++ b/README.md
@@ -379,13 +379,13 @@ v4 keys a connection pool per `"tenant:role"`, so *switching* into a tenant crea
 |---|---|---|
 | Names only (enqueue a job, build a list) | `Apartment.tenant_names.each { ... }` | No switch, no pool created |
 | Per-tenant-schema work (read/write tenant tables) | `Apartment::Tenant.each(release_connection: true) { ... }` | One pool per tenant; released between iterations |
-| Global/pinned data only | Don't switch — read it in the default context | A switch routes pinned/global models *through* the tenant pool |
+| Global/pinned data only | Don't switch — read it in the default context | Under shared pinned connections (PG schema, MySQL default), a switch routes pinned/global models *through* the tenant pool |
 
 Rules of thumb:
 
 - **Enqueueing jobs?** Don't switch — pass the tenant as a job argument (`Job.perform_async(tenant: name)`) and let your worker middleware switch when the job runs. Switching only to enqueue spins up a pool for nothing.
 - **Only need global/pinned data?** Don't switch. Under shared pinned connections a `switch` resolves pinned and excluded models through the *current tenant's* pool, so reading global data inside a switch still creates a tenant pool.
-- **Large fan-out doing real per-tenant work?** Pass `release_connection: true` to `Tenant.each` — it releases the connection after each tenant so the reaper can evict finished tenants' pools mid-run. It only matters for blocks that hold a connection (raw `ActiveRecord::Base.connection`, an open transaction, a long operation); modern query methods (`create!`, `where`, …) check the connection back in themselves (Rails 7.2+).
+- **Large fan-out doing real per-tenant work?** Pass `release_connection: true` to `Tenant.each` — it releases connections after each tenant so the reaper can evict finished tenants' pools mid-run. It matters for blocks that hold a connection (raw `ActiveRecord::Base.connection`, an open transaction, a long operation); modern query methods (`create!`, `where`, …) check the connection back in themselves (Rails 7.2+), so a fan-out of only those needs no release. **It releases *every* connection leased to the current thread (`clear_active_connections!(:all)`), so don't use it inside an outer transaction or while holding a connection for non-tenant work.**
 
 ## Convenience Methods
 

--- a/docs/plans/v4-pool-adopter-ergonomics/pr3-tenant-each-release.md
+++ b/docs/plans/v4-pool-adopter-ergonomics/pr3-tenant-each-release.md
@@ -1,0 +1,121 @@
+# `Tenant.each(release_connection:)` + iteration guide — Implementation Plan (PR 3)
+
+**Goal:** Let `Apartment::Tenant.each` release the leased connection between tenants so pools become reap-eligible mid-fan-out, and document how to choose a cross-tenant iteration primitive.
+
+**Design spec:** `docs/designs/v4-pool-adopter-ergonomics.md` (component B).
+
+**Branch:** `feat/tenant-each-release` off `main`.
+
+**Doc placement note:** the design put the iteration guide in `docs/observability.md`; the README ("Background Workers" / "Convenience Methods") is the more discoverable home for usage guidance, so it goes there instead.
+
+---
+
+### Task 1: `Tenant.each(release_connection: false)`
+
+**Files:** `lib/apartment/tenant.rb`, `spec/unit/tenant_spec.rb`
+
+```ruby
+def each(tenants = nil, release_connection: false)
+  raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
+
+  tenants ||= Apartment.tenant_names
+  tenants.each do |tenant|
+    switch(tenant) { yield(tenant) }
+    # v4 keys a pool per "tenant:role"; the switch leaves a leased connection
+    # that keeps the pool un-reapable. Release it so a long fan-out doesn't hold
+    # one warm connection per visited tenant. Handler-wide (:all) covers writing
+    # + reading roles — the gem's established release call (see memory_stability_spec).
+    ActiveRecord::Base.connection_handler.clear_active_connections!(:all) if release_connection
+  end
+end
+```
+
+Default `false` preserves current behavior. Unit specs (spy on the real handler — real AR is loaded in `tenant_spec`):
+
+```ruby
+it 'releases the connection after each tenant when release_connection: true' do
+  allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+  described_class.each(release_connection: true) { |_t| }
+  expect(ActiveRecord::Base.connection_handler)
+    .to(have_received(:clear_active_connections!).with(:all).twice)   # 2 tenants
+end
+
+it 'does not release connections by default' do
+  allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+  described_class.each { |_t| }
+  expect(ActiveRecord::Base.connection_handler).not_to(have_received(:clear_active_connections!))
+end
+```
+
+TDD + commit.
+
+---
+
+### Task 2: Integration proof (release makes pools reap-eligible)
+
+**Files:** `spec/integration/v4/tenant_each_release_spec.rb` (new)
+
+Mirror `memory_stability_spec` setup (V4IntegrationHelper, skip on sqlite). Create N tenants with a `widgets` table, then:
+
+```ruby
+it 'leaves no leased connection on visited pools when release_connection is true' do
+  stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+  role = ActiveRecord::Base.current_role
+
+  Apartment::Tenant.each(release_connection: true) { Widget.create!(name: 'x') }
+
+  tenants.each do |t|
+    pool = Apartment.pool_manager.peek("#{t}:#{role}")
+    expect(pool).not_to(be_nil)
+    expect(pool.connections.any?(&:in_use?)).to(be(false), "#{t} pool still has a leased connection")
+  end
+end
+
+it 'leaves leased connections without release_connection (contrast)' do
+  stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+  role = ActiveRecord::Base.current_role
+
+  Apartment::Tenant.each { Widget.create!(name: 'x') }
+
+  leased = tenants.any? do |t|
+    pool = Apartment.pool_manager.peek("#{t}:#{role}")
+    pool && pool.connections.any?(&:in_use?)
+  end
+  expect(leased).to(be(true))
+ensure
+  ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+end
+```
+
+TDD + commit. Run on PostgreSQL: `DATABASE_ENGINE=postgresql BUNDLE_GEMFILE=gemfiles/rails_8.1_postgresql.gemfile bundle exec rspec spec/integration/v4/tenant_each_release_spec.rb`.
+
+---
+
+### Task 3: Iteration guide (README)
+
+**Files:** `README.md`
+
+Add an "## Iterating across tenants" section after "Background Workers":
+
+- One question — *does the block do per-tenant-schema work?* — and a table:
+
+| Need | Use | v4 cost |
+|---|---|---|
+| Names only (enqueue, list) | `Apartment.tenant_names.each { ... }` | No switch, no pool created |
+| Per-tenant-schema work | `Apartment::Tenant.each(release_connection: true) { ... }` | One pool per tenant; released between iterations |
+| Global/pinned data only | Don't switch — read it in the default context | A switch resolves pinned models *through* the tenant pool |
+
+- The gotcha: under shared-pinned-connections a `switch` routes pinned/excluded models through the current tenant's pool, so switching only to read global data spins up a tenant pool for nothing.
+- Note `release_connection: true` for large fan-outs (keeps pools reap-eligible).
+
+Commit.
+
+---
+
+### Task 4: Verify + review
+
+- `bundle exec rspec spec/unit/tenant_spec.rb` + full unit suite — green
+- Integration: PostgreSQL (+ MySQL if available) for `tenant_each_release_spec`
+- `bundle exec rubocop` on changed files — clean
+- Cross-version unit smoke (7.2 + 8.1)
+- Adversarial panel review (standard) → address findings → PR `feat/tenant-each-release` → `main`

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -185,11 +185,24 @@ module Apartment
       # Accepts an optional tenant list; defaults to tenants_provider.
       # Fail-fast: raises immediately if a block raises for any tenant;
       # tenants after the failing one are not visited.
-      def each(tenants = nil)
+      #
+      # release_connection: when true, release the leased connection after each
+      # tenant so the reaper can evict finished tenants' pools mid-run. v4 keys a
+      # pool per "tenant:role"; a fan-out whose block leaves a connection checked
+      # out (raw ActiveRecord::Base.connection use, an open transaction, a long-
+      # held connection) would otherwise hold one warm connection per visited
+      # tenant. Modern query methods (create!, where, ...) check the connection
+      # back in themselves (Rails 7.2+), so a fan-out of those needs no release.
+      def each(tenants = nil, release_connection: false)
         raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
 
         tenants ||= Apartment.tenant_names
-        tenants.each { |tenant| switch(tenant) { yield(tenant) } }
+        tenants.each do |tenant|
+          switch(tenant) { yield(tenant) }
+          # Handler-wide (:all) covers writing + reading roles — the gem's
+          # established release call (see memory_stability_spec).
+          ActiveRecord::Base.connection_handler.clear_active_connections!(:all) if release_connection
+        end
       end
 
       # Block-scoped override of the tenant resolver. For the duration of the

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -186,13 +186,22 @@ module Apartment
       # Fail-fast: raises immediately if a block raises for any tenant;
       # tenants after the failing one are not visited.
       #
-      # release_connection: when true, release the leased connection after each
+      # release_connection: when true, release leased connections after each
       # tenant so the reaper can evict finished tenants' pools mid-run. v4 keys a
       # pool per "tenant:role"; a fan-out whose block leaves a connection checked
       # out (raw ActiveRecord::Base.connection use, an open transaction, a long-
       # held connection) would otherwise hold one warm connection per visited
       # tenant. Modern query methods (create!, where, ...) check the connection
-      # back in themselves (Rails 7.2+), so a fan-out of those needs no release.
+      # back in themselves (Rails 7.2+), so a fan-out of only those needs no
+      # release — but when in doubt for a large fan-out, pass it; it is a cheap
+      # no-op when there is nothing to release.
+      #
+      # WARNING: the release is handler-wide (clear_active_connections!(:all)) —
+      # it drops EVERY connection leased to the current execution context, across
+      # all pools and roles, not just the tenant pool. Do NOT use it inside an
+      # outer ActiveRecord::Base.transaction, or while holding a non-tenant
+      # connection you mean to keep. Fail-fast: if the block raises, the failing
+      # tenant is not released (the fan-out aborts).
       def each(tenants = nil, release_connection: false)
         raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
 

--- a/spec/integration/v4/tenant_each_release_spec.rb
+++ b/spec/integration/v4/tenant_each_release_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+
+# Tenant.each(release_connection: true) returns the leased connection after each
+# tenant so a long fan-out doesn't hold one warm connection per visited tenant —
+# the finished tenant's pool becomes reap-eligible mid-run. See component B of
+# docs/designs/v4-pool-adopter-ergonomics.md.
+#
+# The effect is only observable for blocks that leave a connection checked out
+# for the thread (raw `ActiveRecord::Base.connection` use, an open transaction, a
+# long-held connection). Modern query methods (create!, where, ...) check the
+# connection back in themselves on Rails 7.2+, so these specs use the raw
+# `connection.execute` pattern to exercise the sticky lease release_connection
+# targets.
+RSpec.describe('v4 Tenant.each(release_connection:)', :integration,
+               skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
+  include V4IntegrationHelper
+
+  context 'releasing connections between iterations',
+          skip: (if V4IntegrationHelper.sqlite?
+                   'SQLite pool-per-tenant less meaningful with single-writer lock'
+                 else
+                   false
+                 end) do
+    let(:tmp_dir) { Dir.mktmpdir('apartment_each_release') }
+    let(:tenants) { Array.new(4) { |i| "each_release_#{i}" } }
+
+    before do
+      V4IntegrationHelper.ensure_test_database!
+      config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+      V4IntegrationHelper.create_test_table!
+
+      Apartment.configure do |c|
+        c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+        c.tenants_provider = -> { tenants }
+        c.default_tenant = V4IntegrationHelper.default_tenant
+        c.check_pending_migrations = false
+      end
+
+      Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+      Apartment.activate!
+
+      tenants.each { |t| Apartment.adapter.create(t) }
+    end
+
+    after do
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+      V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter)
+      Apartment.clear_config
+      Apartment::Current.reset
+      FileUtils.rm_rf(tmp_dir)
+    end
+
+    # Pools (one per "tenant:role") with at least one leased connection — i.e.
+    # not yet reap-eligible.
+    def leased_pool_count
+      role = ActiveRecord::Base.current_role
+      tenants.count do |t|
+        pool = Apartment.pool_manager.peek("#{t}:#{role}")
+        pool&.connections&.any?(&:in_use?)
+      end
+    end
+
+    it 'leaves no leased connection on any visited pool' do
+      # Clean slate, then a fan-out whose block holds a connection.
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
+      Apartment::Tenant.each(release_connection: true) do
+        ActiveRecord::Base.connection.execute('SELECT 1')
+      end
+
+      expect(leased_pool_count).to(eq(0))
+    end
+
+    it 'leaves a leased connection per tenant without release_connection (contrast)' do
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
+      Apartment::Tenant.each do
+        ActiveRecord::Base.connection.execute('SELECT 1')
+      end
+
+      expect(leased_pool_count).to(eq(tenants.size))
+    end
+  end
+end

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -425,6 +425,23 @@ RSpec.describe(Apartment::Tenant) do
       expect(called).to(be(false))
     end
 
+    it 'releases the connection after each tenant when release_connection: true' do
+      allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+
+      described_class.each(release_connection: true) { |_t| }
+
+      expect(ActiveRecord::Base.connection_handler)
+        .to(have_received(:clear_active_connections!).with(:all).twice)
+    end
+
+    it 'does not release connections by default' do
+      allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+
+      described_class.each { |_t| }
+
+      expect(ActiveRecord::Base.connection_handler).not_to(have_received(:clear_active_connections!))
+    end
+
     it 'returns the result of iterating the tenant list' do
       result = described_class.each(%w[a b]) { |_t| }
       expect(result).to(eq(%w[a b]))


### PR DESCRIPTION
## Summary

Last of three PRs for **v4 pool adopter ergonomics** (design: `docs/designs/v4-pool-adopter-ergonomics.md`, component B; plan: `docs/plans/v4-pool-adopter-ergonomics/pr3-tenant-each-release.md`).

- **`Apartment::Tenant.each(tenants = nil, release_connection: false)`** — when `release_connection: true`, releases leased connections after each tenant (`connection_handler.clear_active_connections!(:all)`) so the reaper can evict finished tenants' pools mid-fan-out, instead of holding one warm connection per visited tenant. Default `false` preserves current behavior; the kwarg is backward-compatible.
- **README "Iterating across tenants"** — a decision guide: names-only fan-out → `Apartment.tenant_names.each` (no switch, no pool); per-tenant-schema work → `Tenant.each(release_connection: true)`; global/pinned reads → don't switch (under shared pinned connections a switch routes pinned models *through* the tenant pool).

### A verified nuance
`release_connection` only matters for blocks that **hold a connection** — raw `ActiveRecord::Base.connection`, an open transaction, a long operation. Modern query methods (`create!`, `where`) check the connection back in themselves; verified on Rails 7.2 and 8.1 (`create!`/`where` → 0 leased, `connection.execute` → N leased). The integration spec demonstrates the effect with the sticky `connection.execute` pattern (leased 4 → 0).

### Footgun, documented
The release is handler-wide (`:all`) — it drops *every* lease for the current execution context, so it must not be used inside an outer transaction or while holding a non-tenant connection. Kept `:all` (the gem's established pattern; per-pool scoping was rejected in design as over-engineering and risks brittle AR internals) and documented the constraint prominently.

## Test Plan

- [x] Unit (`tenant_spec`): `release_connection: true` calls `clear_active_connections!(:all)` once per tenant; default doesn't — green
- [x] Integration (`tenant_each_release_spec`) on **PostgreSQL + MySQL**: leased pools 4 → 0 with the flag, 4 without (SQLite skipped, like other pool specs)
- [x] Full unit suite — 942 examples, 0 failures; cross-version 7.2 + 8.1
- [x] `bundle exec rubocop` — clean
- [x] Adversarial panel review (Codex/Gemini/Cursor/Mistral): no logic defect; `:all` footgun + doc precision addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)