### PR TITLE
v4 adopter-review polish: PoolObserver misconfig warning, Tenant.each ensure-release, observability docs

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -70,7 +70,7 @@ boots:
 
 $apartment_observer = Apartment::PoolObserver.install!(
   sink: ->(sample) { MyMetrics.record(sample) },
-  sample_interval: 60,            # seconds between gauge passes; omit to disable
+  sample_interval: 60,            # seconds between gauge passes; omit/nil to disable (a non-positive value warns)
   backend_count: -> { ActiveRecord::Base.connection_pool.connections.size }
 )
 ```
@@ -195,6 +195,16 @@ Apartment::PoolObserver.install!(
 
 The callable is error-isolated: if it raises, the error is logged to `warn` and
 the pass continues.
+
+> **Fleet aggregation differs by gauge — don't SUM both blindly.**
+> `tenant_pools_live` is **per-process** (each process reports its own
+> `PoolManager`), so the fleet figure is a **SUM** across processes.
+> `backend_connections` is per-process only if your `backend_count` returns a
+> per-process number (e.g. `ActiveRecord::Base.connection_pool.connections.size`).
+> A **cluster-wide** source — `pg_stat_activity`, an RDS Proxy / PgBouncer total —
+> returns the *same* value from every process, so it must be rolled up with **MAX
+> (or last), never SUM**, or a dashboard multiplies it by the process count. Match
+> the dashboard aggregation to what your callable actually measures.
 
 ### Teardown
 

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -24,7 +24,18 @@ module Apartment
     def self.install!(sink:, sample_interval: nil, backend_count: nil)
       observer = new(sink: sink, backend_count: backend_count)
       observer.subscribe!
-      observer.start_sampler!(interval: sample_interval) if sample_interval&.positive?
+      if sample_interval.nil?
+        # nil is the intentional "no gauge sampler" signal; counters still flow.
+      elsif sample_interval.positive?
+        observer.start_sampler!(interval: sample_interval)
+      else
+        # A non-nil, non-positive interval is almost always a misconfig (e.g. an
+        # empty APARTMENT_POOL_SAMPLE_INTERVAL coerced to 0). Silently skipping
+        # the sampler ships an observer whose gauges never emit; surface it.
+        warn "[Apartment::PoolObserver] sample_interval=#{sample_interval.inspect} is not " \
+             'positive; gauge sampler not started (tenant_pools_live/backend_connections ' \
+             'will not emit). Pass a positive interval, or nil to disable the sampler.'
+      end
       observer
     rescue StandardError
       # Don't leak subscriptions if a later step (e.g. a bad sample_interval)

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -213,8 +213,16 @@ module Apartment
           # Handler-wide (:all) covers writing + reading roles — the gem's
           # established release call (see memory_stability_spec). In an ensure so
           # a raising tenant is still released; the exception then propagates and
-          # halts the fan-out (fail-fast preserved).
-          ActiveRecord::Base.connection_handler.clear_active_connections!(:all) if release_connection
+          # halts the fan-out (fail-fast preserved). Best-effort: a release
+          # failure must never mask the block's exception, so it is rescued and
+          # warned rather than raised out of the ensure.
+          if release_connection
+            begin
+              ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+            rescue StandardError => e
+              warn("[Apartment::Tenant.each] connection release failed: #{e.class}: #{e.message}")
+            end
+          end
         end
       end
 

--- a/lib/apartment/tenant.rb
+++ b/lib/apartment/tenant.rb
@@ -200,16 +200,20 @@ module Apartment
       # it drops EVERY connection leased to the current execution context, across
       # all pools and roles, not just the tenant pool. Do NOT use it inside an
       # outer ActiveRecord::Base.transaction, or while holding a non-tenant
-      # connection you mean to keep. Fail-fast: if the block raises, the failing
-      # tenant is not released (the fan-out aborts).
+      # connection you mean to keep. Fail-fast: a raising block still aborts the
+      # fan-out, but the failing tenant's connection is released first — the
+      # release is best-effort cleanup (in an ensure), not iteration semantics.
       def each(tenants = nil, release_connection: false)
         raise(ArgumentError, 'Apartment::Tenant.each requires a block') unless block_given?
 
         tenants ||= Apartment.tenant_names
         tenants.each do |tenant|
           switch(tenant) { yield(tenant) }
+        ensure
           # Handler-wide (:all) covers writing + reading roles — the gem's
-          # established release call (see memory_stability_spec).
+          # established release call (see memory_stability_spec). In an ensure so
+          # a raising tenant is still released; the exception then propagates and
+          # halts the fan-out (fail-fast preserved).
           ActiveRecord::Base.connection_handler.clear_active_connections!(:all) if release_connection
         end
       end

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -140,7 +140,8 @@ RSpec.describe(Apartment::PoolObserver) do
       recorded = Concurrent::Array.new
       capturing_sink = ->(sample) { recorded << sample }
 
-      # A non-numeric interval makes start_sampler! raise *after* subscribe!.
+      # A non-numeric interval raises NoMethodError at the `positive?` check
+      # (inside install!, after subscribe!) — the sampler is never reached.
       expect { described_class.install!(sink: capturing_sink, sample_interval: 'nope') }
         .to(raise_error(NoMethodError))
 

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -150,6 +150,36 @@ RSpec.describe(Apartment::PoolObserver) do
     end
   end
 
+  describe '.install! with a non-positive sample_interval' do
+    # nil is the intentional "no sampler" signal; a non-nil, non-positive value
+    # (e.g. an empty APARTMENT_POOL_SAMPLE_INTERVAL coerced to 0) is almost
+    # always a misconfig. Surface it instead of shipping a gauge-less observer.
+    it 'warns and does not start the sampler (0)' do
+      allow(described_class).to(receive(:warn))
+      observer = described_class.install!(sink: sink, sample_interval: 0)
+
+      expect(described_class).to(have_received(:warn).with(/not positive/))
+      expect(observer.instance_variable_get(:@sampler)).to(be_nil)
+      observer.stop!
+    end
+
+    it 'warns for a negative interval too' do
+      allow(described_class).to(receive(:warn))
+      observer = described_class.install!(sink: sink, sample_interval: -5)
+
+      expect(described_class).to(have_received(:warn).with(/not positive/))
+      observer.stop!
+    end
+
+    it 'does not warn when the interval is nil (intentional no-sampler)' do
+      allow(described_class).to(receive(:warn))
+      observer = described_class.install!(sink: sink, sample_interval: nil)
+
+      expect(described_class).not_to(have_received(:warn))
+      observer.stop!
+    end
+  end
+
   describe '#subscribe! / .install!' do
     subject(:observer) { described_class.install!(sink: sink) }
 

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -458,6 +458,22 @@ RSpec.describe(Apartment::Tenant) do
         .to(have_received(:clear_active_connections!).with(:all).once)
     end
 
+    it 'preserves the block exception when the connection release also raises' do
+      # Release is best-effort: a failure in clear_active_connections! must not
+      # mask the real error from the tenant block (ensure-exception replacement).
+      allow(ActiveRecord::Base.connection_handler)
+        .to(receive(:clear_active_connections!).and_raise(IOError, 'release boom'))
+      allow(described_class).to(receive(:warn))
+
+      expect do
+        described_class.each(%w[tenant1 tenant2], release_connection: true) do |t|
+          raise('block boom') if t == 'tenant1'
+        end
+      end.to(raise_error(RuntimeError, 'block boom'))
+
+      expect(described_class).to(have_received(:warn).with(/release failed/))
+    end
+
     it 'returns the result of iterating the tenant list' do
       result = described_class.each(%w[a b]) { |_t| }
       expect(result).to(eq(%w[a b]))

--- a/spec/unit/tenant_spec.rb
+++ b/spec/unit/tenant_spec.rb
@@ -442,6 +442,22 @@ RSpec.describe(Apartment::Tenant) do
       expect(ActiveRecord::Base.connection_handler).not_to(have_received(:clear_active_connections!))
     end
 
+    it 'releases the connection even when the block raises (release_connection: true)' do
+      # Release is best-effort cleanup, not iteration semantics: a raising tenant
+      # must still have its leased connection returned. Fail-fast is preserved —
+      # the exception propagates and halts iteration (tenant2 is never visited).
+      allow(ActiveRecord::Base.connection_handler).to(receive(:clear_active_connections!))
+
+      expect do
+        described_class.each(%w[tenant1 tenant2], release_connection: true) do |t|
+          raise('boom') if t == 'tenant1'
+        end
+      end.to(raise_error(RuntimeError, 'boom'))
+
+      expect(ActiveRecord::Base.connection_handler)
+        .to(have_received(:clear_active_connections!).with(:all).once)
+    end
+
     it 'returns the result of iterating the tenant list' do
       result = described_class.each(%w[a b]) { |_t| }
       expect(result).to(eq(%w[a b]))


### PR DESCRIPTION
Three small, independent items surfaced by a v4 adopter review of the pool/observability seams.

## 1. `PoolObserver.install!` warns on a non-positive `sample_interval`

`install!` did `start_sampler!(interval:) if sample_interval&.positive?`, so a non-nil but non-positive value (e.g. an empty `APARTMENT_POOL_SAMPLE_INTERVAL` coerced to `0`) silently produced a subscribed observer with **no gauge sampler and no warning** — `tenant_pools_live` / `backend_connections` just never emit. `nil` remains the intentional "no sampler" signal; a non-positive *numeric* now warns. Non-numeric intervals still raise (existing behavior + test preserved).

## 2. `Tenant.each(release_connection:)` releases even when the block raises

The per-iteration `clear_active_connections!(:all)` sat after `switch`, not in an `ensure`, so a raising tenant skipped its release. Moved into an `ensure`: the connection is now released best-effort for the failing tenant, then the exception propagates and halts the fan-out — **fail-fast iteration is preserved** (the existing fail-fast test still passes), the release is just no longer part of iteration semantics. Covers long-running non-executor scripts where the Rails executor wouldn't bound the leak.

## 3. Observability docs: gauge fleet-aggregation semantics

`docs/observability.md` didn't say the two gauges aggregate differently across a fleet: `tenant_pools_live` is per-process (fleet total = **SUM**), but `backend_connections` is often a cluster-wide number (`pg_stat_activity`, proxy total) that's identical from every process and must roll up as **MAX, never SUM** — otherwise a dashboard double-counts. Added a callout in the `backend_count` seam, plus a note about the non-positive `sample_interval` warning at the recipe call site.

## Verification

- `spec/unit/pool_observer_spec.rb` (23) + `spec/unit/tenant_spec.rb` (116) green, including the preserved non-numeric-raises and fail-fast tests.
- `spec/integration/v4/tenant_each_release_spec.rb` green on Rails 8.1 + PG.
- Rubocop clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)