### PR TITLE
Bump version to 4.0.0.alpha5

### DIFF
--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha4'
+  VERSION = '4.0.0.alpha5'
 end


### PR DESCRIPTION
Standalone version bump cutting **alpha5** from `main`, per `RELEASING.md` (bump on `main`, then merge `main` → `4-0-alpha` to publish).

`main` carries 30 commits since alpha4. Notable:
- `:reading`-role multi-handler coverage — closes fixture-pool #7 role axis (#449)
- v4 adopter-review polish: PoolObserver non-positive `sample_interval` warning, `Tenant.each` best-effort release (ensure + rescue-guard), observability gauge-aggregation docs (#450)
- the pool-observer, `reap_in_test`, and `Tenant.each(release_connection:)` line, plus RELEASING/docs updates

**This PR only bumps the version** — it's the release marker. Merging the follow-up `main → 4-0-alpha` PR is what actually publishes `v4.0.0.alpha5` to RubyGems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)