### PR TITLE
Release v4.0.0.alpha4

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ All options are set in `config/initializers/apartment.rb` inside an `Apartment.c
 
 `pool_overflow_policy`: behavior when a new pool would breach `max_total_connections` and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
 
+### Observability
+
+Apartment emits `ActiveSupport::Notifications` for the pool lifecycle and ships
+`Apartment::PoolObserver`, a sink-agnostic subscriber + sampler. See
+[docs/observability.md](docs/observability.md).
+
 ### Elevator (Request Tenant Detection)
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Apartment uses **schema-per-tenant** (PostgreSQL) or **database-per-tenant** (My
 
 ## About ros-apartment
 
-This gem is a maintained fork of the original [Apartment gem](https://github.com/influitive/apartment). Maintained by [CampusESP](https://www.campusesp.com) since 2024. Same `require 'apartment'`; v4 introduces a pool-per-tenant architecture that replaces the thread-local switching of v3. Tenant context is fiber-safe via `CurrentAttributes`, and connection pools are managed per tenant rather than swapping search paths on a shared connection. See the [upgrade guide](docs/upgrading-to-v4.md) for migration steps from v3.
+This gem is a maintained fork of the original [Apartment gem](https://github.com/influitive/apartment). Maintained by [CampusESP](https://www.campusesp.com) since 2024. Same `require 'apartment'`; v4 introduces a pool-per-tenant architecture that replaces the thread-local switching of v3. Tenant context is fiber-safe via `CurrentAttributes`, and connection pools are managed per tenant rather than swapping search paths on a shared connection. For *why* v4 chose this model over the alternatives (including fully-qualified table names), see [`docs/designs/v4-connection-model-rationale.md`](docs/designs/v4-connection-model-rationale.md). See the [upgrade guide](docs/upgrading-to-v4.md) for migration steps from v3.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ All options are set in `config/initializers/apartment.rb` inside an `Apartment.c
 
 `pool_overflow_policy`: behavior when a new pool would breach `max_total_connections` and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
 
-`reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the Railtie stops it in test, where fixture transactions make mid-example eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping — that's cleaner than guarding `RAILS_ENV` at boot to avoid silently leaking connections.
+`reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the Railtie stops it in test, where fixture transactions make mid-example eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping — that's cleaner than guarding `RAILS_ENV` at boot to avoid silently leaking connections. It applies to *every* `Rails.env.test?` process, including CI, so enable it only when a real deployment needs it.
 
 ### Observability
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ All options are set in `config/initializers/apartment.rb` inside an `Apartment.c
 
 `pool_overflow_policy`: behavior when a new pool would breach `max_total_connections` and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
 
+`reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the Railtie stops it in test, where fixture transactions make mid-example eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping — that's cleaner than guarding `RAILS_ENV` at boot to avoid silently leaking connections.
+
 ### Observability
 
 Apartment emits `ActiveSupport::Notifications` for the pool lifecycle and ships

--- a/README.md
+++ b/README.md
@@ -371,6 +371,22 @@ tenant's keyspace. Guard routed work with `Apartment::Tenant.require_tenant!`
 `require_default_tenant!`. See [Tenant-Aware Caching](docs/caching.md) for the
 routed-vs-pinned model and the two-store recipe.
 
+## Iterating across tenants
+
+v4 keys a connection pool per `"tenant:role"`, so *switching* into a tenant creates a pool. Pick the lightest primitive for the work — the question is **does the block touch per-tenant-schema data?**
+
+| Need | Use | v4 cost |
+|---|---|---|
+| Names only (enqueue a job, build a list) | `Apartment.tenant_names.each { ... }` | No switch, no pool created |
+| Per-tenant-schema work (read/write tenant tables) | `Apartment::Tenant.each(release_connection: true) { ... }` | One pool per tenant; released between iterations |
+| Global/pinned data only | Don't switch — read it in the default context | A switch routes pinned/global models *through* the tenant pool |
+
+Rules of thumb:
+
+- **Enqueueing jobs?** Don't switch — pass the tenant as a job argument (`Job.perform_async(tenant: name)`) and let your worker middleware switch when the job runs. Switching only to enqueue spins up a pool for nothing.
+- **Only need global/pinned data?** Don't switch. Under shared pinned connections a `switch` resolves pinned and excluded models through the *current tenant's* pool, so reading global data inside a switch still creates a tenant pool.
+- **Large fan-out doing real per-tenant work?** Pass `release_connection: true` to `Tenant.each` — it releases the connection after each tenant so the reaper can evict finished tenants' pools mid-run. It only matters for blocks that hold a connection (raw `ActiveRecord::Base.connection`, an open transaction, a long operation); modern query methods (`create!`, `where`, …) check the connection back in themselves (Rails 7.2+).
+
 ## Convenience Methods
 
 `Apartment.tenant_names` returns the current tenant list (delegates to `config.tenants_provider.call`). Preserves the v3 API so existing call sites work without changes.

--- a/README.md
+++ b/README.md
@@ -379,13 +379,13 @@ v4 keys a connection pool per `"tenant:role"`, so *switching* into a tenant crea
 |---|---|---|
 | Names only (enqueue a job, build a list) | `Apartment.tenant_names.each { ... }` | No switch, no pool created |
 | Per-tenant-schema work (read/write tenant tables) | `Apartment::Tenant.each(release_connection: true) { ... }` | One pool per tenant; released between iterations |
-| Global/pinned data only | Don't switch — read it in the default context | A switch routes pinned/global models *through* the tenant pool |
+| Global/pinned data only | Don't switch — read it in the default context | Under shared pinned connections (PG schema, MySQL default), a switch routes pinned/global models *through* the tenant pool |
 
 Rules of thumb:
 
 - **Enqueueing jobs?** Don't switch — pass the tenant as a job argument (`Job.perform_async(tenant: name)`) and let your worker middleware switch when the job runs. Switching only to enqueue spins up a pool for nothing.
 - **Only need global/pinned data?** Don't switch. Under shared pinned connections a `switch` resolves pinned and excluded models through the *current tenant's* pool, so reading global data inside a switch still creates a tenant pool.
-- **Large fan-out doing real per-tenant work?** Pass `release_connection: true` to `Tenant.each` — it releases the connection after each tenant so the reaper can evict finished tenants' pools mid-run. It only matters for blocks that hold a connection (raw `ActiveRecord::Base.connection`, an open transaction, a long operation); modern query methods (`create!`, `where`, …) check the connection back in themselves (Rails 7.2+).
+- **Large fan-out doing real per-tenant work?** Pass `release_connection: true` to `Tenant.each` — it releases connections after each tenant so the reaper can evict finished tenants' pools mid-run. It matters for blocks that hold a connection (raw `ActiveRecord::Base.connection`, an open transaction, a long operation); modern query methods (`create!`, `where`, …) check the connection back in themselves (Rails 7.2+), so a fan-out of only those needs no release. **It releases *every* connection leased to the current thread (`clear_active_connections!(:all)`), so don't use it inside an outer transaction or while holding a connection for non-tenant work.**
 
 ## Convenience Methods
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ This document describes the release process for the `ros-apartment` gem.
 | `3-4-stable` | v3 maintenance releases |
 | `4-0-stable` | v4 stable releases (created when v4.0.0 GA ships) |
 
-Features go to `main`. When a release is ready, push to the appropriate release branch. `rake release` (via the `gem-publish.yml` workflow) creates the tag and publishes to RubyGems.
+Features go to `main`. To publish, the release content has to land on a release branch — for the v4 line, by **merging `main` into `4-0-alpha`** (see Release Steps); for a maintenance branch on a different major version, by cherry-picking (see v3 Maintenance). The resulting push triggers `gem-publish.yml`, whose `rake release` step creates the tag and publishes to RubyGems.
 
 ## Who Can Release
 
@@ -19,92 +19,72 @@ Only the primary maintainer pushes to release branches. Release branches are lis
 
 ## Overview
 
-Releases are automated via GitHub Actions. Pushing to a release branch triggers `gem-publish.yml`, which runs `rake release` to create a git tag and publish to RubyGems using trusted publishing (no API key required).
+Releases are automated via GitHub Actions. While `main` is the v4 development line, `4-0-alpha` is a **publish gate that tracks `main`**: merging `main` into it triggers `gem-publish.yml`, which runs `rake release` to create a git tag and publish to RubyGems using trusted publishing (no API key required). Maintenance branches on a different major version (`3-4-stable`) are curated with cherry-picks instead, because they cannot track `main`.
 
-## Release Steps
+## Release Steps (v4 pre-releases — `4-0-alpha`)
 
-### 1. Prepare the release branch
+While `main` is the v4 development line, `4-0-alpha` simply tracks it: an alpha/beta/rc is "current `main`, published." You release by bumping the version on `main`, then merging `main` into `4-0-alpha`. No cherry-picking, no backport.
 
-For a new release track, create the branch from `main`:
+### 1. Bump the version on `main`
 
-```bash
-git checkout main
-git pull origin main
-git checkout -b 4-0-alpha    # or 4-0-stable, etc.
-```
-
-For a subsequent release, work on the existing branch:
-
-```bash
-git checkout 4-0-alpha
-git pull origin 4-0-alpha
-git cherry-pick <commit>      # backport fixes from main if needed
-```
-
-### 2. Bump the version
-
-Update `lib/apartment/version.rb` on the release branch:
+Update `lib/apartment/version.rb` on `main` — either in the feature PR that completes the release, or a standalone bump PR — and merge it:
 
 ```ruby
 module Apartment
-  VERSION = 'X.Y.Z'           # or 'X.Y.Z.alpha2', 'X.Y.Z.beta1', etc.
+  VERSION = '4.0.0.alpha4'    # SemVer + optional pre-release suffix
 end
 ```
 
-Follow [Semantic Versioning](https://semver.org/):
-- MAJOR (X): Breaking changes
-- MINOR (Y): New features, backwards compatible
-- PATCH (Z): Bug fixes, backwards compatible
+Follow [Semantic Versioning](https://semver.org/): MAJOR = breaking, MINOR = new features (compatible), PATCH = fixes (compatible). Pre-release suffixes: `.alpha1`, `.beta1`, `.rc1`.
 
-Pre-release suffixes: `.alpha1`, `.beta1`, `.rc1`
-
-### 3. Push to publish
-
-Commit the version bump and push:
+### 2. Open the release PR: `main` → `4-0-alpha`
 
 ```bash
-git add lib/apartment/version.rb
-git commit -m "Bump version to X.Y.Z"
-git push origin 4-0-alpha
+gh pr create --base 4-0-alpha --head main --title "Release v4.0.0.alpha4"
 ```
 
-The push triggers `gem-publish.yml`. `rake release` creates the `vX.Y.Z` tag and publishes the gem. No manual tag creation needed.
+**Merging this PR is the publish.** The merge pushes `main`'s commits onto `4-0-alpha`, which triggers `gem-publish.yml`; `rake release` creates the `v4.0.0.alpha4` tag and pushes the gem to RubyGems. Don't merge until you mean to ship — a published version number can be yanked but not reused.
 
-### 4. Verify the publish
+### 3. Verify the publish
 
-Monitor the workflow run. Verify at: https://rubygems.org/gems/ros-apartment
-
-### 5. Create GitHub Release
-
-1. Go to https://github.com/rails-on-services/apartment/releases/new
-2. Select the `vX.Y.Z` tag (created by `rake release`)
-3. Click "Generate release notes" for a starting point
-4. Edit the release notes to highlight key changes
-5. For pre-releases, check the "Set as a pre-release" checkbox
-6. Publish the release
-
-We use GitHub Releases as our changelog (no CHANGELOG.md file).
-
-### 6. Backport the version bump
-
-Cherry-pick the version bump back to `main` so the version file stays current:
+Watch the workflow run (Actions → "Publish to RubyGems"), then confirm the version is live:
 
 ```bash
-git checkout main
-git cherry-pick <version-bump-commit>
-git push origin main
+gem list -r --prerelease ros-apartment    # prereleases are hidden without --prerelease
 ```
 
-## v3 Maintenance Releases
+or the versions page: https://rubygems.org/gems/ros-apartment/versions
 
-Same process on the `3-4-stable` branch:
+### 4. Create the GitHub Release
 
-1. Cherry-pick or apply fixes to `3-4-stable`
-2. Bump version (e.g., `3.4.2`)
-3. Push to `3-4-stable`; `rake release` tags and publishes
+1. https://github.com/rails-on-services/apartment/releases/new
+2. Select the `v4.0.0.alpha4` tag (created by `rake release`)
+3. "Generate release notes", then edit to highlight key changes
+4. For pre-releases, check "Set as a pre-release"
+5. Publish
+
+GitHub Releases are our changelog (no `CHANGELOG.md` file).
+
+**No backport step** — the version bump originated on `main`, so `main` already carries it and `4-0-alpha` received it through the merge. The two branches agree by construction.
+
+### Why merge `main` instead of cherry-picking?
+
+While `main` *is* the v4 line, an alpha should be exactly "what's on `main`", so merging keeps them in lock-step with zero per-release curation. The trade-off: an alpha ships everything on `main` — keep not-yet-releasable work behind a flag or unmerged until it's ready. (A maintenance branch on a different major version can't merge `main` and uses cherry-pick instead — see v3 Maintenance. A future `4-0-stable` GA branch will likely also curate rather than track `main` wholesale.)
+
+### Why a branch and not a tag?
+
+`gem-publish.yml` triggers on a push to a release branch, never on `main` or on a tag. That's deliberate: `rake release` creates the version tag *itself*, so triggering on tag pushes would make the workflow re-trigger on its own tag. The release branch is the publish gate.
+
+## v3 Maintenance Releases (`3-4-stable`)
+
+`3-4-stable` carries a different major version than `main`, so it **cannot** track `main` by merge — you curate it with cherry-picks:
+
+1. Cherry-pick (or apply) the fixes onto `3-4-stable`
+2. Bump the version on `3-4-stable` (e.g., `3.4.5`)
+3. Push `3-4-stable`; `rake release` tags and publishes
 4. Create a GitHub Release noting it as a maintenance release
 
-Do not merge `3-4-stable` into `main`; they contain different major versions.
+Do not merge `3-4-stable` into `main` (or `main` into it); they contain different major versions.
 
 ### Version coordination
 
@@ -137,18 +117,18 @@ The `gem-publish.yml` workflow uses:
 
 ### Workflow fails with "tag already exists"
 
-The version in `version.rb` matches a tag that was already pushed. Either bump to a new version or delete the existing tag:
+The version in `version.rb` matches a tag that was already pushed. Either bump to a new version on `main` or delete the existing tag:
 
 ```bash
 git push origin --delete vX.Y.Z
 git tag -d vX.Y.Z
 ```
 
-Then push to the release branch again.
+Then re-run the publish (re-merge the release PR, or push the release branch again).
 
 ### Gem published but GitHub Release missing
 
-The GitHub Release is created manually (step 5). The gem is already available on RubyGems; the release is for documentation.
+The GitHub Release is created manually (Release Steps, step 4). The gem is already available on RubyGems; the release is for documentation.
 
 ### RubyGems trusted publishing fails
 

--- a/docs/designs/v4-connection-model-rationale.md
+++ b/docs/designs/v4-connection-model-rationale.md
@@ -1,0 +1,211 @@
+# Why v4 Uses Pool-per-Tenant (Connection Model Rationale)
+
+## TLDR
+
+v4 moves tenant isolation **out of** a mutable per-connection session variable
+(`search_path`, flipped on a shared pool) **and into** the connection pool itself: one
+immutable pool per `"tenant:role"`, each with its tenant's `search_path` baked in at
+connection establishment. This trades a higher backend-connection ceiling for isolation
+by construction, safe cross-tenant concurrency, and the removal of the per-request `SET`
+churn that pinned connection poolers under v3. Fully-qualified table names — the question
+adopters keep raising (#200, #302, #438) — is the cleanest model on paper and is **not**
+rejected as wrong; it is rejected as the gem's default because it makes tenancy an
+every-query, app-wide concern instead of something the library can own at one boundary.
+
+This is the "why we chose this" companion to the "what / how" docs. For the architecture
+itself see [`apartment-v4.md`](apartment-v4.md); for the connection-budget controls see
+[`pool-admission-control.md`](pool-admission-control.md) and
+[`v4-pool-adopter-ergonomics.md`](v4-pool-adopter-ergonomics.md). This doc does not restate
+those — it explains the decision behind them.
+
+## The decision
+
+In v3, every tenant shares one connection pool and tenant identity lives in a connection
+session variable: each `Tenant.switch` issues `SET search_path` on the connection it
+borrows. The connection is general-purpose; what makes it "tenant A's connection" is a
+GUC that the next switch will overwrite.
+
+v4 inverts that. Tenant identity becomes a property of the pool, not a mutation on a
+borrowed connection. `Apartment::Patches::ConnectionHandling#connection_pool` keys a
+distinct pool per `"#{tenant}:#{role}"`
+(`lib/apartment/patches/connection_handling.rb`), and the PostgreSQL schema adapter bakes
+the tenant's `schema_search_path` into that pool's immutable config at establishment time
+(`PostgresqlSchemaAdapter#resolve_connection_config`,
+`lib/apartment/adapters/postgresql_schema_adapter.rb`). There is no per-switch and no
+per-query `SET`: switching tenants is a pool lookup, and the connection a query borrows
+already has the right `search_path` because no other tenant ever borrows from that pool.
+
+## v3's two structural limits this addresses
+
+**1. Isolation depends on vigilance over a shared, mutable, connection-global
+`search_path`.** Because the `search_path` is global to the connection and any code can
+change it, a missed reset, an exception that skips cleanup, or a stray `SET` leaves the
+connection pointing at the wrong tenant. The failure mode is the dangerous one: a
+wrong-`search_path` query against a *live* schema returns the wrong tenant's rows with
+**no error** — it is indistinguishable from a correct query until someone notices the
+data is wrong. Low probability, high impact, silent. v3 mitigates this with disciplined
+block-scoped switching and `ensure` cleanup, but the safety is procedural, not
+structural.
+
+**2. A shared connection with a mutable `search_path` cannot safely serve concurrent
+cross-tenant work.** The `search_path` is connection-global state; two fibers (or an
+async query and its caller) sharing a connection cannot each hold a different tenant
+context, because the second `SET` races the first. v3's thread-local switching model is
+the root of the cross-thread leakage reported in ActionCable, async query, and
+fiber-server contexts (#199, #239, #304 — see [`apartment-v4.md`](apartment-v4.md)
+§ Problems with v3). You cannot make a single mutable global concurrent by being careful;
+the data structure has to change.
+
+## What v4 buys, in priority order
+
+**1. Tenant isolation by construction.** The `search_path` cannot be flipped under a
+running query, because it is fixed for the life of the pool and the pool serves exactly
+one tenant. The wrong-tenant-rows-with-no-error failure mode above is removed at the
+mechanism level, not guarded against at the call site. (This bounds the *gem-induced*
+leak, not application-level wrong-tenant selection — see Non-goals.)
+
+**2. Safe cross-tenant concurrency.** Distinct tenants resolve to distinct pools, so
+concurrent fibers, an async query and its consumer, or a streaming response and its
+parent can each operate in their own tenant context without racing a shared global.
+Tenant context rides on `ActiveSupport::CurrentAttributes` (fiber-safe), and the pool a
+query lands on is determined by that context at resolution time. (The consumer-fiber
+contract for `load_async` is its own subtlety — see
+[`apartment-v4.md`](apartment-v4.md) § Async query correctness.)
+
+**3. The per-request `SET` churn that blocked connection poolers is gone — with a
+caveat.** v3 issues `SET search_path` on every switch, i.e. on essentially every request,
+which drove near-1:1 connection pinning under PgBouncer / RDS Proxy transaction mode
+(#302): a connection that has run a session `SET` cannot be multiplexed. v4 issues no
+per-switch `SET` at all. **Honest qualification:** Rails' PostgreSQL adapter still runs a
+**one-time** `SET search_path` when it *establishes* each new connection (it applies the
+pool's baked-in `schema_search_path` once). So v4 does **not** magically unlock
+transaction-mode multiplexing — a freshly established connection has still run a session
+`SET`. That is exactly what issue #438 (set `search_path` via the libpq `options`
+connection parameter, at the protocol level, avoiding the `SET` statement entirely) is
+still open to close. What v4 *does* realize today is that eliminating per-request churn
+makes a **connection ceiling and session-mode pooling viable** where v3's per-request
+pinning made them impractical. Do not read this as "RDS Proxy compatible" without the
+establishment-`SET` qualification.
+
+## Alternatives considered, and why not chosen for the gem
+
+These are legitimate models. The question is not "which is correct in the abstract" but
+"which can a multi-tenancy *library* own at one boundary without conscripting every query
+the application writes."
+
+### v3 status quo — shared pool + per-switch `SET search_path`
+
+The predecessor. Isolation by vigilance (procedural cleanup, not structural), no safe
+cross-tenant concurrency, per-request `SET` that pins poolers. Sections above cover why
+each of these is the limit v4 set out to remove. Rejected because the failures are
+inherent to a shared mutable global, not to any fixable detail of the implementation.
+
+### Fully-qualified table names — `"schema"."table"` everywhere, no `search_path`
+
+The purest model, and the strongest on the dimensions this doc cares about. With every
+table reference schema-qualified, there is no `search_path`, hence no session state, hence
+**no `SET` to pin a pooler and nothing to leak** — it is best-in-class for connection
+multiplexing and stateless by construction. On paper it dominates.
+
+It is not the gem's default for one reason: **scope of ownership.** Fully-qualifying
+names would require ActiveRecord to schema-qualify, *per tenant and dynamically*, every
+table, index, sequence, association join, and raw-SQL fragment the application emits — not
+once, but on every query, for code the gem does not control. That turns tenancy from a
+single connection-routing boundary the library can own into a pervasive, app-wide,
+every-query concern. The leak surface moves from "did the gem route the connection
+correctly" (one place) to "did every query — including every gem dependency's queries and
+every hand-written SQL string — remember to qualify" (everywhere). A library cannot
+enforce that contract; only the whole application can.
+
+So FQN is rejected as a *gem default*, not as a bad idea. It remains a legitimate
+architecture, and for an application that adopts it pervasively it is not mutually
+exclusive with v4 in the long term — an app could qualify its own hot paths while the gem
+routes connections. The gem simply cannot make every-query qualification its baseline.
+
+### Prepend `SET search_path` to every statement (the "atomic switch")
+
+A middle position: instead of `SET` per switch, run `SET LOCAL search_path` (or an
+equivalent prefix) inside every statement so the window between switching and querying
+shrinks to zero. This closes the *timing* class of the wrong-tenant leak — there is no
+interval during which a query can run against a stale `search_path`. But it keeps tenancy
+as **connection session state**, so it still pins poolers (a per-statement `SET` is more
+churn, not less), and it requires intercepting every statement execution to inject the
+prefix. It buys the smallest slice of the upside (one failure class) at meaningful cost,
+and leaves the concurrency and pooler limits untouched. Rejected as solving the least
+while complicating the most.
+
+### The throughline
+
+v4 localizes tenant isolation to the **connection-routing boundary** — the one seam a
+multi-tenancy library can actually own — instead of spreading it across every query
+(FQN), every statement (atomic prefix), or every developer's discipline (v3). The model
+that owns the fewest places wins, provided those places are sufficient. Pool-per-tenant
+is sufficient because the connection *is* the tenant.
+
+## The trade-off v4 accepts
+
+Pool-per-tenant raises the backend-connection ceiling: each `"tenant:role"` is a separate
+pool, so total connection demand scales with **how many distinct tenants each process
+touches**, not with how many threads it runs. A worker that handles a long tail of tenants
+can hold far more pools than a v3 worker that shared one. This is the real cost, and it is
+stated plainly because pretending otherwise is how adopters get surprised by their
+database connection limit.
+
+The gem ships the mechanisms to bound it (all cross-linked, not restated here):
+
+- **`tenant_pool_size`** — cap connections per tenant pool; injected into each pool's
+  config (`AbstractAdapter#apply_tenant_pool_size`). Defaults to `nil` (Rails' own
+  default applies) for back-compat.
+- **`max_total_connections` + synchronous admission control** — a hard-ish ceiling on
+  total pools: a cold create at capacity evicts the LRU idle pool inline before
+  establishing the new one, with `pool_overflow_policy` (`:evict_idle` soft cap /
+  `:raise` hard cap) governing the all-busy case. See
+  [`pool-admission-control.md`](pool-admission-control.md).
+- **`PoolReaper`** — background idle + LRU eviction so cold tenants don't hold pools
+  forever (`lib/apartment/pool_reaper.rb`); reap cadence is decoupled from the idle
+  window via `reaper_interval`.
+- **`Tenant.each(release_connection:)`** — release leased connections between tenants in a
+  fan-out so finished tenants' pools become reap-eligible mid-run, instead of one warm
+  connection per visited tenant. See
+  [`v4-pool-adopter-ergonomics.md`](v4-pool-adopter-ergonomics.md) and the README
+  "Iterating across tenants" section.
+
+The honest framing: v4 chose a model whose default footprint is larger and gave adopters
+the levers to bound it, rather than a model whose footprint is small but whose isolation
+is procedural. The connection ceiling is a capacity-planning problem with knobs; the v3
+silent-leak is not.
+
+## Non-goals and honest caveats
+
+- **v4 prevents the `search_path`-mutation leak, not application-level wrong-tenant
+  selection.** If your code switches into the wrong tenant — asks for tenant B when it
+  meant tenant A — v4 will faithfully route to B's pool and return B's data. The mechanism
+  guarantees that a query runs against the tenant the code *asked for*; it cannot know
+  which tenant the code *should have* asked for. Authorization and correct tenant
+  resolution remain the application's job (see the elevator and
+  [`elevator-tenant-validation.md`](elevator-tenant-validation.md) for the request-path
+  guardrails the gem does provide).
+- **The pooler benefit is "ceiling becomes viable," not "transaction-mode multiplexing
+  unlocked."** The one-time establishment `SET` still exists (#438). Session-mode pooling
+  and a fixed connection budget are the realized wins; do not overclaim transaction-mode
+  compatibility.
+- **FQN remains a reasonable alternative** for teams that want maximal pooler statelessness
+  and are willing to own every-query qualification themselves. v4 does not foreclose it.
+- **No runtime detection of consumer-fiber leaks.** The async-query contract is a
+  documented discipline, not an enforced one — see
+  [`apartment-v4.md`](apartment-v4.md) § Async query correctness.
+
+## References
+
+- **Issues** — #200, #302, #438: variants of "why not fully-qualify table names / avoid
+  `search_path` entirely?" #302 is the PgBouncer / RDS Proxy session-pinning report that
+  motivated removing per-request `SET`; #438 tracks the still-open libpq `options` path
+  that would remove even the one-time establishment `SET`.
+- **Architecture (what / how)** — [`apartment-v4.md`](apartment-v4.md): pool resolution,
+  `CurrentAttributes`, async-query correctness, PgBouncer section, open-issue resolution
+  table.
+- **Connection-budget controls** — [`pool-admission-control.md`](pool-admission-control.md)
+  (the ceiling), [`v4-pool-adopter-ergonomics.md`](v4-pool-adopter-ergonomics.md) (reaper
+  control, iteration hygiene, observability).
+- **Upgrade context** — [`../upgrading-to-v4.md`](../upgrading-to-v4.md) § What Changed and
+  Why, § Connection Model.

--- a/docs/designs/v4-pool-adopter-ergonomics.md
+++ b/docs/designs/v4-pool-adopter-ergonomics.md
@@ -1,0 +1,178 @@
+# v4 Pool Adopter Ergonomics
+
+## TLDR
+
+Four small additions that remove boilerplate large schema-per-tenant adopters
+currently reinvent against the v4 pool-per-`"tenant:role"` model:
+
+- **A — `config.reap_in_test`**: control the reaper's `Rails.env.test?` auto-stop
+  declaratively, so adopters stop writing boot guards around it.
+- **B — `Tenant.each(release_connection:)` + iteration guidance**: release the leased
+  connection between tenants so pools stay reap-eligible during a fan-out, plus docs on
+  choosing a cross-tenant primitive (a v4 `switch` creates a pool — even for pinned/global
+  reads).
+- **C — `Apartment::PoolObserver`**: a sink-agnostic subscriber (+ optional gauge sampler)
+  for the gem's pool events. Ships no transport; the adopter's sink maps samples to its
+  metrics backend.
+- **D — `docs/observability.md`**: the event/stats contract the gem already emits but never
+  documented.
+
+Each ships as its own PR. Nothing AWS/Sidekiq/PostgreSQL-specific lands in the gem.
+
+## Motivation
+
+v4 keys a separate connection pool per `"tenant:role"`, so backend-connection demand scales
+with tenant fan-out. The gem already gives adopters the primitives to manage and observe
+that (the reaper, admission control, `PoolManager#stats`, instrumentation events). But three
+patterns recur in adopter code because the gem stops one step short of turnkey:
+
+1. **Boot guards around the reaper's silent test auto-stop.** `Railtie.deactivate_pool_reaper_in_test_env!`
+   stops the reaper whenever `Rails.env.test?`. There is no config to override it — only the
+   imperative `Apartment.pool_reaper.start`. Adopters whose environment model doesn't map
+   cleanly to `RAILS_ENV` write a boot guard to keep a deployed process from silently
+   disabling reaping.
+2. **Per-iteration connection release, and "which iteration primitive?" confusion.**
+   `Tenant.each` switches into each tenant; under v4 each switch leases a connection that
+   stays checked out, so a long fan-out holds one un-reapable pool per visited tenant. Worse,
+   `Tenant.each` gets reached for when no switch is needed at all — and a `switch` resolves
+   pinned/global models *through the tenant pool* (shared-pinned-connections), so even reading
+   global data inside a switch spins up a tenant pool.
+3. **A from-scratch telemetry module.** The gem emits the right events but documents no
+   observability contract and ships no subscriber, so each adopter re-derives the event names,
+   payloads, and a sampler before they can watch pool pressure.
+
+## Design
+
+### A. `config.reap_in_test` — declarative reaper control
+
+**Add a boolean config; the railtie reads it before stopping the reaper.**
+
+- `config.reap_in_test` — Boolean, **default `false`** (today's behavior: reaper stopped under
+  `Rails.env.test?`). Validated like the other booleans in `Config#validate!`.
+- `Railtie.deactivate_pool_reaper_in_test_env!` gains one guard: `return if Apartment.config.reap_in_test`.
+  When `true`, the reaper keeps running in test.
+- **Adopter payoff**: set `reap_in_test = true` to keep eviction on regardless of what Rails
+  reports as the environment — a misconfigured or non-standard deployment no longer silently
+  leaks connections, so no boot guard is needed. The existing `:reaper_stopped` event still
+  fires when the reaper *is* stopped.
+
+Back-compat: default `false` reproduces the current `Rails.env.test?` stop exactly.
+
+### B. `Tenant.each(release_connection:)` + iteration guidance
+
+**Code.** `Tenant.each(tenants = nil, release_connection: false)`. When `release_connection` is
+`true`, release the leased connection after each iteration so each finished tenant's pool
+becomes reap-eligible mid-fan-out:
+
+```ruby
+def each(tenants = nil, release_connection: false)
+  raise(ArgumentError, ...) unless block_given?
+
+  tenants ||= Apartment.tenant_names
+  tenants.each do |tenant|
+    switch(tenant) { yield(tenant) }
+    ActiveRecord::Base.connection_handler.clear_active_connections! if release_connection
+  end
+end
+```
+
+Default `false` preserves current behavior. The release is the broad
+`clear_active_connections!` (handler-wide idle-lease release), not a per-pool release — proven
+sufficient in adopter use and far simpler.
+
+**Docs.** A "choosing a cross-tenant iteration primitive" section in `docs/observability.md`
+(cross-referenced from the README tenant-operations section), framed on one question — *does the
+block do per-tenant-schema work?*:
+
+| Need | Use | v4 cost |
+|---|---|---|
+| Names only (enqueue, list) | `Apartment.tenant_names.each { ... }` | No switch, no pool created |
+| Per-tenant-schema work | `Apartment::Tenant.each(release_connection: true) { ... }` | One pool per tenant; released between iterations |
+| Global/pinned data only | Don't switch — read it in the default context | A switch would resolve pinned models through the tenant pool |
+
+The third row is the non-obvious one: under shared-pinned-connections a `switch` routes pinned
+and excluded models through the current tenant's pool, so switching only to read global data
+spins up a tenant pool for nothing.
+
+### C. `Apartment::PoolObserver` — sink-agnostic observability
+
+**A small class that subscribes to the gem's notifications, normalizes each into a `Sample`, and
+forwards to a caller-supplied sink. Ships no transport.**
+
+```ruby
+Apartment::PoolObserver.install!(
+  sink: ->(sample) { Metrics.emit(sample.name, sample.value, sample.dimensions) },
+  sample_interval: 30,                       # optional: starts a gauge sampler TimerTask
+  backend_count: -> { current_backend_count } # optional: adopter's DB-specific ground truth
+)
+```
+
+- **`Sample`** — `Data.define(:name, :kind, :value, :dimensions, :payload)`. `kind` is `:counter`
+  (events) or `:gauge` (samples); `name` is a Symbol (`:evict`, `:tenant_pools_live`, …);
+  `dimensions` is a curated Hash (e.g. `{ reason: :idle }`); `payload` is the raw notification
+  payload so the sink can read anything the curated set omits.
+- **Subscribes to** the pool-lifecycle events: `create`, `evict`, `cap_unmet`, `skip_evict`,
+  `reaper_stopped`. Each becomes a `:counter` Sample with `value: 1`.
+- **Optional sampler** — when `sample_interval` is given, a `Concurrent::TimerTask` (same idiom
+  as the reaper) emits `:gauge` Samples from `PoolManager#stats` (`tenant_pools_live`) and, when
+  `backend_count` is supplied, `backend_connections`. Without an interval, the observer only
+  subscribes; the adopter can call `#sample!` from their own scheduler.
+- **Error isolation** — every sink/sampler call is rescued and logged; the observer never raises
+  into the gem's instrumentation or timer path.
+- **Lifecycle** — `install!` returns the observer; `#stop!` unsubscribes and shuts the sampler.
+  Like the reaper, after `fork` the adopter re-installs (web/worker boot hook).
+
+The two adopter-owned seams — the **sink** (transport/metric naming) and **`backend_count`**
+(DB-specific ground truth, e.g. a `pg_stat_activity` count) — are exactly the parts that must not
+live in the gem. Alerting stays in the sink: it can branch on `sample.name` to page on
+`:cap_unmet` / `:skip_evict`.
+
+### D. `docs/observability.md`
+
+The contract the gem already emits, written down once:
+
+- **Event catalog** — all seven `*.apartment` events (`create`, `drop`, `evict`, `cap_unmet`,
+  `skip_evict`, `reaper_stopped`, `migrate_tenant`): when each fires and its payload fields
+  (e.g. `evict` → `tenant`, `reason`; `skip_evict` → `busy_connections`, `open_transactions`;
+  `cap_unmet` → `max_total`, `current`, `unevicted`).
+- **`PoolManager#stats`** — `total_pools`, `tenants`.
+- **The `PoolObserver` recipe** and the iteration-primitive table from B.
+
+## Alternatives considered
+
+- **Tri-state `pool_reaper_enabled` (`:auto`/`true`/`false`)** instead of boolean `reap_in_test`.
+  More flexible, more surface. Rejected: the only real friction is the test auto-stop; a boolean
+  named for it is clearer.
+- **Always release the connection in `Tenant.each`** (no opt-in). Rejected: a behavior change that
+  could break callers relying on connection reuse across iterations.
+- **Per-pool precise release** instead of `clear_active_connections!`. Rejected as
+  over-engineering; the broad release is proven sufficient and reads plainly.
+- **Ship a concrete sink** (CloudWatch/StatsD/Datadog). Rejected: couples the gem to a transport
+  and its SDK. The sink callable keeps the gem dependency-free.
+- **Snapshot-only observer** (no built-in sampler). Reasonable, but the optional `TimerTask`
+  mirrors the reaper and saves every adopter the same scheduler wiring; kept as opt-in.
+
+## Out of scope
+
+- Concrete metric transports and DB-specific backend-count queries — adopter callables.
+- App-level environment guards (e.g. `PLATFORM_ENV` boot checks) — stay app-side; `reap_in_test`
+  removes their reason, not their environment model.
+- Changing the reaper's *default* test behavior — default stays "stop in test."
+
+## Testing
+
+- **A** — railtie keeps/stops the reaper in test under each `reap_in_test` value; config
+  validation rejects non-boolean; default reproduces current behavior.
+- **B** — `Tenant.each(release_connection: true)` releases leases (integration: a visited
+  tenant's pool is reap-eligible after the iteration); default leaves leases held; arity/return
+  unchanged.
+- **C** — `PoolObserver` forwards a normalized `Sample` to a fake sink for each subscribed event;
+  the sampler emits gauge Samples; a raising sink does not propagate; `stop!` unsubscribes and
+  halts the sampler.
+- **D** — doc only.
+
+## PR sequence
+
+1. `config.reap_in_test` + railtie guard (A).
+2. `Tenant.each(release_connection:)` + iteration docs (B).
+3. `Apartment::PoolObserver` + `docs/observability.md` (C, D).

--- a/docs/designs/v4-pool-adopter-ergonomics.md
+++ b/docs/designs/v4-pool-adopter-ergonomics.md
@@ -136,7 +136,9 @@ The contract the gem already emits, written down once:
   (e.g. `evict` → `tenant`, `reason`; `skip_evict` → `busy_connections`, `open_transactions`;
   `cap_unmet` → `max_total`, `current`, `unevicted`).
 - **`PoolManager#stats`** — `total_pools`, `tenants`.
-- **The `PoolObserver` recipe** and the iteration-primitive table from B.
+- **The `PoolObserver` recipe** (ships in PR 1). The iteration-primitive table from B is
+  added in PR 3, alongside the `release_connection:` code it documents — so the doc never
+  references an option the gem hasn't shipped yet.
 
 ## Alternatives considered
 
@@ -173,6 +175,12 @@ The contract the gem already emits, written down once:
 
 ## PR sequence
 
-1. `config.reap_in_test` + railtie guard (A).
-2. `Tenant.each(release_connection:)` + iteration docs (B).
-3. `Apartment::PoolObserver` + `docs/observability.md` (C, D).
+Lead with the observer — it's what an adopter's hand-rolled telemetry module most directly
+replaces, and it's self-contained (subscribe + forward, no behavior change).
+
+1. **`Apartment::PoolObserver` + `docs/observability.md`** (event catalog, `PoolManager#stats`,
+   observer recipe) — C and the observability half of D.
+2. **`config.reap_in_test` + railtie guard** — A.
+3. **`Tenant.each(release_connection:)` + the iteration-primitive section** added to
+   `docs/observability.md` — B and the iteration half of D. The table ships with the
+   `release_connection:` code it documents.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -78,6 +78,38 @@ $apartment_observer = Apartment::PoolObserver.install!(
 `install!` returns the observer. Store it somewhere accessible so you can call
 `stop!` on shutdown (see teardown below).
 
+The `sink` runs **inline on the thread that emitted the event** — for `evict` /
+`cap_unmet` / `skip_evict` that can be the reaper thread or, during admission, a
+request thread holding the pool-creation lock. Keep the sink **non-blocking**:
+enqueue to your metrics client and return. A sink that does slow synchronous I/O
+will stall pool reaping/admission. (It never *raises* into the gem — failures are
+rescued — but it can *block*.)
+
+#### Preforking servers (Puma cluster, Unicorn, Sidekiq with preload)
+
+The gauge sampler runs on a background thread, and **threads do not survive
+`fork`**. If you call `install!` with a `sample_interval` in `after_initialize`,
+the sampler starts in the master process and is dead in every forked worker —
+counters keep firing (notification subscriptions are inherited), but
+`tenant_pools_live` / `backend_connections` silently flatline.
+
+Split the two concerns: subscribe once at boot, start the sampler per worker.
+
+```ruby
+# config/initializers/apartment_observability.rb
+$apartment_observer = Apartment::PoolObserver.new(
+  sink: ->(sample) { MyMetrics.record(sample) },
+  backend_count: -> { ActiveRecord::Base.connection_pool.connections.size }
+)
+$apartment_observer.subscribe!   # inherited across fork — safe to do at boot
+
+# config/puma.rb
+on_worker_boot { $apartment_observer.start_sampler!(interval: 60) }
+```
+
+Don't call `install!` again per worker — `subscribe!` is not idempotent, so a
+second subscription would double-count every counter.
+
 ### `Sample` shape
 
 Every `sink` call receives one `Sample`:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -102,9 +102,9 @@ Apartment::PoolObserver::Sample
 `PoolManager#stats[:total_pools]`), `:backend_connections` (`value` = your
 `backend_count` callable result; omitted when the callable returns `nil`).
 
-**Dimensions** are curated for cardinality. Only `reason:` is promoted from
-payload into `dimensions` for counter events that carry it (`:evict`,
-`:skip_evict`). Everything else stays in `payload`.
+**Dimensions** are curated for cardinality. `reason:` is promoted from payload
+into `dimensions` for any counter event that carries it (currently `:evict`,
+`:skip_evict`, and `:reaper_stopped`). Everything else stays in `payload`.
 
 ### Wiring a sink
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,183 @@
+# Observability
+
+Apartment emits `ActiveSupport::Notifications` events for every significant pool
+and tenant lifecycle moment, and exposes `PoolManager#stats` for gauge sampling.
+`Apartment::PoolObserver` wires both into a single sink-agnostic subscriber so you
+can forward metrics to any backend without writing the subscription boilerplate
+yourself.
+
+The gem ships no transport. Counters arrive through events; gauges arrive through
+the optional periodic sampler. Your `sink` proc maps `Sample` objects to whatever
+backend you use.
+
+## Event catalog
+
+All events are namespaced `<name>.apartment` and published through
+`ActiveSupport::Notifications`.
+
+| Event | When fired | Payload keys |
+|---|---|---|
+| `create.apartment` | After a tenant schema/database is created | `tenant:` |
+| `drop.apartment` | After a tenant schema/database is dropped | `tenant:` |
+| `evict.apartment` | After a tenant pool is removed from the pool manager | `tenant:`, `reason:` (`:idle`, `:lru`, `:admission`) |
+| `cap_unmet.apartment` | When the pool cap cannot be met by eviction (soft-cap breach) | `max_total:`, `current:`, `unevicted:` |
+| `skip_evict.apartment` | When a candidate pool is skipped during eviction | `tenant:`, `reason:` (`:pinned`, `:in_use`), `eviction_reason:` (`:idle`, `:lru`, `:admission`); plus `busy_connections:` and `open_transactions:` when `reason: :in_use` |
+| `reaper_stopped.apartment` | When the background reaper is deactivated in the test environment | `reason:` (`:test_env`) |
+| `migrate_tenant.apartment` | After migrations run for one tenant | `tenant:`, `versions:` (array of migration version integers) |
+
+**`cap_unmet` fires on two paths:** from the synchronous admission path (when a
+new pool would breach the cap and no idle pool can be freed) and from the
+background LRU reaper (when excess pools remain after a reap cycle). The payload
+is identical on both paths.
+
+**`skip_evict` reason detail:** `:pinned` means Rails' transactional-fixture
+machinery has pinned the pool (`@pinned_connection` is set). `:in_use` means at
+least one connection is leased or holds an open transaction; `busy_connections`
+and `open_transactions` are included in the payload only for `:in_use` so the
+skip is diagnosable from instrumentation without inspecting the pool.
+
+## `PoolManager#stats`
+
+```ruby
+Apartment.pool_manager.stats
+# => { total_pools: 12, tenants: ["acme:writing", "beta:writing", ...] }
+```
+
+`total_pools` is the count of live tenant pools in the process. `tenants` is the
+full list of pool keys (formatted as `"<tenant>:<role>"`).
+
+Per-pool idle time is available via `stats_for`:
+
+```ruby
+Apartment.pool_manager.stats_for("acme:writing")
+# => { seconds_idle: 47.3 }
+# => nil  (when the pool is not tracked)
+```
+
+`seconds_idle` is computed from a monotonic clock (`Process::CLOCK_MONOTONIC`);
+it reflects elapsed time since the pool was last accessed, not a wall-clock
+timestamp. Calling `stats_for` for an untracked key returns `nil`.
+
+## `Apartment::PoolObserver` recipe
+
+### Install once per process
+
+Wire the observer in an `after_initialize` hook so it subscribes after the app
+boots:
+
+```ruby
+# config/initializers/apartment_observability.rb
+
+$apartment_observer = Apartment::PoolObserver.install!(
+  sink: ->(sample) { MyMetrics.record(sample) },
+  sample_interval: 60,            # seconds between gauge passes; omit to disable
+  backend_count: -> { ActiveRecord::Base.connection_pool.connections.size }
+)
+```
+
+`install!` returns the observer. Store it somewhere accessible so you can call
+`stop!` on shutdown (see teardown below).
+
+### `Sample` shape
+
+Every `sink` call receives one `Sample`:
+
+```ruby
+Apartment::PoolObserver::Sample
+# Data.define(:name, :kind, :value, :dimensions, :payload)
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | `Symbol` | Metric identity — see names below |
+| `kind` | `:counter` or `:gauge` | How to record it |
+| `value` | `Numeric` | Always `1` for counters; the measured value for gauges |
+| `dimensions` | `Hash` | Curated subset of payload suitable for metric tags |
+| `payload` | `Hash` | Raw notification payload (counters) or `{}` (gauges) |
+
+**Counter names** (one per event, `value: 1`): `:create`, `:evict`,
+`:cap_unmet`, `:skip_evict`, `:reaper_stopped`.
+
+**Gauge names** (from the periodic sampler): `:tenant_pools_live` (`value` =
+`PoolManager#stats[:total_pools]`), `:backend_connections` (`value` = your
+`backend_count` callable result; omitted when the callable returns `nil`).
+
+**Dimensions** are curated for cardinality. Only `reason:` is promoted from
+payload into `dimensions` for counter events that carry it (`:evict`,
+`:skip_evict`). Everything else stays in `payload`.
+
+### Wiring a sink
+
+```ruby
+sink = lambda do |sample|
+  tags = sample.dimensions.map { |k, v| "#{k}:#{v}" }
+
+  case sample.kind
+  when :counter
+    MyMetrics.increment(sample.name, tags: tags)
+  when :gauge
+    MyMetrics.gauge(sample.name, sample.value, tags: tags)
+  end
+end
+
+$apartment_observer = Apartment::PoolObserver.install!(sink: sink)
+```
+
+### Alerting in the sink
+
+Branch on `sample.name` for operational alerts:
+
+```ruby
+sink = lambda do |sample|
+  # ... normal recording ...
+
+  case sample.name
+  when :cap_unmet
+    # Pool cap is being breached; investigate pool sizing or max_total_connections.
+    MyAlerts.trigger(:pool_cap_breach, payload: sample.payload)
+  when :skip_evict
+    # A pool is being skipped repeatedly; may indicate a long-running transaction.
+    if sample.payload[:reason] == :in_use
+      MyAlerts.trigger(:pool_eviction_skipped,
+                       tenant: sample.payload[:tenant],
+                       open_transactions: sample.payload[:open_transactions])
+    end
+  end
+end
+```
+
+### `backend_count` seam
+
+Supply `backend_count` as a callable that returns the total connection count from
+your backend (connection pool, proxy, or database driver). The observer calls it
+on each gauge pass and emits a `:backend_connections` gauge. Return `nil` to skip
+the sample for that cycle:
+
+```ruby
+Apartment::PoolObserver.install!(
+  sink: sink,
+  sample_interval: 30,
+  backend_count: -> { MyConnectionProxy.active_connections }
+)
+```
+
+The callable is error-isolated: if it raises, the error is logged to `warn` and
+the pass continues.
+
+### Teardown
+
+```ruby
+$apartment_observer.stop!
+```
+
+`stop!` unsubscribes from all events and shuts down the gauge sampler. Safe to
+call twice. Call it in a shutdown hook (e.g. `at_exit`, Puma's `on_worker_shutdown`)
+to avoid orphaned subscriptions across worker restarts.
+
+### Constructor reference
+
+| Argument | Default | Meaning |
+|---|---|---|
+| `sink:` | required | Callable `(Sample) -> void`; receives every sample |
+| `sample_interval:` | `nil` | Seconds between gauge passes; `nil` disables the sampler |
+| `backend_count:` | `nil` | Callable `-> Numeric|nil`; drives `:backend_connections` gauge |

--- a/docs/plans/v4-pool-adopter-ergonomics/pr1-pool-observer.md
+++ b/docs/plans/v4-pool-adopter-ergonomics/pr1-pool-observer.md
@@ -1,0 +1,551 @@
+# PoolObserver + Observability Docs — Implementation Plan (PR 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `Apartment::PoolObserver`, a sink-agnostic subscriber (+ optional gauge sampler) for the gem's pool-lifecycle events, and `docs/observability.md` documenting the event/stats contract.
+
+**Architecture:** A single `Concurrent`-backed class subscribes to the gem's `ActiveSupport::Notifications`, normalizes each event into a `Sample` value object, and forwards it to a caller-supplied `sink` callable. An optional `Concurrent::TimerTask` (same idiom as `PoolReaper`) emits gauge samples from `PoolManager#stats` plus an optional adopter-supplied `backend_count`. All sink/sampler calls are error-isolated — telemetry never raises into the gem's instrumentation or timer path. The gem ships no transport; the adopter's `sink` maps `Sample`s to its metrics backend.
+
+**Tech Stack:** Ruby 3.3+ (`Data.define`), `concurrent-ruby` (`TimerTask`), `ActiveSupport::Notifications`. No database, no Rails required for the unit suite.
+
+**Design spec:** `docs/designs/v4-pool-adopter-ergonomics.md` (component C + the observability half of D).
+
+**Branch:** cut `feat/pool-observer` off `main` before Task 1.
+
+---
+
+### Task 1: File skeleton — `Sample` value object + constructor validation
+
+**Files:**
+- Create: `lib/apartment/pool_observer.rb`
+- Test: `spec/unit/pool_observer_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+```ruby
+# spec/unit/pool_observer_spec.rb
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Apartment::PoolObserver) do
+  let(:samples) { Concurrent::Array.new }
+  let(:sink) { ->(sample) { samples << sample } }
+
+  describe '.new' do
+    it 'raises ArgumentError when the sink is not callable' do
+      expect { described_class.new(sink: 'not callable') }
+        .to(raise_error(ArgumentError, /sink must be callable/))
+    end
+
+    it 'accepts a callable sink' do
+      expect { described_class.new(sink: sink) }.not_to(raise_error)
+    end
+  end
+
+  describe 'Sample' do
+    it 'is a value object with the documented fields' do
+      sample = described_class::Sample.new(
+        name: :evict, kind: :counter, value: 1, dimensions: { reason: :idle }, payload: { tenant: 'acme' }
+      )
+      expect(sample).to(have_attributes(name: :evict, kind: :counter, value: 1,
+                                        dimensions: { reason: :idle }, payload: { tenant: 'acme' }))
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb`
+Expected: FAIL with `uninitialized constant Apartment::PoolObserver`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ruby
+# lib/apartment/pool_observer.rb
+# frozen_string_literal: true
+
+require 'concurrent'
+
+module Apartment
+  # Sink-agnostic observer for the v4 pool lifecycle. Subscribes to the gem's
+  # ActiveSupport::Notifications and forwards a normalized Sample to a caller-
+  # supplied sink; optionally samples pool gauges on an interval. Ships no
+  # transport — the adopter's sink maps Samples to CloudWatch/StatsD/logs/etc.
+  # All sink/sampler calls are error-isolated: telemetry must never raise into
+  # the gem's instrumentation or timer path. See docs/observability.md.
+  class PoolObserver
+    # name: Symbol (:evict, :tenant_pools_live, ...); kind: :counter | :gauge;
+    # value: Numeric; dimensions: Hash (curated, e.g. { reason: :idle });
+    # payload: the raw notification payload (counters) or {} (gauges).
+    Sample = Data.define(:name, :kind, :value, :dimensions, :payload)
+
+    def initialize(sink:, backend_count: nil)
+      raise(ArgumentError, 'sink must be callable') unless sink.respond_to?(:call)
+
+      @sink = sink
+      @backend_count = backend_count
+      @subscribers = []
+      @sampler = nil
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb`
+Expected: PASS (3 examples)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/pool_observer.rb spec/unit/pool_observer_spec.rb
+git commit -m "PoolObserver: Sample value object + constructor validation"
+```
+
+---
+
+### Task 2: `subscribe!` + `record_event` + `.install!` — counter samples
+
+**Files:**
+- Modify: `lib/apartment/pool_observer.rb`
+- Test: `spec/unit/pool_observer_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ruby
+# Add inside the RSpec.describe block, after the 'Sample' describe.
+  describe '#subscribe! / .install!' do
+    subject(:observer) { described_class.install!(sink: sink) }
+
+    after { observer.stop! }
+
+    it 'forwards a subscribed event to the sink as a counter Sample' do
+      observer
+      Apartment::Instrumentation.instrument(:evict, tenant: 'acme', reason: :idle)
+
+      sample = samples.find { |s| s.name == :evict }
+      expect(sample).not_to(be_nil)
+      expect(sample).to(have_attributes(kind: :counter, value: 1, dimensions: { reason: :idle }))
+      expect(sample.payload).to(include(tenant: 'acme', reason: :idle))
+    end
+
+    it 'curates :reason into dimensions and leaves the rest in payload' do
+      observer
+      Apartment::Instrumentation.instrument(:cap_unmet, max_total: 5, current: 6, unevicted: 1)
+
+      sample = samples.find { |s| s.name == :cap_unmet }
+      expect(sample.dimensions).to(eq({}))
+      expect(sample.payload).to(include(max_total: 5, current: 6, unevicted: 1))
+    end
+
+    it 'subscribes to all pool-lifecycle counter events' do
+      observer
+      %i[create evict cap_unmet skip_evict reaper_stopped].each do |event|
+        Apartment::Instrumentation.instrument(event, {})
+      end
+      expect(samples.map(&:name)).to(include(:create, :evict, :cap_unmet, :skip_evict, :reaper_stopped))
+    end
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb -e subscribe`
+Expected: FAIL with `undefined method 'install!'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ruby
+# Add to lib/apartment/pool_observer.rb inside class PoolObserver, after Sample.
+
+    # Pool-lifecycle events forwarded as counters (value 1 each).
+    COUNTER_EVENTS = %i[create evict cap_unmet skip_evict reaper_stopped].freeze
+
+    # Build, subscribe, and (optionally) start the gauge sampler. Returns the
+    # observer; call #stop! to tear it down. Idempotent subscription is NOT
+    # guaranteed — install once per process (e.g. an after_initialize hook).
+    def self.install!(sink:, sample_interval: nil, backend_count: nil)
+      observer = new(sink: sink, backend_count: backend_count)
+      observer.subscribe!
+      observer.start_sampler!(interval: sample_interval) if sample_interval&.positive?
+      observer
+    end
+
+    def subscribe!
+      COUNTER_EVENTS.each do |event|
+        subscriber = ActiveSupport::Notifications.subscribe("#{event}.apartment") do |_name, _start, _finish, _id, payload|
+          record_event(event, payload || {})
+        end
+        @subscribers << subscriber
+      end
+      self
+    end
+```
+
+```ruby
+# Add a private section at the bottom of class PoolObserver.
+
+    private
+
+    def record_event(event, payload)
+      dimensions = payload[:reason] ? { reason: payload[:reason] } : {}
+      emit(Sample.new(name: event, kind: :counter, value: 1, dimensions: dimensions, payload: payload))
+    rescue StandardError => e
+      warn_failure("record_event(#{event})", e)
+    end
+
+    def emit(sample)
+      @sink.call(sample)
+    rescue StandardError => e
+      warn_failure("sink(#{sample.name})", e)
+    end
+
+    def warn_failure(context, error)
+      warn "[Apartment::PoolObserver] #{context} failed: #{error.class}: #{error.message}"
+    end
+```
+
+> Note: `start_sampler!` and `stop!` are referenced by `install!`/specs but defined in Task 4. Add a temporary no-op `def stop!; @subscribers.each { |s| ActiveSupport::Notifications.unsubscribe(s) }; @subscribers.clear; end` and `def start_sampler!(interval:); end` now so Task 2 runs green; Task 4 replaces them with the full versions.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/pool_observer.rb spec/unit/pool_observer_spec.rb
+git commit -m "PoolObserver: subscribe to pool events, forward counter Samples to the sink"
+```
+
+---
+
+### Task 3: `sample!` — gauge samples (`tenant_pools_live` + optional `backend_connections`)
+
+**Files:**
+- Modify: `lib/apartment/pool_observer.rb`
+- Test: `spec/unit/pool_observer_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ruby
+# Add inside the RSpec.describe block.
+  describe '#sample!' do
+    let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 3, tenants: [] }) }
+
+    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+
+    it 'emits a tenant_pools_live gauge from PoolManager#stats' do
+      observer = described_class.new(sink: sink)
+      observer.sample!
+
+      sample = samples.find { |s| s.name == :tenant_pools_live }
+      expect(sample).to(have_attributes(kind: :gauge, value: 3, dimensions: {}, payload: {}))
+    end
+
+    it 'emits backend_connections when a backend_count callable is supplied' do
+      observer = described_class.new(sink: sink, backend_count: -> { 42 })
+      observer.sample!
+
+      sample = samples.find { |s| s.name == :backend_connections }
+      expect(sample).to(have_attributes(kind: :gauge, value: 42))
+    end
+
+    it 'skips backend_connections when backend_count returns nil' do
+      observer = described_class.new(sink: sink, backend_count: -> { nil })
+      observer.sample!
+
+      expect(samples.map(&:name)).not_to(include(:backend_connections))
+    end
+
+    it 'reports zero pools when the manager is absent (unconfigured)' do
+      allow(Apartment).to(receive(:pool_manager).and_return(nil))
+      observer = described_class.new(sink: sink)
+      observer.sample!
+
+      expect(samples.find { |s| s.name == :tenant_pools_live }.value).to(eq(0))
+    end
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb -e sample!`
+Expected: FAIL with `undefined method 'sample!'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ruby
+# Add to lib/apartment/pool_observer.rb as a PUBLIC method (above `private`).
+
+    # One gauge pass: live tenant-pool count, plus the adopter's backend count
+    # when supplied. Safe to call from start_sampler! or an external scheduler.
+    def sample!
+      total = Apartment.pool_manager&.stats&.fetch(:total_pools, 0) || 0
+      emit(Sample.new(name: :tenant_pools_live, kind: :gauge, value: total, dimensions: {}, payload: {}))
+
+      return unless @backend_count
+
+      backends = @backend_count.call
+      return if backends.nil?
+
+      emit(Sample.new(name: :backend_connections, kind: :gauge, value: backends, dimensions: {}, payload: {}))
+    rescue StandardError => e
+      warn_failure('sample!', e)
+    end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/pool_observer.rb spec/unit/pool_observer_spec.rb
+git commit -m "PoolObserver: sample! emits tenant_pools_live + optional backend_connections gauges"
+```
+
+---
+
+### Task 4: `start_sampler!` / `stop!` — lifecycle
+
+**Files:**
+- Modify: `lib/apartment/pool_observer.rb` (replace the Task 2 temporary stubs)
+- Test: `spec/unit/pool_observer_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ruby
+# Add inside the RSpec.describe block.
+  describe '#start_sampler! / #stop!' do
+    let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 2, tenants: [] }) }
+
+    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+
+    it 'runs sample! on the configured interval' do
+      observer = described_class.new(sink: sink)
+      observer.start_sampler!(interval: 0.05)
+      sleep 0.15
+      observer.stop!
+
+      expect(samples.any? { |s| s.name == :tenant_pools_live }).to(be(true))
+    end
+
+    it 'stop! unsubscribes so later events no longer reach the sink' do
+      observer = described_class.install!(sink: sink)
+      observer.stop!
+      samples.clear
+
+      Apartment::Instrumentation.instrument(:evict, {})
+      expect(samples).to(be_empty)
+    end
+
+    it 'stop! halts the sampler' do
+      observer = described_class.new(sink: sink)
+      observer.start_sampler!(interval: 0.05)
+      observer.stop!
+      sleep 0.1
+      count = samples.size
+      sleep 0.1
+      expect(samples.size).to(eq(count))
+    end
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb -e sampler`
+Expected: FAIL (the temporary `start_sampler!` is a no-op, so no `tenant_pools_live` sample appears)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ruby
+# Replace the temporary stubs from Task 2 with these PUBLIC methods (above `private`).
+
+    def start_sampler!(interval:)
+      @sampler&.shutdown
+      @sampler = Concurrent::TimerTask.new(execution_interval: interval) { sample! }
+      @sampler.execute
+      @sampler
+    end
+
+    # Unsubscribe from all events and shut down the sampler. Safe to call twice.
+    def stop!
+      @subscribers.each { |subscriber| ActiveSupport::Notifications.unsubscribe(subscriber) }
+      @subscribers.clear
+      @sampler&.shutdown
+      @sampler = nil
+    end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/apartment/pool_observer.rb spec/unit/pool_observer_spec.rb
+git commit -m "PoolObserver: start_sampler! TimerTask + stop! teardown"
+```
+
+---
+
+### Task 5: Error isolation — sink/sample failures never propagate
+
+**Files:**
+- Test: `spec/unit/pool_observer_spec.rb` (the rescues already exist from Tasks 2-3; this locks them with tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+```ruby
+# Add inside the RSpec.describe block.
+  describe 'error isolation' do
+    let(:boom_sink) { ->(_sample) { raise('sink boom') } }
+
+    after { @observer&.stop! }
+
+    it 'does not propagate when the sink raises on an event' do
+      @observer = described_class.install!(sink: boom_sink)
+      expect { Apartment::Instrumentation.instrument(:evict, {}) }.not_to(raise_error)
+    end
+
+    it 'does not propagate when the sink raises during sample!' do
+      allow(Apartment).to(receive(:pool_manager)
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+      @observer = described_class.new(sink: boom_sink)
+      expect { @observer.sample! }.not_to(raise_error)
+    end
+
+    it 'does not propagate when backend_count raises' do
+      allow(Apartment).to(receive(:pool_manager)
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+      @observer = described_class.new(sink: sink, backend_count: -> { raise('backend boom') })
+      expect { @observer.sample! }.not_to(raise_error)
+    end
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they pass (rescues already present)**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb -e "error isolation"`
+Expected: PASS (Tasks 2-3 already added the `rescue StandardError` guards; if any test fails, the corresponding guard is missing — add it before moving on)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec/unit/pool_observer_spec.rb
+git commit -m "PoolObserver: lock error isolation for sink and sample failures"
+```
+
+---
+
+### Task 6: `docs/observability.md` — the event/stats contract
+
+**Files:**
+- Create: `docs/observability.md`
+- Modify: `README.md` (add one link under an Observability/Pool section)
+- Modify: `lib/apartment/CLAUDE.md` (add a `pool_observer.rb` file-guide entry)
+
+- [ ] **Step 1: Write `docs/observability.md`**
+
+Document, in this order:
+
+1. **Event catalog** — a table of the seven `*.apartment` events and their payload fields:
+   - `create` → `{ tenant: }`
+   - `drop` → `{ tenant: }`
+   - `evict` → `{ tenant:, reason: }` (`reason`: `:idle` / `:lru` / `:admission`)
+   - `cap_unmet` → `{ max_total:, current:, unevicted: }`
+   - `skip_evict` → `{ tenant:, reason:, eviction_reason:, busy_connections?, open_transactions? }`
+   - `reaper_stopped` → `{ reason: }` (`:test_env`)
+   - `migrate_tenant` → `{ tenant:, ... }`
+   (Cross-check each against `lib/apartment/pool_reaper.rb` and the adapters before writing — payloads must match the source.)
+2. **`PoolManager#stats`** — returns `{ total_pools:, tenants: }`; note monotonic-clock `stats_for(tenant_key)` → `{ seconds_idle: }`.
+3. **`Apartment::PoolObserver` recipe** — the `install!` example, the `Sample` shape, the `sink`/`backend_count` seams, alerting in the sink (branch on `sample.name` for `:cap_unmet` / `:skip_evict`), and `stop!` for teardown.
+4. A short "ships no transport" note: counters via events, gauges via the sampler; the adopter owns the metrics backend.
+
+- [ ] **Step 2: Add a README pointer**
+
+Add under the README's pool/observability area:
+
+```markdown
+### Observability
+
+Apartment emits `ActiveSupport::Notifications` for the pool lifecycle and ships
+`Apartment::PoolObserver`, a sink-agnostic subscriber + sampler. See
+[docs/observability.md](docs/observability.md).
+```
+
+- [ ] **Step 3: Add the file-guide entry**
+
+In `lib/apartment/CLAUDE.md`, add under the v4 files list:
+
+```markdown
+### pool_observer.rb — Observability (opt-in)
+
+Sink-agnostic subscriber for the pool events (`create`/`evict`/`cap_unmet`/`skip_evict`/`reaper_stopped`) + an optional `Concurrent::TimerTask` gauge sampler (`tenant_pools_live`, optional adopter `backend_count`). Normalizes each to a `Sample` and forwards to a caller `sink`; ships no transport. Error-isolated — never raises into instrumentation. See `docs/observability.md`.
+```
+
+- [ ] **Step 4: Verify the doc links resolve and commit**
+
+Run: `grep -n "docs/observability.md" README.md && test -f docs/observability.md && echo OK`
+Expected: prints the README line and `OK`
+
+```bash
+git add docs/observability.md README.md lib/apartment/CLAUDE.md
+git commit -m "Docs: observability guide (event catalog, PoolManager#stats, PoolObserver recipe)"
+```
+
+---
+
+### Task 7: Verify — RuboCop + full unit suite + cross-version
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: RuboCop on the new/changed files**
+
+Run: `bundle exec rubocop lib/apartment/pool_observer.rb spec/unit/pool_observer_spec.rb`
+Expected: `no offenses detected` (fix any inline; the class may need a `# rubocop:disable Metrics/...` only if genuinely over a threshold)
+
+- [ ] **Step 2: Full unit suite**
+
+Run: `bundle exec rspec spec/unit/`
+Expected: all green, 0 failures (new `pool_observer_spec` examples included)
+
+- [ ] **Step 3: Cross-version smoke (oldest + newest supported Rails)**
+
+Run: `bundle exec appraisal rails-7.2-sqlite3 rspec spec/unit/pool_observer_spec.rb`
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/unit/pool_observer_spec.rb`
+Expected: green on both (confirms `Data.define` + `ActiveSupport::Notifications` behavior across the matrix)
+
+- [ ] **Step 4: Final commit (if any RuboCop fixes were needed)**
+
+```bash
+git add -A
+git commit -m "PoolObserver: rubocop + cross-version green"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (component C + observability half of D):**
+- Sink-agnostic subscribe → `Sample` → sink: Tasks 1-2. ✓
+- Optional sampler (`tenant_pools_live` + optional `backend_count`): Tasks 3-4. ✓
+- Error isolation (never raises into instrumentation): Tasks 2-3 (guards) + Task 5 (tests). ✓
+- Lifecycle (`install!` / `stop!`): Tasks 2, 4. ✓
+- `Sample` value object (name/kind/value/dimensions/payload): Task 1. ✓
+- Observability docs (event catalog, stats, recipe): Task 6. ✓
+- Out of scope (transport, DB-specific backend query): kept as `sink` / `backend_count` callables. ✓
+- NOT in this PR (per the reordered sequence): `reap_in_test` (A), `Tenant.each(release_connection:)` + iteration table (B). Correct — those are PR 2 and PR 3.
+
+**Placeholder scan:** Task 6 step 1 describes doc *content* rather than pasting final prose — acceptable for a docs task, but the executor must cross-check every payload field against source before writing (called out inline). No `TODO`/`TBD` in code steps.
+
+**Type consistency:** `Sample.new(name:, kind:, value:, dimensions:, payload:)` is identical across Tasks 1-5. `COUNTER_EVENTS` (Task 2) matches the subscribed-events test (Task 2) and the file-guide entry (Task 6). `install!(sink:, sample_interval:, backend_count:)` and `sample!`/`start_sampler!(interval:)`/`stop!` signatures are consistent across tasks. The Task 2 temporary `stop!`/`start_sampler!` stubs are explicitly replaced in Task 4 (flagged inline) to avoid a dangling no-op.

--- a/docs/plans/v4-pool-adopter-ergonomics/pr2-reap-in-test.md
+++ b/docs/plans/v4-pool-adopter-ergonomics/pr2-reap-in-test.md
@@ -1,0 +1,120 @@
+# `config.reap_in_test` — Implementation Plan (PR 2)
+
+**Goal:** Add a declarative `config.reap_in_test` so adopters can control the reaper's `Rails.env.test?` auto-stop, removing the need for app-side boot guards.
+
+**Architecture:** New boolean config (default `false` = today's behavior). `Railtie.deactivate_pool_reaper_in_test_env!` gains one guard: skip the stop when `reap_in_test` is `true`. No behavior change at the default.
+
+**Design spec:** `docs/designs/v4-pool-adopter-ergonomics.md` (component A).
+
+**Branch:** `feat/reap-in-test` off `main`.
+
+---
+
+### Task 1: `config.reap_in_test` — default + validation
+
+**Files:** `lib/apartment/config.rb`, `spec/unit/config_spec.rb`
+
+- Add `:reap_in_test` to the `attr_accessor` list; `@reap_in_test = false` in `initialize`.
+- In `validate!`, with the other booleans:
+
+```ruby
+unless [true, false].include?(@reap_in_test)
+  raise(ConfigurationError, "reap_in_test must be true or false, got: #{@reap_in_test.inspect}")
+end
+```
+
+- Specs (`config_spec.rb`):
+
+```ruby
+it { expect(config.reap_in_test).to(be(false)) }   # in the defaults block
+
+it 'raises when reap_in_test is not a boolean' do
+  config.tenant_strategy = :schema
+  config.tenants_provider = -> { [] }
+  config.reap_in_test = 'yes'
+  expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /reap_in_test/))
+end
+
+it 'accepts reap_in_test = true' do
+  config.tenant_strategy = :schema
+  config.tenants_provider = -> { [] }
+  config.reap_in_test = true
+  expect { config.validate! }.not_to(raise_error)
+end
+```
+
+TDD + commit.
+
+---
+
+### Task 2: Railtie guard
+
+**Files:** `lib/apartment/railtie.rb`, `spec/unit/railtie_spec.rb`
+
+- Add the guard (config may be nil when the method is unit-tested in isolation, so use `&.`):
+
+```ruby
+def self.deactivate_pool_reaper_in_test_env!
+  return unless Rails.env.test?
+  return if Apartment.config&.reap_in_test
+  return unless Apartment.pool_reaper
+
+  Apartment.pool_reaper.stop
+  Apartment::Instrumentation.instrument(:reaper_stopped, reason: :test_env)
+end
+```
+
+- Update the method's doc comment to note that `config.reap_in_test = true` keeps the reaper running in test (so a deployment that runs under `RAILS_ENV=test` semantics doesn't silently disable reaping — no boot guard needed).
+
+- Specs (`railtie_spec.rb`, in the existing `.deactivate_pool_reaper_in_test_env!` describe):
+
+```ruby
+it 'leaves the reaper running when config.reap_in_test is true' do
+  reaper = instance_double(Apartment::PoolReaper, stop: nil)
+  allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+  allow(Apartment).to(receive(:config).and_return(instance_double(Apartment::Config, reap_in_test: true)))
+  allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+  Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+  expect(reaper).not_to(have_received(:stop))
+end
+
+it 'stops the reaper when config.reap_in_test is false (default)' do
+  reaper = instance_double(Apartment::PoolReaper, stop: nil)
+  allow(Apartment).to(receive(:pool_reaper).and_return(reaper))
+  allow(Apartment).to(receive(:config).and_return(instance_double(Apartment::Config, reap_in_test: false)))
+  allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+  Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+  expect(reaper).to(have_received(:stop))
+end
+```
+
+TDD + commit. The existing deactivate specs (which don't stub `config`) must still pass — `&.` makes a nil config fall through to the stop.
+
+---
+
+### Task 3: Docs
+
+**Files:** `README.md`, `docs/upgrading-to-v4.md`
+
+- README "Pool Settings": add
+
+  > `reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the railtie stops it in test, since fixture transactions make eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping, instead of guarding `RAILS_ENV` at boot.
+
+- `docs/upgrading-to-v4.md` pool-config table: add the `reap_in_test` row (default `false`).
+
+Commit.
+
+---
+
+### Task 4: Verify
+
+- `bundle exec rspec spec/unit/config_spec.rb spec/unit/railtie_spec.rb` — green
+- `bundle exec rspec spec/unit/` — green, no regressions (existing deactivate specs still pass)
+- `bundle exec rubocop lib/apartment/config.rb lib/apartment/railtie.rb spec/unit/config_spec.rb spec/unit/railtie_spec.rb` — clean
+- `bundle exec appraisal rails-7.2-sqlite3 rspec spec/unit/config_spec.rb` and `rails-8.1-sqlite3` — green
+
+Then: adversarial panel review (standard for this series) → address findings → PR `feat/reap-in-test` → `main`.

--- a/docs/plans/v4-pool-adopter-ergonomics/pr3-tenant-each-release.md
+++ b/docs/plans/v4-pool-adopter-ergonomics/pr3-tenant-each-release.md
@@ -1,0 +1,121 @@
+# `Tenant.each(release_connection:)` + iteration guide — Implementation Plan (PR 3)
+
+**Goal:** Let `Apartment::Tenant.each` release the leased connection between tenants so pools become reap-eligible mid-fan-out, and document how to choose a cross-tenant iteration primitive.
+
+**Design spec:** `docs/designs/v4-pool-adopter-ergonomics.md` (component B).
+
+**Branch:** `feat/tenant-each-release` off `main`.
+
+**Doc placement note:** the design put the iteration guide in `docs/observability.md`; the README ("Background Workers" / "Convenience Methods") is the more discoverable home for usage guidance, so it goes there instead.
+
+---
+
+### Task 1: `Tenant.each(release_connection: false)`
+
+**Files:** `lib/apartment/tenant.rb`, `spec/unit/tenant_spec.rb`
+
+```ruby
+def each(tenants = nil, release_connection: false)
+  raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
+
+  tenants ||= Apartment.tenant_names
+  tenants.each do |tenant|
+    switch(tenant) { yield(tenant) }
+    # v4 keys a pool per "tenant:role"; the switch leaves a leased connection
+    # that keeps the pool un-reapable. Release it so a long fan-out doesn't hold
+    # one warm connection per visited tenant. Handler-wide (:all) covers writing
+    # + reading roles — the gem's established release call (see memory_stability_spec).
+    ActiveRecord::Base.connection_handler.clear_active_connections!(:all) if release_connection
+  end
+end
+```
+
+Default `false` preserves current behavior. Unit specs (spy on the real handler — real AR is loaded in `tenant_spec`):
+
+```ruby
+it 'releases the connection after each tenant when release_connection: true' do
+  allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+  described_class.each(release_connection: true) { |_t| }
+  expect(ActiveRecord::Base.connection_handler)
+    .to(have_received(:clear_active_connections!).with(:all).twice)   # 2 tenants
+end
+
+it 'does not release connections by default' do
+  allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+  described_class.each { |_t| }
+  expect(ActiveRecord::Base.connection_handler).not_to(have_received(:clear_active_connections!))
+end
+```
+
+TDD + commit.
+
+---
+
+### Task 2: Integration proof (release makes pools reap-eligible)
+
+**Files:** `spec/integration/v4/tenant_each_release_spec.rb` (new)
+
+Mirror `memory_stability_spec` setup (V4IntegrationHelper, skip on sqlite). Create N tenants with a `widgets` table, then:
+
+```ruby
+it 'leaves no leased connection on visited pools when release_connection is true' do
+  stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+  role = ActiveRecord::Base.current_role
+
+  Apartment::Tenant.each(release_connection: true) { Widget.create!(name: 'x') }
+
+  tenants.each do |t|
+    pool = Apartment.pool_manager.peek("#{t}:#{role}")
+    expect(pool).not_to(be_nil)
+    expect(pool.connections.any?(&:in_use?)).to(be(false), "#{t} pool still has a leased connection")
+  end
+end
+
+it 'leaves leased connections without release_connection (contrast)' do
+  stub_const('Widget', Class.new(ActiveRecord::Base) { self.table_name = 'widgets' })
+  role = ActiveRecord::Base.current_role
+
+  Apartment::Tenant.each { Widget.create!(name: 'x') }
+
+  leased = tenants.any? do |t|
+    pool = Apartment.pool_manager.peek("#{t}:#{role}")
+    pool && pool.connections.any?(&:in_use?)
+  end
+  expect(leased).to(be(true))
+ensure
+  ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+end
+```
+
+TDD + commit. Run on PostgreSQL: `DATABASE_ENGINE=postgresql BUNDLE_GEMFILE=gemfiles/rails_8.1_postgresql.gemfile bundle exec rspec spec/integration/v4/tenant_each_release_spec.rb`.
+
+---
+
+### Task 3: Iteration guide (README)
+
+**Files:** `README.md`
+
+Add an "## Iterating across tenants" section after "Background Workers":
+
+- One question — *does the block do per-tenant-schema work?* — and a table:
+
+| Need | Use | v4 cost |
+|---|---|---|
+| Names only (enqueue, list) | `Apartment.tenant_names.each { ... }` | No switch, no pool created |
+| Per-tenant-schema work | `Apartment::Tenant.each(release_connection: true) { ... }` | One pool per tenant; released between iterations |
+| Global/pinned data only | Don't switch — read it in the default context | A switch resolves pinned models *through* the tenant pool |
+
+- The gotcha: under shared-pinned-connections a `switch` routes pinned/excluded models through the current tenant's pool, so switching only to read global data spins up a tenant pool for nothing.
+- Note `release_connection: true` for large fan-outs (keeps pools reap-eligible).
+
+Commit.
+
+---
+
+### Task 4: Verify + review
+
+- `bundle exec rspec spec/unit/tenant_spec.rb` + full unit suite — green
+- Integration: PostgreSQL (+ MySQL if available) for `tenant_each_release_spec`
+- `bundle exec rubocop` on changed files — clean
+- Cross-version unit smoke (7.2 + 8.1)
+- Adversarial panel review (standard) → address findings → PR `feat/tenant-each-release` → `main`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -231,12 +231,18 @@ What to do instead, depending on the call site:
 
 ### Pool reaper
 
-`Apartment::PoolReaper` evicts idle and excess tenant pools on a background timer. In production it bounds memory under high tenant counts; in test suites it's typically a liability — short runs, few tenants, no memory pressure, and an eviction mid-example can orphan transactional-fixture state. **The Railtie stops the reaper automatically when `Rails.env.test?`.** A suite that genuinely needs eviction (long-running parallel tenant churn, large fixtures) can opt back in:
+`Apartment::PoolReaper` evicts idle and excess tenant pools on a background timer. In production it bounds memory under high tenant counts; in test suites it's typically a liability — short runs, few tenants, no memory pressure, and an eviction mid-example can orphan transactional-fixture state. **The Railtie stops the reaper automatically when `Rails.env.test?`.**
+
+A suite (or a deployed process that runs under `Rails.env.test?` semantics) that needs the reaper on should set the config flag — it applies at boot, before the reaper is stopped:
 
 ```ruby
-# spec/rails_helper.rb
-Apartment.pool_reaper&.start
+Apartment.configure do |config|
+  # ...
+  config.reap_in_test = true   # don't auto-stop the reaper under Rails.env.test?
+end
 ```
+
+This applies to **every** `Rails.env.test?` process, including CI — where mid-example eviction can orphan transactional fixtures and surface as intermittent failures. Prefer it only when a real deployment runs test-env semantics; for a one-off local need, `Apartment.pool_reaper&.start` after boot is the manual escape hatch.
 
 The reaper is also defensive against transactional state when it does run. Two guards block eviction of a candidate pool:
 

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -215,6 +215,7 @@ Key config options for pool tuning:
 | `reaper_interval` | nil | Seconds between reap passes; nil derives from `pool_idle_timeout` |
 | `max_total_connections` | nil | Ceiling on live tenant pools; enforced synchronously at create time |
 | `pool_overflow_policy` | `:evict_idle` | At-capacity-with-no-idle-pool behavior: `:evict_idle` (soft) or `:raise` (hard) |
+| `reap_in_test` | `false` | Keep the reaper running under `Rails.env.test?`; `true` avoids a boot guard for deployments that run test-env semantics |
 
 ## Migration Steps
 

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -12,6 +12,8 @@
 
 v4 replaces the thread-local tenant switching model with pool-per-tenant architecture: each tenant gets a dedicated connection pool, eliminating cross-thread tenant leakage (a persistent problem in ActionCable, Sidekiq, and fiber-based servers). Tenant context is tracked via `ActiveSupport::CurrentAttributes`, fiber-safe under `:fiber` isolation (Rails' default is `:thread`; see Connection Model below). Configuration is immutable after boot (`Config#freeze!` runs after `Apartment.configure`). Global models use a declarative `pin_tenant` call on each class instead of a centralized config list.
 
+For the design rationale behind the pool-per-tenant connection model — why isolation moved out of a mutable `search_path` and into the pool, and why fully-qualified table names (a common adopter question) was not adopted as the gem default — see [`designs/v4-connection-model-rationale.md`](designs/v4-connection-model-rationale.md).
+
 ## Breaking Changes
 
 ### Configuration

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -95,6 +95,10 @@ All inherit from `AbstractAdapter`. Override `resolve_connection_config`, `creat
 
 **Shim compatibility:** `process_pinned_model` dynamically includes `Apartment::Model` on classes registered via the `excluded_models` shim that lack the concern. This is a runtime `include` on a partially-booted class — acceptable for the legacy shim path but new code should always use `include Apartment::Model` + `pin_tenant` explicitly.
 
+### pool_observer.rb — Observability (opt-in)
+
+Sink-agnostic subscriber for the pool events (`create`/`evict`/`cap_unmet`/`skip_evict`/`reaper_stopped`) + an optional `Concurrent::TimerTask` gauge sampler (`tenant_pools_live`, optional adopter `backend_count`). Normalizes each to a `Sample` and forwards to a caller `sink`; ships no transport. Error-isolated — never raises into instrumentation. See `docs/observability.md`.
+
 ### railtie.rb — v4 Rails Integration
 
 Three hooks in Rails boot order:

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -26,7 +26,7 @@ module Apartment
                   :active_record_log, :sql_query_tags,
                   :shard_key_prefix,
                   :migration_role, :app_role, :schema_cache_per_tenant, :check_pending_migrations,
-                  :force_separate_pinned_pool, :test_fixture_cleanup
+                  :force_separate_pinned_pool, :test_fixture_cleanup, :reap_in_test
 
     def initialize # rubocop:disable Metrics/AbcSize
       @tenant_strategy = nil
@@ -59,6 +59,7 @@ module Apartment
       @schema_cache_per_tenant = false
       @check_pending_migrations = true
       @force_separate_pinned_pool = false
+      @reap_in_test = false
       @test_fixture_cleanup = true
     end
 
@@ -207,6 +208,11 @@ module Apartment
       unless [true, false].include?(@test_fixture_cleanup)
         raise(ConfigurationError,
               "test_fixture_cleanup must be true or false, got: #{@test_fixture_cleanup.inspect}")
+      end
+
+      unless [true, false].include?(@reap_in_test)
+        raise(ConfigurationError,
+              "reap_in_test must be true or false, got: #{@reap_in_test.inspect}")
       end
 
       unless @tenant_validator.nil? || @tenant_validator == false || @tenant_validator.respond_to?(:call)

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'concurrent'
+
+module Apartment
+  # Sink-agnostic observer for the v4 pool lifecycle. Subscribes to the gem's
+  # ActiveSupport::Notifications and forwards a normalized Sample to a caller-
+  # supplied sink; optionally samples pool gauges on an interval. Ships no
+  # transport — the adopter's sink maps Samples to CloudWatch/StatsD/logs/etc.
+  # All sink/sampler calls are error-isolated: telemetry must never raise into
+  # the gem's instrumentation or timer path. See docs/observability.md.
+  class PoolObserver
+    # name: Symbol (:evict, :tenant_pools_live, ...); kind: :counter | :gauge;
+    # value: Numeric; dimensions: Hash (curated, e.g. { reason: :idle });
+    # payload: the raw notification payload (counters) or {} (gauges).
+    Sample = Data.define(:name, :kind, :value, :dimensions, :payload)
+
+    def initialize(sink:, backend_count: nil)
+      raise(ArgumentError, 'sink must be callable') unless sink.respond_to?(:call)
+
+      @sink = sink
+      @backend_count = backend_count
+      @subscribers = []
+      @sampler = nil
+    end
+  end
+end

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -15,6 +15,19 @@ module Apartment
     # payload: the raw notification payload (counters) or {} (gauges).
     Sample = Data.define(:name, :kind, :value, :dimensions, :payload)
 
+    # Pool-lifecycle events forwarded as counters (value 1 each).
+    COUNTER_EVENTS = %i[create evict cap_unmet skip_evict reaper_stopped].freeze
+
+    # Build, subscribe, and (optionally) start the gauge sampler. Returns the
+    # observer; call #stop! to tear it down. Idempotent subscription is NOT
+    # guaranteed — install once per process (e.g. an after_initialize hook).
+    def self.install!(sink:, sample_interval: nil, backend_count: nil)
+      observer = new(sink: sink, backend_count: backend_count)
+      observer.subscribe!
+      observer.start_sampler!(interval: sample_interval) if sample_interval&.positive?
+      observer
+    end
+
     def initialize(sink:, backend_count: nil)
       raise(ArgumentError, 'sink must be callable') unless sink.respond_to?(:call)
 
@@ -22,6 +35,44 @@ module Apartment
       @backend_count = backend_count
       @subscribers = []
       @sampler = nil
+    end
+
+    def subscribe!
+      COUNTER_EVENTS.each do |event|
+        subscriber = ActiveSupport::Notifications.subscribe("#{event}.apartment") do |_name, _start, _finish, _id, payload|
+          record_event(event, payload || {})
+        end
+        @subscribers << subscriber
+      end
+      self
+    end
+
+    # Temporary stub — replaced by full implementation in Task 4.
+    def start_sampler!(interval:); end # rubocop:disable Style/Semicolon
+
+    # Temporary stub — replaced by full implementation in Task 4.
+    def stop!
+      @subscribers.each { |s| ActiveSupport::Notifications.unsubscribe(s) }
+      @subscribers.clear
+    end
+
+    private
+
+    def record_event(event, payload)
+      dimensions = payload[:reason] ? { reason: payload[:reason] } : {}
+      emit(Sample.new(name: event, kind: :counter, value: 1, dimensions: dimensions, payload: payload))
+    rescue StandardError => e
+      warn_failure("record_event(#{event})", e)
+    end
+
+    def emit(sample)
+      @sink.call(sample)
+    rescue StandardError => e
+      warn_failure("sink(#{sample.name})", e)
+    end
+
+    def warn_failure(context, error)
+      warn "[Apartment::PoolObserver] #{context} failed: #{error.class}: #{error.message}"
     end
   end
 end

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -47,6 +47,22 @@ module Apartment
       self
     end
 
+    # One gauge pass: live tenant-pool count, plus the adopter's backend count
+    # when supplied. Safe to call from start_sampler! or an external scheduler.
+    def sample!
+      total = Apartment.pool_manager&.stats&.fetch(:total_pools, 0) || 0
+      emit(Sample.new(name: :tenant_pools_live, kind: :gauge, value: total, dimensions: {}, payload: {}))
+
+      return unless @backend_count
+
+      backends = @backend_count.call
+      return if backends.nil?
+
+      emit(Sample.new(name: :backend_connections, kind: :gauge, value: backends, dimensions: {}, payload: {}))
+    rescue StandardError => e
+      warn_failure('sample!', e)
+    end
+
     # Temporary stub — replaced by full implementation in Task 4.
     def start_sampler!(interval:); end # rubocop:disable Style/Semicolon
 

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -39,10 +39,9 @@ module Apartment
 
     def subscribe!
       COUNTER_EVENTS.each do |event|
-        subscriber = ActiveSupport::Notifications.subscribe("#{event}.apartment") do |_name, _start, _finish, _id, payload|
+        @subscribers << ActiveSupport::Notifications.subscribe("#{event}.apartment") do |*, payload|
           record_event(event, payload || {})
         end
-        @subscribers << subscriber
       end
       self
     end

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -63,13 +63,19 @@ module Apartment
       warn_failure('sample!', e)
     end
 
-    # Temporary stub — replaced by full implementation in Task 4.
-    def start_sampler!(interval:); end # rubocop:disable Style/Semicolon
+    def start_sampler!(interval:)
+      @sampler&.shutdown
+      @sampler = Concurrent::TimerTask.new(execution_interval: interval) { sample! }
+      @sampler.execute
+      @sampler
+    end
 
-    # Temporary stub — replaced by full implementation in Task 4.
+    # Unsubscribe from all events and shut down the sampler. Safe to call twice.
     def stop!
-      @subscribers.each { |s| ActiveSupport::Notifications.unsubscribe(s) }
+      @subscribers.each { |subscriber| ActiveSupport::Notifications.unsubscribe(subscriber) }
       @subscribers.clear
+      @sampler&.shutdown
+      @sampler = nil
     end
 
     private

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -26,6 +26,11 @@ module Apartment
       observer.subscribe!
       observer.start_sampler!(interval: sample_interval) if sample_interval&.positive?
       observer
+    rescue StandardError
+      # Don't leak subscriptions if a later step (e.g. a bad sample_interval)
+      # raises after subscribe! has registered listeners.
+      observer&.stop!
+      raise
     end
 
     def initialize(sink:, backend_count: nil)
@@ -73,13 +78,25 @@ module Apartment
     def stop!
       @subscribers.each { |subscriber| ActiveSupport::Notifications.unsubscribe(subscriber) }
       @subscribers.clear
-      @sampler&.shutdown
-      @sampler = nil
+      shutdown_sampler!
     end
 
     private
 
+    # shutdown stops future ticks; wait_for_termination ensures an in-flight
+    # sample! can't emit after stop! returns (mirrors PoolReaper#stop_internal).
+    def shutdown_sampler!
+      return unless @sampler
+
+      @sampler.shutdown
+      @sampler.wait_for_termination(5)
+      @sampler = nil
+    end
+
     def record_event(event, payload)
+      # Copy the notification payload so a sink that mutates Sample#payload
+      # can't corrupt it for other subscribers of the same event.
+      payload = payload.dup
       dimensions = payload[:reason] ? { reason: payload[:reason] } : {}
       emit(Sample.new(name: event, kind: :counter, value: 1, dimensions: dimensions, payload: payload))
     rescue StandardError => e
@@ -94,6 +111,10 @@ module Apartment
 
     def warn_failure(context, error)
       warn "[Apartment::PoolObserver] #{context} failed: #{error.class}: #{error.message}"
+    rescue StandardError
+      # The failure logger must never be the thing that raises into the gem's
+      # instrumentation path (e.g. a closed/replaced $stderr).
+      nil
     end
   end
 end

--- a/lib/apartment/railtie.rb
+++ b/lib/apartment/railtie.rb
@@ -171,8 +171,13 @@ module Apartment
     # can call Apartment.pool_reaper.start explicitly. Emits :reaper_stopped
     # so an upgrading adopter notices the behavior change without combing
     # release notes.
+    #
+    # Opt out with `config.reap_in_test = true`: a deployment whose processes
+    # can run under Rails.env.test? semantics (and must keep reaping) then needs
+    # no boot guard around RAILS_ENV to avoid silently leaking connections.
     def self.deactivate_pool_reaper_in_test_env!
       return unless Rails.env.test?
+      return if Apartment.config&.reap_in_test
       return unless Apartment.pool_reaper
 
       Apartment.pool_reaper.stop

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -185,11 +185,24 @@ module Apartment
       # Accepts an optional tenant list; defaults to tenants_provider.
       # Fail-fast: raises immediately if a block raises for any tenant;
       # tenants after the failing one are not visited.
-      def each(tenants = nil)
+      #
+      # release_connection: when true, release the leased connection after each
+      # tenant so the reaper can evict finished tenants' pools mid-run. v4 keys a
+      # pool per "tenant:role"; a fan-out whose block leaves a connection checked
+      # out (raw ActiveRecord::Base.connection use, an open transaction, a long-
+      # held connection) would otherwise hold one warm connection per visited
+      # tenant. Modern query methods (create!, where, ...) check the connection
+      # back in themselves (Rails 7.2+), so a fan-out of those needs no release.
+      def each(tenants = nil, release_connection: false)
         raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
 
         tenants ||= Apartment.tenant_names
-        tenants.each { |tenant| switch(tenant) { yield(tenant) } }
+        tenants.each do |tenant|
+          switch(tenant) { yield(tenant) }
+          # Handler-wide (:all) covers writing + reading roles — the gem's
+          # established release call (see memory_stability_spec).
+          ActiveRecord::Base.connection_handler.clear_active_connections!(:all) if release_connection
+        end
       end
 
       # Block-scoped override of the tenant resolver. For the duration of the

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -186,13 +186,22 @@ module Apartment
       # Fail-fast: raises immediately if a block raises for any tenant;
       # tenants after the failing one are not visited.
       #
-      # release_connection: when true, release the leased connection after each
+      # release_connection: when true, release leased connections after each
       # tenant so the reaper can evict finished tenants' pools mid-run. v4 keys a
       # pool per "tenant:role"; a fan-out whose block leaves a connection checked
       # out (raw ActiveRecord::Base.connection use, an open transaction, a long-
       # held connection) would otherwise hold one warm connection per visited
       # tenant. Modern query methods (create!, where, ...) check the connection
-      # back in themselves (Rails 7.2+), so a fan-out of those needs no release.
+      # back in themselves (Rails 7.2+), so a fan-out of only those needs no
+      # release — but when in doubt for a large fan-out, pass it; it is a cheap
+      # no-op when there is nothing to release.
+      #
+      # WARNING: the release is handler-wide (clear_active_connections!(:all)) —
+      # it drops EVERY connection leased to the current execution context, across
+      # all pools and roles, not just the tenant pool. Do NOT use it inside an
+      # outer ActiveRecord::Base.transaction, or while holding a non-tenant
+      # connection you mean to keep. Fail-fast: if the block raises, the failing
+      # tenant is not released (the fan-out aborts).
       def each(tenants = nil, release_connection: false)
         raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
 

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha3'
+  VERSION = '4.0.0.alpha4'
 end

--- a/spec/integration/v4/tenant_each_release_spec.rb
+++ b/spec/integration/v4/tenant_each_release_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+
+# Tenant.each(release_connection: true) returns the leased connection after each
+# tenant so a long fan-out doesn't hold one warm connection per visited tenant —
+# the finished tenant's pool becomes reap-eligible mid-run. See component B of
+# docs/designs/v4-pool-adopter-ergonomics.md.
+#
+# The effect is only observable for blocks that leave a connection checked out
+# for the thread (raw `ActiveRecord::Base.connection` use, an open transaction, a
+# long-held connection). Modern query methods (create!, where, ...) check the
+# connection back in themselves on Rails 7.2+, so these specs use the raw
+# `connection.execute` pattern to exercise the sticky lease release_connection
+# targets.
+RSpec.describe('v4 Tenant.each(release_connection:)', :integration,
+               skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
+  include V4IntegrationHelper
+
+  context 'releasing connections between iterations',
+          skip: (if V4IntegrationHelper.sqlite?
+                   'SQLite pool-per-tenant less meaningful with single-writer lock'
+                 else
+                   false
+                 end) do
+    let(:tmp_dir) { Dir.mktmpdir('apartment_each_release') }
+    let(:tenants) { Array.new(4) { |i| "each_release_#{i}" } }
+
+    before do
+      V4IntegrationHelper.ensure_test_database!
+      config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+      V4IntegrationHelper.create_test_table!
+
+      Apartment.configure do |c|
+        c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+        c.tenants_provider = -> { tenants }
+        c.default_tenant = V4IntegrationHelper.default_tenant
+        c.check_pending_migrations = false
+      end
+
+      Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+      Apartment.activate!
+
+      tenants.each { |t| Apartment.adapter.create(t) }
+    end
+
+    after do
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+      V4IntegrationHelper.cleanup_tenants!(tenants, Apartment.adapter)
+      Apartment.clear_config
+      Apartment::Current.reset
+      FileUtils.rm_rf(tmp_dir)
+    end
+
+    # Pools (one per "tenant:role") with at least one leased connection — i.e.
+    # not yet reap-eligible.
+    def leased_pool_count
+      role = ActiveRecord::Base.current_role
+      tenants.count do |t|
+        pool = Apartment.pool_manager.peek("#{t}:#{role}")
+        pool&.connections&.any?(&:in_use?)
+      end
+    end
+
+    it 'leaves no leased connection on any visited pool' do
+      # Clean slate, then a fan-out whose block holds a connection.
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
+      Apartment::Tenant.each(release_connection: true) do
+        ActiveRecord::Base.connection.execute('SELECT 1')
+      end
+
+      expect(leased_pool_count).to(eq(0))
+    end
+
+    it 'leaves a leased connection per tenant without release_connection (contrast)' do
+      ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+
+      Apartment::Tenant.each do
+        ActiveRecord::Base.connection.execute('SELECT 1')
+      end
+
+      expect(leased_pool_count).to(eq(tenants.size))
+    end
+  end
+end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.shard_key_prefix).to(eq('apartment')) }
     it { expect(config.force_separate_pinned_pool).to(be(false)) }
     it { expect(config.test_fixture_cleanup).to(be(true)) }
+    it { expect(config.reap_in_test).to(be(false)) }
     it { expect(config.default_tenant_switch_allowed).to(be(true)) }
   end
 
@@ -208,6 +209,20 @@ RSpec.describe(Apartment::Config) do
       config.tenant_strategy = :schema
       config.tenants_provider = -> { [] }
       config.pool_overflow_policy = :raise
+      expect { config.validate! }.not_to(raise_error)
+    end
+
+    it 'raises when reap_in_test is not a boolean' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.reap_in_test = 'yes'
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /reap_in_test/))
+    end
+
+    it 'accepts reap_in_test = true' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.reap_in_test = true
       expect { config.validate! }.not_to(raise_error)
     end
 

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -27,6 +27,43 @@ RSpec.describe(Apartment::PoolObserver) do
     end
   end
 
+  describe '#sample!' do
+    let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 3, tenants: [] }) }
+
+    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+
+    it 'emits a tenant_pools_live gauge from PoolManager#stats' do
+      observer = described_class.new(sink: sink)
+      observer.sample!
+
+      sample = samples.find { |s| s.name == :tenant_pools_live }
+      expect(sample).to(have_attributes(kind: :gauge, value: 3, dimensions: {}, payload: {}))
+    end
+
+    it 'emits backend_connections when a backend_count callable is supplied' do
+      observer = described_class.new(sink: sink, backend_count: -> { 42 })
+      observer.sample!
+
+      sample = samples.find { |s| s.name == :backend_connections }
+      expect(sample).to(have_attributes(kind: :gauge, value: 42))
+    end
+
+    it 'skips backend_connections when backend_count returns nil' do
+      observer = described_class.new(sink: sink, backend_count: -> { nil })
+      observer.sample!
+
+      expect(samples.map(&:name)).not_to(include(:backend_connections))
+    end
+
+    it 'reports zero pools when the manager is absent (unconfigured)' do
+      allow(Apartment).to(receive(:pool_manager).and_return(nil))
+      observer = described_class.new(sink: sink)
+      observer.sample!
+
+      expect(samples.find { |s| s.name == :tenant_pools_live }.value).to(eq(0))
+    end
+  end
+
   describe '#subscribe! / .install!' do
     subject(:observer) { described_class.install!(sink: sink) }
 

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -26,4 +26,37 @@ RSpec.describe(Apartment::PoolObserver) do
                                         dimensions: { reason: :idle }, payload: { tenant: 'acme' }))
     end
   end
+
+  describe '#subscribe! / .install!' do
+    subject(:observer) { described_class.install!(sink: sink) }
+
+    after { observer.stop! }
+
+    it 'forwards a subscribed event to the sink as a counter Sample' do
+      observer
+      Apartment::Instrumentation.instrument(:evict, tenant: 'acme', reason: :idle)
+
+      sample = samples.find { |s| s.name == :evict }
+      expect(sample).not_to(be_nil)
+      expect(sample).to(have_attributes(kind: :counter, value: 1, dimensions: { reason: :idle }))
+      expect(sample.payload).to(include(tenant: 'acme', reason: :idle))
+    end
+
+    it 'curates :reason into dimensions and leaves the rest in payload' do
+      observer
+      Apartment::Instrumentation.instrument(:cap_unmet, max_total: 5, current: 6, unevicted: 1)
+
+      sample = samples.find { |s| s.name == :cap_unmet }
+      expect(sample.dimensions).to(eq({}))
+      expect(sample.payload).to(include(max_total: 5, current: 6, unevicted: 1))
+    end
+
+    it 'subscribes to all pool-lifecycle counter events' do
+      observer
+      %i[create evict cap_unmet skip_evict reaper_stopped].each do |event|
+        Apartment::Instrumentation.instrument(event, {})
+      end
+      expect(samples.map(&:name)).to(include(:create, :evict, :cap_unmet, :skip_evict, :reaper_stopped))
+    end
+  end
 end

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -98,6 +98,31 @@ RSpec.describe(Apartment::PoolObserver) do
     end
   end
 
+  describe 'error isolation' do
+    let(:boom_sink) { ->(_sample) { raise('sink boom') } }
+
+    after { @observer&.stop! }
+
+    it 'does not propagate when the sink raises on an event' do
+      @observer = described_class.install!(sink: boom_sink)
+      expect { Apartment::Instrumentation.instrument(:evict, {}) }.not_to(raise_error)
+    end
+
+    it 'does not propagate when the sink raises during sample!' do
+      allow(Apartment).to(receive(:pool_manager)
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+      @observer = described_class.new(sink: boom_sink)
+      expect { @observer.sample! }.not_to(raise_error)
+    end
+
+    it 'does not propagate when backend_count raises' do
+      allow(Apartment).to(receive(:pool_manager)
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+      @observer = described_class.new(sink: sink, backend_count: -> { raise('backend boom') })
+      expect { @observer.sample! }.not_to(raise_error)
+    end
+  end
+
   describe '#subscribe! / .install!' do
     subject(:observer) { described_class.install!(sink: sink) }
 

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe(Apartment::PoolObserver) do
     end
 
     it 'skips backend_connections when backend_count returns nil' do
-      observer = described_class.new(sink: sink, backend_count: -> { nil })
+      observer = described_class.new(sink: sink, backend_count: -> {})
       observer.sample!
 
       expect(samples.map(&:name)).not_to(include(:backend_connections))

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe(Apartment::PoolObserver) do
+  let(:samples) { Concurrent::Array.new }
+  let(:sink) { ->(sample) { samples << sample } }
+
+  describe '.new' do
+    it 'raises ArgumentError when the sink is not callable' do
+      expect { described_class.new(sink: 'not callable') }
+        .to(raise_error(ArgumentError, /sink must be callable/))
+    end
+
+    it 'accepts a callable sink' do
+      expect { described_class.new(sink: sink) }.not_to(raise_error)
+    end
+  end
+
+  describe 'Sample' do
+    it 'is a value object with the documented fields' do
+      sample = described_class::Sample.new(
+        name: :evict, kind: :counter, value: 1, dimensions: { reason: :idle }, payload: { tenant: 'acme' }
+      )
+      expect(sample).to(have_attributes(name: :evict, kind: :counter, value: 1,
+                                        dimensions: { reason: :idle }, payload: { tenant: 'acme' }))
+    end
+  end
+end

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -96,6 +96,12 @@ RSpec.describe(Apartment::PoolObserver) do
       sleep 0.1
       expect(samples.size).to(eq(count))
     end
+
+    it 'stop! is safe to call twice' do
+      observer = described_class.install!(sink: sink)
+      observer.stop!
+      expect { observer.stop! }.not_to(raise_error)
+    end
   end
 
   describe 'error isolation' do
@@ -153,6 +159,14 @@ RSpec.describe(Apartment::PoolObserver) do
         Apartment::Instrumentation.instrument(event, {})
       end
       expect(samples.map(&:name)).to(include(:create, :evict, :cap_unmet, :skip_evict, :reaper_stopped))
+    end
+
+    it 'promotes :reason into dimensions for any event carrying it (e.g. reaper_stopped)' do
+      observer
+      Apartment::Instrumentation.instrument(:reaper_stopped, reason: :test_env)
+
+      sample = samples.find { |s| s.name == :reaper_stopped }
+      expect(sample.dimensions).to(eq(reason: :test_env))
     end
   end
 end

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -127,6 +127,27 @@ RSpec.describe(Apartment::PoolObserver) do
       @observer = described_class.new(sink: sink, backend_count: -> { raise('backend boom') })
       expect { @observer.sample! }.not_to(raise_error)
     end
+
+    it 'does not propagate even when the failure logger itself raises' do
+      @observer = described_class.install!(sink: boom_sink)
+      allow(@observer).to(receive(:warn).and_raise('warn boom'))
+      expect { Apartment::Instrumentation.instrument(:evict, {}) }.not_to(raise_error)
+    end
+  end
+
+  describe '.install! cleanup on partial failure' do
+    it 'tears down subscriptions when a later step raises after subscribing' do
+      recorded = Concurrent::Array.new
+      capturing_sink = ->(sample) { recorded << sample }
+
+      # A non-numeric interval makes start_sampler! raise *after* subscribe!.
+      expect { described_class.install!(sink: capturing_sink, sample_interval: 'nope') }
+        .to(raise_error(NoMethodError))
+
+      # If cleanup worked, the orphaned subscriptions are gone and no event lands.
+      Apartment::Instrumentation.instrument(:evict, {})
+      expect(recorded).to(be_empty)
+    end
   end
 
   describe '#subscribe! / .install!' do

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -64,6 +64,40 @@ RSpec.describe(Apartment::PoolObserver) do
     end
   end
 
+  describe '#start_sampler! / #stop!' do
+    let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 2, tenants: [] }) }
+
+    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+
+    it 'runs sample! on the configured interval' do
+      observer = described_class.new(sink: sink)
+      observer.start_sampler!(interval: 0.05)
+      sleep 0.15
+      observer.stop!
+
+      expect(samples.any? { |s| s.name == :tenant_pools_live }).to(be(true))
+    end
+
+    it 'stop! unsubscribes so later events no longer reach the sink' do
+      observer = described_class.install!(sink: sink)
+      observer.stop!
+      samples.clear
+
+      Apartment::Instrumentation.instrument(:evict, {})
+      expect(samples).to(be_empty)
+    end
+
+    it 'stop! halts the sampler' do
+      observer = described_class.new(sink: sink)
+      observer.start_sampler!(interval: 0.05)
+      observer.stop!
+      sleep 0.1
+      count = samples.size
+      sleep 0.1
+      expect(samples.size).to(eq(count))
+    end
+  end
+
   describe '#subscribe! / .install!' do
     subject(:observer) { described_class.install!(sink: sink) }
 

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -188,15 +188,20 @@ if railtie_loaded
         expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
       end
 
-      it 'leaves the reaper running when config.reap_in_test is true' do
+      it 'leaves the reaper running (and emits no reaper_stopped) when config.reap_in_test is true' do
         reaper = instance_double(Apartment::PoolReaper, stop: nil)
         allow(Apartment).to(receive_messages(pool_reaper: reaper,
                                              config: instance_double(Apartment::Config, reap_in_test: true)))
         allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+        events = []
+        sub = ActiveSupport::Notifications.subscribe('reaper_stopped.apartment') { |e| events << e }
 
         Apartment::Railtie.deactivate_pool_reaper_in_test_env!
 
         expect(reaper).not_to(have_received(:stop))
+        expect(events).to(be_empty)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(sub) if sub
       end
 
       it 'stops the reaper when config.reap_in_test is false' do

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -187,6 +187,28 @@ if railtie_loaded
 
         expect { Apartment::Railtie.deactivate_pool_reaper_in_test_env! }.not_to(raise_error)
       end
+
+      it 'leaves the reaper running when config.reap_in_test is true' do
+        reaper = instance_double(Apartment::PoolReaper, stop: nil)
+        allow(Apartment).to(receive_messages(pool_reaper: reaper,
+                                             config: instance_double(Apartment::Config, reap_in_test: true)))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+        Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+        expect(reaper).not_to(have_received(:stop))
+      end
+
+      it 'stops the reaper when config.reap_in_test is false' do
+        reaper = instance_double(Apartment::PoolReaper, stop: nil)
+        allow(Apartment).to(receive_messages(pool_reaper: reaper,
+                                             config: instance_double(Apartment::Config, reap_in_test: false)))
+        allow(Rails).to(receive(:env).and_return(ActiveSupport::StringInquirer.new('test')))
+
+        Apartment::Railtie.deactivate_pool_reaper_in_test_env!
+
+        expect(reaper).to(have_received(:stop))
+      end
     end
 
     describe 'TenantNotFound rescue_responses mapping' do

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -425,6 +425,23 @@ RSpec.describe(Apartment::Tenant) do
       expect(called).to(be(false))
     end
 
+    it 'releases the connection after each tenant when release_connection: true' do
+      allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+
+      described_class.each(release_connection: true) { |_t| }
+
+      expect(ActiveRecord::Base.connection_handler)
+        .to(have_received(:clear_active_connections!).with(:all).twice)
+    end
+
+    it 'does not release connections by default' do
+      allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+
+      described_class.each { |_t| }
+
+      expect(ActiveRecord::Base.connection_handler).not_to(have_received(:clear_active_connections!))
+    end
+
     it 'returns the result of iterating the tenant list' do
       result = described_class.each(%w[a b]) { |_t| }
       expect(result).to(eq(%w[a b]))


### PR DESCRIPTION
## Publishing this PR

**Merging this PR is the publish.** It pushes `main`'s commits onto `4-0-alpha`, triggering `gem-publish.yml`; `rake release` creates the `v4.0.0.alpha4` tag and pushes the gem to RubyGems (trusted publishing, gated by the `production` environment). Do not merge until you mean to ship — a published version number can be yanked but not reused.

Step 2 of the Model-A flow (`RELEASING.md` § Release Steps). The version bump (#446) already landed on `main`, so no backport is needed — the branches agree by construction after this merge.

## What ships in alpha4

Everything on `main` since the published `4.0.0.alpha3`. Adopter-facing API surface:

- **#441** `Apartment::PoolObserver` — sink-agnostic pool observability (+ `docs/observability.md`)
- **#443** `config.reap_in_test` — declarative control of the reaper's test-env auto-stop
- **#444** `Tenant.each(release_connection:)` — release leases between tenants in a fan-out

Plus:

- **#442** `RELEASING.md` reconciled with the actual flow (Model A)
- **#445** `docs/designs/v4-connection-model-rationale.md` — why pool-per-tenant over fully-qualified names
- **#446** version bump → `4.0.0.alpha4`

An alpha ships *everything* on `main`; `main` is currently clean (no half-finished work behind this set), so that's safe this round.

## After merge

1. Verify `4.0.0.alpha4` on RubyGems and that the `v4.0.0.alpha4` tag was created.
2. Cut the GitHub Release on the `v4.0.0.alpha4` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)