### PR TITLE
Bump version to 4.0.0.alpha4

### DIFF
--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha3'
+  VERSION = '4.0.0.alpha4'
 end


### PR DESCRIPTION
## What

Bumps `lib/apartment/version.rb` from `4.0.0.alpha3` → `4.0.0.alpha4`.

**Step 1 of the Model-A release flow** (`RELEASING.md` § Release Steps). This PR ships nothing on its own — it only sets the version on `main`. The publish happens in a separate `main` → `4-0-alpha` PR, whose merge triggers `gem-publish.yml` (`rake release` tags `v4.0.0.alpha4` and pushes to RubyGems).

## Why now

`4.0.0.alpha3` is already published to RubyGems, and `main` has accumulated the full pool-adopter-ergonomics series plus the connection-model rationale beyond it — none of it installable yet. Three are real adopter-facing API surface:

- **#441** `Apartment::PoolObserver` — sink-agnostic pool observability (+ `docs/observability.md`)
- **#443** `config.reap_in_test` — declarative control of the reaper's test-env auto-stop
- **#444** `Tenant.each(release_connection:)` — release leases between tenants in a fan-out

Plus **#442** (RELEASING.md reconciled to Model A) and **#445** (`docs/designs/v4-connection-model-rationale.md`).

## Next step (maintainer)

After this merges: open `main` → `4-0-alpha` titled `Release v4.0.0.alpha4` and merge it to publish. An alpha ships *everything* on `main` — `main` is currently clean (no half-finished work), so that's safe this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)