### PR TITLE
Fix(v4): confirm destructive tenant drops at the CLI layer (#457)

### DIFF
--- a/lib/apartment/cli/tenants.rb
+++ b/lib/apartment/cli/tenants.rb
@@ -29,7 +29,7 @@ module Apartment
       DESC
       method_option :force, type: :boolean, desc: 'Skip confirmation prompt'
       def drop(tenant)
-        return say('Cancelled.') if !force? && !yes?("Drop tenant '#{tenant}'? This cannot be undone. [y/N]")
+        return unless confirmed_destructive?(tenant)
 
         Apartment::Tenant.drop(tenant)
         say("Dropped tenant: #{tenant}") unless quiet?
@@ -75,6 +75,28 @@ module Apartment
 
       def force?
         options[:force] || ENV['APARTMENT_FORCE'] == '1'
+      end
+
+      # Whether the irreversible drop may proceed. --force / APARTMENT_FORCE=1
+      # is the explicit opt-in. On a TTY we prompt [y/N]. In a non-interactive
+      # context (deploy/cron/CI, binstub, rake) we cannot prompt: rather than
+      # let Thor's yes? read EOF as "no" — a silent cancel that still exits 0 —
+      # or block on $stdin.gets against an open-but-empty pipe, refuse loudly
+      # with a non-zero exit. Centralizing it here (not in the rake wrapper)
+      # covers every entry point uniformly. See issue #457.
+      def confirmed_destructive?(tenant)
+        return true if force?
+
+        unless $stdin.tty?
+          raise(Thor::Error,
+                'apartment tenants drop is destructive and cannot prompt in a ' \
+                'non-interactive context. Re-run with --force or APARTMENT_FORCE=1 to proceed.')
+        end
+
+        return true if yes?("Drop tenant '#{tenant}'? This cannot be undone. [y/N]")
+
+        say('Cancelled.')
+        false
       end
 
       def quiet?

--- a/lib/apartment/tasks/v4.rake
+++ b/lib/apartment/tasks/v4.rake
@@ -15,7 +15,16 @@ namespace :apartment do
   desc 'Drop a tenant schema/database'
   task :drop, [:tenant] => :environment do |_t, args|
     abort('Usage: rake apartment:drop[tenant_name]') unless args[:tenant]
-    Apartment::CLI::Tenants.new.invoke(:drop, [args[:tenant]], force: true)
+    # Plain delegate: Apartment::CLI::Tenants#drop owns the confirmation policy
+    # (TTY prompts [y/N]; non-interactive requires --force / APARTMENT_FORCE=1,
+    # otherwise raises Thor::Error). The rake wrapper adds no force handling of
+    # its own. It only reformats the guard error: `.new.invoke` bypasses
+    # Thor.start's exit_on_failure? handling, so an unrescued Thor::Error would
+    # surface as a raw `rake aborted!` backtrace that buries the actionable
+    # message — abort re-emits it as a clean one-liner with a non-zero exit.
+    Apartment::CLI::Tenants.new.invoke(:drop, [args[:tenant]])
+  rescue Thor::Error => e
+    abort(e.message)
   end
 
   desc 'Run migrations for all tenants (or one: rake apartment:migrate[tenant])'

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha5'
+  VERSION = '4.0.0.alpha6'
 end

--- a/spec/unit/cli/tenants_spec.rb
+++ b/spec/unit/cli/tenants_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe(Apartment::CLI::Tenants) do
   end
 
   describe 'drop' do
+    # Isolate from an ambient APARTMENT_FORCE=1: it makes force? true and would
+    # short-circuit the confirmation branch these examples assert on.
+    around do |example|
+      original = ENV.fetch('APARTMENT_FORCE', nil)
+      ENV.delete('APARTMENT_FORCE')
+      example.run
+    ensure
+      ENV['APARTMENT_FORCE'] = original
+    end
+
     before do
       allow(Apartment::Tenant).to(receive(:drop))
     end
@@ -67,20 +77,42 @@ RSpec.describe(Apartment::CLI::Tenants) do
       expect(Apartment::Tenant).to(have_received(:drop).with('acme'))
     end
 
-    it 'prompts for confirmation without --force' do
+    it 'prompts for confirmation without --force (interactive)' do
       instance = described_class.new
+      allow($stdin).to(receive(:tty?).and_return(true))
       allow(instance).to(receive(:yes?).and_return(false))
       allow(instance).to(receive(:say))
       instance.drop('acme')
       expect(Apartment::Tenant).not_to(have_received(:drop))
     end
 
-    it 'proceeds when confirmation is accepted' do
+    it 'proceeds when confirmation is accepted (interactive)' do
       instance = described_class.new
+      allow($stdin).to(receive(:tty?).and_return(true))
       allow(instance).to(receive(:yes?).and_return(true))
       allow(instance).to(receive(:say))
       instance.drop('acme')
       expect(Apartment::Tenant).to(have_received(:drop).with('acme'))
+    end
+
+    # Issue #457: a non-interactive drop (no TTY) without --force/APARTMENT_FORCE
+    # must fail loudly rather than let Thor's yes? read EOF as "no" (a silent
+    # cancel that still exits 0) or block on $stdin.
+    it 'raises Thor::Error and never drops when non-interactive without force' do
+      instance = described_class.new
+      allow($stdin).to(receive(:tty?).and_return(false))
+      expect { instance.drop('acme') }.to(raise_error(Thor::Error, /APARTMENT_FORCE=1/))
+      expect(Apartment::Tenant).not_to(have_received(:drop))
+    end
+
+    # The binstub (`bin/apartment tenants drop x`) reaches drop via
+    # Thor's .start, where exit_on_failure? turns the Thor::Error into a
+    # non-zero SystemExit. This is the entry point the rake wrapper does not
+    # cover, so assert the whole-process behavior here (mirrors the create path).
+    it 'exits non-zero via .start (binstub) when non-interactive without force' do
+      allow($stdin).to(receive(:tty?).and_return(false))
+      expect { run_command('drop', 'acme') }.to(raise_error(SystemExit))
+      expect(Apartment::Tenant).not_to(have_received(:drop))
     end
   end
 

--- a/spec/unit/tasks/v4_rake_spec.rb
+++ b/spec/unit/tasks/v4_rake_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rake'
+require 'apartment/cli'
+
+# Unit coverage for the apartment: rake wrappers in lib/apartment/tasks/v4.rake.
+# The tasks are thin delegations to the Thor CLI; the confirmation policy lives
+# in Apartment::CLI::Tenants (see spec/unit/cli/tenants_spec.rb). These specs
+# load the task file into a throwaway Rake application and drive the *real* CLI
+# (stubbing only Apartment::Tenant.drop, the boundary below it), so the
+# rake -> CLI -> force?/TTY integration is exercised end to end rather than
+# stubbed away.
+RSpec.describe('apartment rake tasks') do
+  around do |example|
+    original_app = Rake.application
+    Rake.application = Rake::Application.new
+    # v4.rake declares `=> :environment`; stub it so the task can run headless.
+    Rake::Task.define_task(:environment)
+    load(File.expand_path('../../../lib/apartment/tasks/v4.rake', __dir__))
+    example.run
+  ensure
+    Rake.application = original_app
+  end
+
+  before { allow(Apartment::Tenant).to(receive(:drop)) }
+
+  # Issue #457: the wrapper hardcoded force: true, so the rake path was the only
+  # drop entry point that never confirmed an irreversible operation. It now
+  # delegates plainly to the CLI, whose policy requires an interactive TTY or an
+  # explicit APARTMENT_FORCE=1 and otherwise aborts loudly.
+  describe 'apartment:drop' do
+    context 'when non-interactive (no TTY) without APARTMENT_FORCE' do
+      around do |example|
+        original = ENV.fetch('APARTMENT_FORCE', nil)
+        ENV.delete('APARTMENT_FORCE')
+        example.run
+      ensure
+        ENV['APARTMENT_FORCE'] = original
+      end
+
+      before { allow($stdin).to(receive(:tty?).and_return(false)) }
+
+      # The wrapper reformats the CLI's Thor::Error as a clean abort (one-line
+      # message, non-zero exit) rather than a raw `rake aborted!` backtrace.
+      it 'aborts loudly with a clean message and never drops' do
+        expect { Rake::Task['apartment:drop'].invoke('acme') }
+          .to(raise_error(SystemExit).and(output(/APARTMENT_FORCE=1/).to_stderr))
+        expect(Apartment::Tenant).not_to(have_received(:drop))
+      end
+    end
+
+    context 'when non-interactive with APARTMENT_FORCE=1' do
+      around do |example|
+        original = ENV.fetch('APARTMENT_FORCE', nil)
+        ENV['APARTMENT_FORCE'] = '1'
+        example.run
+      ensure
+        ENV['APARTMENT_FORCE'] = original
+      end
+
+      before { allow($stdin).to(receive(:tty?).and_return(false)) }
+
+      it 'drops without prompting (the real CLI honors APARTMENT_FORCE)' do
+        Rake::Task['apartment:drop'].invoke('acme')
+
+        expect(Apartment::Tenant).to(have_received(:drop).with('acme'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #457. `apartment:drop` (rake) hardcoded `force: true`, so it was the only drop entry point that never confirmed an irreversible operation — despite being the one most likely typed by hand.

## Root cause & why the obvious fix is insufficient

The hardcoded force was a deliberate v3-compat choice (Phase 6 / #363 preserved the old non-interactive rake drop). But simply removing it is unsafe, and a rake-only guard is incomplete: the **binstub** (`bin/apartment tenants drop x`) and a direct `apartment tenants drop x` both reach `Apartment::CLI::Tenants#drop` without touching the rake task, where Thor's `yes?` either:

- **silently cancels** — reads EOF as "no" and exits **0**, so a deploy step "succeeds" while the tenant survives (then a later recreate collides with it); or
- **blocks** on `$stdin.gets` against an open-but-empty pipe (hangs to timeout).

## Fix

The confirmation policy now lives in `Apartment::CLI::Tenants#drop`, covering **every** entry point (CLI, binstub, rake) uniformly:

| Context | Behavior |
|---|---|
| `--force` / `APARTMENT_FORCE=1` | proceed (unchanged) |
| Interactive TTY | prompt `[y/N]` (unchanged) |
| Non-interactive, no force | raise `Thor::Error`, exit non-zero, clear message |

`Thor::Error` + `exit_on_failure?` matches how `create`/`seed`/`migrate`/`rollback` already surface failures. The rake wrapper is a plain delegate; it only reformats the guard error as a clean one-liner (because `.new.invoke` bypasses Thor's `exit_on_failure?`, an unrescued error would print a raw `rake aborted!` backtrace).

## ⚠️ Behavior change (release-note item)

Unattended callers of `apartment tenants drop` / `rake apartment:drop[x]` — including piped `yes | ...` and PTY-allocated CI — must now set `APARTMENT_FORCE=1` (or pass `--force`). Previously the rake path dropped unconditionally. This is deliberate: an irreversible drop should require explicit intent in a non-interactive context, and fail loudly rather than silently skip.

## Testing

- `spec/unit/cli/tenants_spec.rb`: TTY-decline, TTY-accept, non-interactive `Thor::Error`, and the binstub `.start` → `SystemExit` path; `APARTMENT_FORCE` isolated from the ambient env.
- `spec/unit/tasks/v4_rake_spec.rb` (new): drives the **real** CLI through the rake task (stubbing only `Apartment::Tenant.drop`), exercising the rake→CLI→`force?`/TTY integration and the clean-abort reformatting.
- Verified by hand: binstub and rake both exit 1 with a clean one-line message non-interactively.
- Full unit suite green; rubocop clean.

## Review

Reviewed with Claude Code (three high-effort workflow reviews across revisions) plus an AI-agent panel (Gemini, Cursor). The reviews drove the design: they confirmed the naive patch silently no-ops in CI (and can hang), then caught that a rake-only guard left the binstub path broken — hence the move to the CLI layer.

## Note

Also bumps `VERSION` to `4.0.0.alpha6` (with the Zeitwerk eager-load fix, this completes alpha6). Per `RELEASING.md`, the bump lands on `main`, then `main → 4-0-alpha` publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
