### PR TITLE
Fix(v4): pool-resolution physical-name validation + advisory-lock ivar guard (W5)

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -25,6 +25,7 @@ module Apartment
       # the adapter builds the tenant config on top of it instead of its own base_config.
       def validated_connection_config(tenant, base_config_override: nil)
         effective_base = base_config_override || base_config
+        validate_pool_key_safety!(tenant)
         TenantNameValidator.validate!(
           physical_tenant_name(tenant),
           strategy: Apartment.config.tenant_strategy,
@@ -45,6 +46,7 @@ module Apartment
       # (raw schema name for :schema, environmentified database name otherwise),
       # so create and the pool-resolution path validate the same name.
       def create(tenant)
+        validate_pool_key_safety!(tenant)
         TenantNameValidator.validate!(
           physical_tenant_name(tenant),
           strategy: Apartment.config.tenant_strategy,
@@ -214,6 +216,20 @@ module Apartment
       # Default tenant from config.
       def default_tenant
         Apartment.config.default_tenant
+      end
+
+      private
+
+      # Validate the raw tenant for pool-key safety: it becomes "#{tenant}:#{role}"
+      # in the pool key, so a colon / whitespace / NUL there breaks PoolManager's
+      # prefix and suffix matching and could evict the wrong tenant's pool.
+      # Validated in addition to physical_tenant_name (which carries the engine
+      # rules) because a callable environmentify_strategy could transform an
+      # unsafe character out of the physical name while the raw name still reaches
+      # the pool key. to_s first so a non-String tenant is stringified, not
+      # rejected (it is the value the pool key interpolates anyway).
+      def validate_pool_key_safety!(tenant)
+        TenantNameValidator.validate_common!(tenant.to_s)
       end
 
       protected

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -26,7 +26,7 @@ module Apartment
       def validated_connection_config(tenant, base_config_override: nil)
         effective_base = base_config_override || base_config
         TenantNameValidator.validate!(
-          tenant,
+          physical_tenant_name(tenant),
           strategy: Apartment.config.tenant_strategy,
           adapter_name: effective_base['adapter']
         )
@@ -197,6 +197,15 @@ module Apartment
           # Callable
           Apartment.config.environmentify_strategy.call(tenant)
         end
+      end
+
+      # The physical identifier used to address this tenant at connection time:
+      # the database name for database-per-tenant strategies (environmentified).
+      # validated_connection_config validates THIS name so the pool-resolution
+      # path agrees with what the connection actually targets. Schema-per-tenant
+      # overrides this to the raw tenant (schemas are named directly).
+      def physical_tenant_name(tenant)
+        environmentify(tenant)
       end
 
       # Default tenant from config.

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -41,9 +41,12 @@ module Apartment
       end
 
       # Create a new tenant (schema or database).
+      # Validates the physical identifier create_tenant actually addresses
+      # (raw schema name for :schema, environmentified database name otherwise),
+      # so create and the pool-resolution path validate the same name.
       def create(tenant)
         TenantNameValidator.validate!(
-          environmentify(tenant),
+          physical_tenant_name(tenant),
           strategy: Apartment.config.tenant_strategy,
           adapter_name: base_config['adapter']
         )

--- a/lib/apartment/adapters/postgresql_schema_adapter.rb
+++ b/lib/apartment/adapters/postgresql_schema_adapter.rb
@@ -38,6 +38,12 @@ module Apartment
         config.merge('schema_search_path' => search_path)
       end
 
+      # Schemas are named directly (never environmentified), so the physical
+      # identifier validated at pool-resolution time is the raw tenant name.
+      def physical_tenant_name(tenant)
+        tenant.to_s
+      end
+
       # The schema-strategy missing-tenant error: a dropped schema is not caught
       # at switch time (search_path accepts a non-existent schema silently) — it
       # surfaces on the first query as ActiveRecord::StatementInvalid

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -222,15 +222,17 @@ module Apartment
     # PG's advisory locks are database-wide and would serialize parallel tenant
     # migrations (issue #298). Rails offers no public setter, so we poke the
     # private @advisory_locks_enabled ivar. The instance_variable_defined? guard
-    # makes a future Rails rename visible: rather than silently creating an
-    # orphan ivar (leaving locks enabled and serializing migrations), we warn and
-    # proceed. The ivar contract is also unit-tested against a real connection.
+    # detects a future Rails *rename or removal* of the ivar (a name-presence
+    # check — it does NOT catch a semantics change where Rails keeps the ivar but
+    # stops honoring it on the lock path). On a detected rename we warn and
+    # proceed rather than silently creating an orphan ivar; the ivar contract is
+    # also unit-tested against a real connection so a rename breaks CI first.
     def with_advisory_locks_disabled
       conn = ActiveRecord::Base.lease_connection
       unless conn.instance_variable_defined?(ADVISORY_LOCKS_IVAR)
         warn "[Apartment::Migrator] ActiveRecord connection #{conn.class} does not define " \
              "#{ADVISORY_LOCKS_IVAR}; cannot disable advisory locks for this Rails version. " \
-             'Parallel tenant migrations will serialize on the database-wide advisory lock.'
+             'Parallel tenant migrations may serialize or fail on the database-wide advisory lock.'
         return yield
       end
       original = conn.instance_variable_get(ADVISORY_LOCKS_IVAR)

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -6,6 +6,11 @@ require_relative 'errors'
 
 module Apartment
   class Migrator # rubocop:disable Metrics/ClassLength
+    # ActiveRecord exposes no public setter for advisory-lock state (only the
+    # advisory_locks_enabled? reader), so we toggle this private ivar directly.
+    # The guard in with_advisory_locks_disabled detects a future Rails rename.
+    ADVISORY_LOCKS_IVAR = :@advisory_locks_enabled
+
     Result = Data.define(
       :tenant,
       :status,
@@ -213,13 +218,26 @@ module Apartment
     # Disable advisory locks on the leased connection for the duration of the
     # block, then restore the original value. lease_connection returns the same
     # connection object for the current thread (fiber-local via IsolatedExecutionState).
+    #
+    # PG's advisory locks are database-wide and would serialize parallel tenant
+    # migrations (issue #298). Rails offers no public setter, so we poke the
+    # private @advisory_locks_enabled ivar. The instance_variable_defined? guard
+    # makes a future Rails rename visible: rather than silently creating an
+    # orphan ivar (leaving locks enabled and serializing migrations), we warn and
+    # proceed. The ivar contract is also unit-tested against a real connection.
     def with_advisory_locks_disabled
       conn = ActiveRecord::Base.lease_connection
-      original = conn.instance_variable_get(:@advisory_locks_enabled)
-      conn.instance_variable_set(:@advisory_locks_enabled, false)
+      unless conn.instance_variable_defined?(ADVISORY_LOCKS_IVAR)
+        warn "[Apartment::Migrator] ActiveRecord connection #{conn.class} does not define " \
+             "#{ADVISORY_LOCKS_IVAR}; cannot disable advisory locks for this Rails version. " \
+             'Parallel tenant migrations will serialize on the database-wide advisory lock.'
+        return yield
+      end
+      original = conn.instance_variable_get(ADVISORY_LOCKS_IVAR)
+      conn.instance_variable_set(ADVISORY_LOCKS_IVAR, false)
       yield
     ensure
-      conn&.instance_variable_set(:@advisory_locks_enabled, original)
+      conn.instance_variable_set(ADVISORY_LOCKS_IVAR, original) if conn&.instance_variable_defined?(ADVISORY_LOCKS_IVAR)
     end
 
     def monotonic_now

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -129,6 +129,15 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter, :isolate_pinned_models) do
         expect { adapter.validated_connection_config('acme') }
           .to(raise_error(Apartment::ConfigurationError, /NUL byte/))
       end
+
+      it 'validates the raw tenant for pool-key safety even when environmentify_strategy strips unsafe chars' do
+        # A pathological callable that strips the colon would otherwise let
+        # "acme:eu" build a pool key ("acme:eu:role") that collides with tenant
+        # "acme" under PoolManager prefix matching. The raw name is validated too.
+        reconfigure(environmentify_strategy: ->(t) { t.tr(':', '_') })
+        expect { adapter.validated_connection_config('acme:eu') }
+          .to(raise_error(Apartment::ConfigurationError, /colon/))
+      end
     end
   end
 
@@ -172,6 +181,14 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter, :isolate_pinned_models) do
       tenant = 'a' * 59
       expect { adapter.create(tenant) }
         .to(raise_error(Apartment::ConfigurationError, /too long.*64.*max 63/))
+      expect(adapter.created_tenants).to(be_empty)
+    end
+
+    it 'rejects a pool-key-unsafe raw tenant on create even if environmentify_strategy strips it' do
+      reconfigure(environmentify_strategy: ->(t) { t.tr(':', '_') })
+      allow(Apartment::Instrumentation).to(receive(:instrument))
+      expect { adapter.create('acme:eu') }
+        .to(raise_error(Apartment::ConfigurationError, /colon/))
       expect(adapter.created_tenants).to(be_empty)
     end
 

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -117,6 +117,19 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter, :isolate_pinned_models) do
         expect(result).to(include('pool' => 2))
       end
     end
+
+    context 'physical-name validation (pool-resolution path)' do
+      # validated_connection_config validates the *physical* tenant identifier
+      # (the database name for database-per-tenant strategies) — the
+      # environmentified name in the base adapter, matching what create uses.
+      # Regression guard: it previously validated the raw tenant, so an invalid
+      # environmentified name slipped through pool resolution.
+      it 'validates the environmentified name, not the raw tenant' do
+        reconfigure(environmentify_strategy: ->(t) { "#{t}\x00" })
+        expect { adapter.validated_connection_config('acme') }
+          .to(raise_error(Apartment::ConfigurationError, /NUL byte/))
+      end
+    end
   end
 
   describe '#resolve_connection_config' do

--- a/spec/unit/adapters/postgresql_schema_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_schema_adapter_spec.rb
@@ -221,6 +221,17 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
 
       adapter.create('my-tenant')
     end
+
+    it 'validates the raw (physical) schema name on create, even with environmentify_strategy' do
+      # Regression: create previously validated environmentify(tenant), so a raw
+      # "pg_"-prefixed name slipped through under :prepend (the env prefix masked
+      # the reserved prefix) while CREATE SCHEMA still used the raw name. create
+      # now validates the physical (raw) name, matching the pool-resolution path.
+      reconfigure(environmentify_strategy: :prepend)
+      expect(connection).not_to(receive(:execute))
+      expect { adapter.create('pg_evil') }
+        .to(raise_error(Apartment::ConfigurationError, /pg_/))
+    end
   end
 
   describe '#drop (via drop_tenant)' do

--- a/spec/unit/adapters/postgresql_schema_adapter_spec.rb
+++ b/spec/unit/adapters/postgresql_schema_adapter_spec.rb
@@ -350,4 +350,20 @@ RSpec.describe(Apartment::Adapters::PostgresqlSchemaAdapter) do
       expect(result['schema_search_path']).to(eq('"acme"'))
     end
   end
+
+  describe '#physical_tenant_name' do
+    # Schema-per-tenant names schemas directly, so pool-resolution validates and
+    # uses the RAW tenant even when environmentify_strategy is set — unlike the
+    # database-per-tenant adapters, which validate the environmentified name.
+    it 'validates the raw tenant name, ignoring environmentify_strategy' do
+      reconfigure(environmentify_strategy: ->(t) { "#{t}\x00" })
+      expect { adapter.validated_connection_config('acme') }.not_to(raise_error)
+    end
+
+    it 'resolves the search_path from the raw tenant name' do
+      reconfigure(environmentify_strategy: ->(t) { "#{t}_ignored" })
+      config = adapter.validated_connection_config('acme')
+      expect(config['schema_search_path']).to(eq('"acme"'))
+    end
+  end
 end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -496,17 +496,25 @@ RSpec.describe(Apartment::Migrator) do
   describe 'advisory-lock ivar contract' do
     # with_advisory_locks_disabled pokes the private @advisory_locks_enabled
     # ivar because Rails has no public setter. This locks the contract: if a
-    # future Rails renames the ivar, this fails in CI instead of silently
-    # serializing parallel tenant migrations (issue #298). Uses a real
-    # in-memory SQLite connection; skips gracefully if the adapter is absent.
+    # future Rails renames or relocates the ivar, this fails in CI instead of
+    # silently serializing parallel tenant migrations (issue #298). Runs against
+    # a real in-memory SQLite connection on a SWAPPED, isolated connection
+    # handler so it never mutates AR::Base's global default connection (other
+    # specs depend on it — removing it caused order-dependent failures). Mirrors
+    # the hermetic handler swap in spec/integration/v4/support.rb. Skips if the
+    # sqlite3 adapter is unavailable in the bundle.
     it 'a real ActiveRecord connection defines @advisory_locks_enabled' do
+      old_handler = ActiveRecord::Base.connection_handler
+      new_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+      ActiveRecord::Base.connection_handler = new_handler
       ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
       conn = ActiveRecord::Base.lease_connection
       expect(conn.instance_variable_defined?(Apartment::Migrator::ADVISORY_LOCKS_IVAR)).to(be(true))
     rescue LoadError, ActiveRecord::AdapterNotFound, ActiveRecord::ConnectionNotEstablished => e
       skip("sqlite3 adapter unavailable in this bundle: #{e.class}")
     ensure
-      ActiveRecord::Base.remove_connection
+      new_handler&.clear_all_connections!
+      ActiveRecord::Base.connection_handler = old_handler if old_handler
     end
   end
 end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -513,8 +513,16 @@ RSpec.describe(Apartment::Migrator) do
     rescue LoadError, ActiveRecord::AdapterNotFound, ActiveRecord::ConnectionNotEstablished => e
       skip("sqlite3 adapter unavailable in this bundle: #{e.class}")
     ensure
-      new_handler&.clear_all_connections!
+      # Restore the global handler FIRST so a failure while clearing the
+      # throwaway handler can never leave AR::Base pointing at it (the exact
+      # leak this test previously caused). Clearing the discarded handler is
+      # best-effort cleanup of its in-memory sqlite connection.
       ActiveRecord::Base.connection_handler = old_handler if old_handler
+      begin
+        new_handler&.clear_all_connections!
+      rescue StandardError => e
+        warn "[advisory-lock contract] clear_all_connections! failed: #{e.message}"
+      end
     end
   end
 end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -149,6 +149,8 @@ RSpec.describe(Apartment::Migrator) do
       allow(ActiveRecord::Base).to(receive_messages(connection_pool: mock_pool, lease_connection: mock_connection))
       allow(mock_connection).to(receive(:instance_variable_get).and_return(true))
       allow(mock_connection).to(receive(:instance_variable_set))
+      allow(mock_connection).to(receive(:instance_variable_defined?)
+        .with(:@advisory_locks_enabled).and_return(true))
       allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
       allow(mock_migration_context).to(receive_messages(needs_migration?: true, migrate: []))
       allow(Apartment::Instrumentation).to(receive(:instrument))
@@ -218,6 +220,14 @@ RSpec.describe(Apartment::Migrator) do
         .with(:@advisory_locks_enabled, false).at_least(:twice))
       expect(mock_connection).to(have_received(:instance_variable_set)
         .with(:@advisory_locks_enabled, true).at_least(:twice))
+    end
+
+    it 'warns and still runs migrations when the connection lacks the advisory-lock ivar' do
+      allow(mock_connection).to(receive(:instance_variable_defined?)
+        .with(:@advisory_locks_enabled).and_return(false))
+      expect(migrator).to(receive(:warn).with(/cannot disable advisory locks/i).at_least(:once))
+      result = migrator.run
+      expect(result).to(be_a(Apartment::Migrator::MigrationRun))
     end
 
     it 'handles empty tenant list' do
@@ -352,6 +362,8 @@ RSpec.describe(Apartment::Migrator) do
       allow(ActiveRecord::Base).to(receive_messages(connection_pool: mock_pool, lease_connection: mock_connection))
       allow(mock_connection).to(receive(:instance_variable_get).and_return(true))
       allow(mock_connection).to(receive(:instance_variable_set))
+      allow(mock_connection).to(receive(:instance_variable_defined?)
+        .with(:@advisory_locks_enabled).and_return(true))
       allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
       allow(mock_migration_context).to(receive_messages(needs_migration?: true, migrate: []))
       allow(Apartment::Instrumentation).to(receive(:instrument))
@@ -450,6 +462,8 @@ RSpec.describe(Apartment::Migrator) do
       allow(ActiveRecord::Base).to(receive_messages(connection_pool: mock_pool, lease_connection: mock_connection))
       allow(mock_connection).to(receive(:instance_variable_get).and_return(true))
       allow(mock_connection).to(receive(:instance_variable_set))
+      allow(mock_connection).to(receive(:instance_variable_defined?)
+        .with(:@advisory_locks_enabled).and_return(true))
       allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
       allow(mock_migration_context).to(receive_messages(needs_migration?: true, migrate: []))
       allow(Apartment::Instrumentation).to(receive(:instrument))
@@ -476,6 +490,23 @@ RSpec.describe(Apartment::Migrator) do
       result = migrator.run
       expect(result.failed.size).to(eq(1))
       expect(result.results.size).to(eq(9))
+    end
+  end
+
+  describe 'advisory-lock ivar contract' do
+    # with_advisory_locks_disabled pokes the private @advisory_locks_enabled
+    # ivar because Rails has no public setter. This locks the contract: if a
+    # future Rails renames the ivar, this fails in CI instead of silently
+    # serializing parallel tenant migrations (issue #298). Uses a real
+    # in-memory SQLite connection; skips gracefully if the adapter is absent.
+    it 'a real ActiveRecord connection defines @advisory_locks_enabled' do
+      ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+      conn = ActiveRecord::Base.lease_connection
+      expect(conn.instance_variable_defined?(Apartment::Migrator::ADVISORY_LOCKS_IVAR)).to(be(true))
+    rescue LoadError, ActiveRecord::AdapterNotFound, ActiveRecord::ConnectionNotEstablished => e
+      skip("sqlite3 adapter unavailable in this bundle: #{e.class}")
+    ensure
+      ActiveRecord::Base.remove_connection
     end
   end
 end


### PR DESCRIPTION
## Summary

First workstream from the v4 beta-readiness roadmap (W5 — the smallest, zero-design-ambiguity item): closes residual Cursor PR-review findings on core paths, plus issues surfaced by an in-depth review + adversarial AI-panel pass on this PR.

**1. Validate the physical tenant name on the pool-resolution path.**
`AbstractAdapter#validated_connection_config` validated the *raw* tenant while `#create` validates the physical (environmentified) identifier — so on database-per-tenant strategies an invalid environmentified name could slip through pool resolution. Fix: an overridable `physical_tenant_name(tenant)` seam (default `environmentify(tenant)`); `PostgresqlSchemaAdapter` overrides it to raw `tenant.to_s` (schemas are named directly).

**2. Both validation paths now agree (review round).** `#create` was still validating `environmentify(tenant)` — for the schema adapter that meant validating a name it never addresses, and under `:prepend` a raw `pg_`-prefixed tenant slipped through (env prefix masked the reserved prefix) while `CREATE SCHEMA` used the raw name. `#create` now routes through `physical_tenant_name` too; a regression test locks the `pg_` bypass closure.

**3. Pool-key safety (review round).** The pool key is `"#{tenant}:#{role}"`, built from the raw tenant. A pathological callable `environmentify_strategy` that strips a colon could let `"acme:eu"` pass physical validation, then collide with tenant `"acme"` under `PoolManager` prefix matching (wrong-tenant pool eviction). Both `#create` and pool resolution now also validate the raw tenant's common rules (colon/whitespace/NUL/length) via `validate_pool_key_safety!`.

**4. Guard the advisory-lock ivar poke in `Migrator`.**
`with_advisory_locks_disabled` set the private `@advisory_locks_enabled` ivar unconditionally; ActiveRecord exposes no public setter, so a future Rails rename would silently re-enable advisory locks and serialize parallel tenant migrations (#298). Fix: guard with `instance_variable_defined?` — warn and proceed when absent (the warning notes parallel migrations may serialize *or fail*, per PG `pg_try_advisory_lock`). A contract unit test against a real in-memory connection makes a rename/removal break CI in the sqlite3 jobs (intentional canary).

## Testing

- Full unit suite: 955 examples, 0 failures.
- Cross-version: touched specs green on Rails 7.2 / 8.0 / 8.1 + PostgreSQL and MySQL; the advisory-lock contract test runs and passes under sqlite3 (pends gracefully where sqlite3 isn't bundled). (trilogy appraisal not run locally — gem absent on dev box; CI covers it.)
- RuboCop: clean on all changed files. TDD throughout.

## Review

Reviewed with an in-depth code-review pass + an adversarial AI panel (Codex, Gemini, Cursor, Mistral). The consensus finding (the `#create`/pool-resolution validation asymmetry, incl. the `pg_` bypass) and the pool-key colon path were folded in here. Deliberately left as-is: a non-String tenant is `to_s`'d rather than re-rejected (the value the pool key uses anyway).

## Context

Roadmap: `docs/designs/v4-beta-readiness.md` (W5). Plan: `docs/plans/v4-beta-readiness/w5-cursor-debt.md`. Both land via a separate docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)