### PR TITLE
Fix(v4): validate pool-key-unsafe tenant names before admission/eviction

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -23,6 +23,13 @@ module Apartment
       # Called by ConnectionHandling — subclasses should NOT override this.
       # base_config_override: when supplied (e.g. a role-specific config from ConnectionHandling),
       # the adapter builds the tenant config on top of it instead of its own base_config.
+      #
+      # This validates only the PHYSICAL identifier (engine rules). Raw pool-key
+      # safety (colon/whitespace/NUL that would corrupt "tenant:role") is enforced
+      # by the sole production caller, ConnectionHandling#connection_pool, before
+      # it builds the pool key — and independently by #create. A future caller
+      # that invokes this directly, bypassing connection_pool, must validate the
+      # raw tenant itself (TenantNameValidator.validate_common!).
       def validated_connection_config(tenant, base_config_override: nil)
         effective_base = base_config_override || base_config
         TenantNameValidator.validate!(

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -25,7 +25,6 @@ module Apartment
       # the adapter builds the tenant config on top of it instead of its own base_config.
       def validated_connection_config(tenant, base_config_override: nil)
         effective_base = base_config_override || base_config
-        validate_pool_key_safety!(tenant)
         TenantNameValidator.validate!(
           physical_tenant_name(tenant),
           strategy: Apartment.config.tenant_strategy,

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_record'
+require_relative '../tenant_name_validator'
 
 module Apartment
   module Patches
@@ -27,6 +28,15 @@ module Apartment
            (adapter.nil? || !adapter.shared_pinned_connection?)
           return super
         end
+
+        # Reject pool-key-unsafe tenant names BEFORE building pool_key or entering
+        # fetch_or_create. In the capped path, fetch_or_admit runs admit! (which
+        # may LRU-evict an idle pool) before the adapter validates inside the
+        # block, so a colon / whitespace / NUL in the raw tenant — which would
+        # also corrupt the "#{tenant}:#{role}" key and PoolManager's prefix
+        # matching — must be caught here. ConfigurationError is an ApartmentError,
+        # so the rescue below re-raises it cleanly.
+        Apartment::TenantNameValidator.validate_common!(tenant.to_s)
 
         role = ActiveRecord::Base.current_role
         pool_key = "#{tenant}:#{role}"

--- a/spec/unit/adapters/abstract_adapter_spec.rb
+++ b/spec/unit/adapters/abstract_adapter_spec.rb
@@ -129,15 +129,6 @@ RSpec.describe(Apartment::Adapters::AbstractAdapter, :isolate_pinned_models) do
         expect { adapter.validated_connection_config('acme') }
           .to(raise_error(Apartment::ConfigurationError, /NUL byte/))
       end
-
-      it 'validates the raw tenant for pool-key safety even when environmentify_strategy strips unsafe chars' do
-        # A pathological callable that strips the colon would otherwise let
-        # "acme:eu" build a pool key ("acme:eu:role") that collides with tenant
-        # "acme" under PoolManager prefix matching. The raw name is validated too.
-        reconfigure(environmentify_strategy: ->(t) { t.tr(':', '_') })
-        expect { adapter.validated_connection_config('acme:eu') }
-          .to(raise_error(Apartment::ConfigurationError, /colon/))
-      end
     end
   end
 

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -71,6 +71,19 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
       end
     end
 
+    context 'when the tenant name is pool-key-unsafe' do
+      # Validation must happen BEFORE pool_key construction and fetch_or_create:
+      # in the capped path, fetch_or_admit calls admit! (which can LRU-evict an
+      # idle pool) before the adapter's deeper validation runs. An invalid name
+      # must be rejected before any admission/eviction side effect.
+      it 'rejects the name before touching the pool manager' do
+        Apartment::Current.tenant = 'bad:name'
+        expect(Apartment.pool_manager).not_to(receive(:fetch_or_create))
+        expect { ActiveRecord::Base.connection_pool }
+          .to(raise_error(Apartment::ConfigurationError, /colon/))
+      end
+    end
+
     context 'when an active tenant is set' do
       it 'returns a different pool from the default' do
         Apartment::Current.tenant = 'acme'


### PR DESCRIPTION
## Summary

Follow-up to #453, closing the admit-ordering finding raised by the adversarial review panel (Codex).

`ConnectionHandling#connection_pool` built `pool_key = "#{tenant}:#{role}"` and entered `fetch_or_create` before the adapter validated the tenant (validation lived inside the block, in `validated_connection_config`). In the capped path, `fetch_or_admit` calls `admit!` — which may LRU-evict an idle pool to make room — *before* that validation runs. So with `max_total_connections` set and at capacity, a request for a pool-key-unsafe tenant name (colon / whitespace / NUL) could spuriously evict a good idle pool before being rejected. Perf-only, not an isolation breach, but real.

## Fix

- Validate the raw tenant (`TenantNameValidator.validate_common!`) at the top of `connection_pool`, right after the short-circuits and before `pool_key` construction — so unsafe names are rejected before any admission/eviction side effect. A colon/whitespace/NUL would also corrupt the `"tenant:role"` key and `PoolManager`'s prefix matching, so this is the correct guard point.
- Drop the now-redundant `validate_pool_key_safety!` call from `validated_connection_config` (its sole caller, `connection_pool`, now guards first). `#create` keeps its own guard (it doesn't go through `connection_pool`).
- `ConfigurationError` is an `ApartmentError`, so the method's existing rescue re-raises it cleanly (no double-wrapping).

## Testing

- New spec: an unsafe tenant name is rejected **before** `Apartment.pool_manager.fetch_or_create` is called (`connection_handling_spec.rb`). It fails on the pre-fix ordering (`fetch_or_create("bad:name:writing")` received) and passes after.
- Removed the now-stale pool-key test from `abstract_adapter_spec` (that responsibility moved off `validated_connection_config`); the `#create`-side guard test stays.
- Full unit suite: 955 examples, 0 failures on Rails 7.2 and 8.1 + sqlite3 across seeds 19801/42; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)