### PR TITLE
Docs(RELEASING): never squash release-branch PRs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,8 @@ gh pr create --base 4-0-alpha --head main --title "Release v4.0.0.alpha4"
 
 **Merging this PR is the publish.** The merge pushes `main`'s commits onto `4-0-alpha`, which triggers `gem-publish.yml`; `rake release` creates the `v4.0.0.alpha4` tag and pushes the gem to RubyGems. Don't merge until you mean to ship — a published version number can be yanked but not reused.
 
+> **⚠️ Always pick "Create a merge commit" — never squash or rebase this PR.** `4-0-alpha` is a publish gate that *tracks* `main`; a squash collapses `main`'s commits into one new parallel commit on `4-0-alpha`, so the branches diverge in history even though their content matches. That (a) breaks GitHub's release-notes generator, which walks per-commit/per-PR, and (b) leaves the next release's `main` → `4-0-alpha` diff re-listing everything already shipped. GitHub offers all three merge methods on this PR (the squash-only ruleset is scoped to `main`, not the release branches), so the choice is manual discipline. If a release PR is squashed by mistake, realign with `git push origin origin/main:refs/heads/4-0-alpha --force-with-lease` once the content is identical (this re-triggers `gem-publish.yml`, which no-op-fails on the already-published tag).
+
 ### 3. Verify the publish
 
 Watch the workflow run (Actions → "Publish to RubyGems"), then confirm the version is live:


### PR DESCRIPTION
## What

Adds a callout to `RELEASING.md` Step 2: a `main` → `4-0-alpha` release PR must be merged with **"Create a merge commit"**, never squash or rebase.

## Why

`v4.0.0.alpha4` (#447) was squash-merged. The publish still succeeded, but the squash forked a parallel commit onto `4-0-alpha` instead of carrying `main`'s commits over — so `main` and `4-0-alpha` diverged in **history** while their **content** stayed identical. Consequences:

1. GitHub's release-notes generator walks per-commit/per-PR and had only the single squash commit to work with → notes came out wrong.
2. The next release's `main` → `4-0-alpha` diff would re-list everything already shipped.

GitHub offers all three merge methods on release-branch PRs — the squash-only ruleset is scoped to `main`, not `4-0-alpha`/`3-4-stable` — so there's no technical gate; it's manual discipline. The callout also documents the `--force-with-lease` realignment recipe for when a squash slips through (content is identical, so it's a safe history-only fix).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)