### PR TITLE
CI: add ci-gate aggregation job for required-check branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
   unit:
     name: Unit · Ruby ${{ matrix.ruby }} · Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    # Rails main is a canary: it tracks an unreleased edge and is allowed to
+    # fail. continue-on-error keeps a red main cell from failing the `unit` job,
+    # so it neither blocks the workflow nor flips needs.unit.result for ci-gate.
+    continue-on-error: ${{ matrix.rails == 'main' }}
     strategy:
       fail-fast: false
       matrix:
@@ -245,3 +249,34 @@ jobs:
         run: bundle exec rspec spec/integration/v4/ --format progress
         env:
           DATABASE_ENGINE: sqlite
+
+  # ── CI gate ────────────────────────────────────────────────────────
+  # Single aggregation check for branch protection: require just `ci-gate`
+  # rather than every matrix cell by name (which would break whenever the
+  # matrix changes and risk pinning the Rails-main canary). Passes only when
+  # every required job succeeded or was skipped — skipped happens only under a
+  # scoped workflow_dispatch, never on the pull_request events that gate merges.
+  # Job results arrive via env (not interpolated into run:) so the shell never
+  # evaluates workflow context directly.
+  ci-gate:
+    if: always()
+    needs: [unit, postgresql, mysql, sqlite]
+    runs-on: ubuntu-latest
+    env:
+      UNIT: ${{ needs.unit.result }}
+      POSTGRESQL: ${{ needs.postgresql.result }}
+      MYSQL: ${{ needs.mysql.result }}
+      SQLITE: ${{ needs.sqlite.result }}
+    steps:
+      - name: Require all CI jobs to have passed
+        run: |
+          failed=0
+          for job in UNIT POSTGRESQL MYSQL SQLITE; do
+            result="${!job}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "::error::Required CI job '$job' concluded '$result'"
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 0 ]; then echo "All required CI jobs passed."; fi
+          exit "$failed"


### PR DESCRIPTION
## Summary

Adds a single **`ci-gate`** aggregation job so branch protection (on `main`) can require **one** stable status check instead of every matrix cell by name.

Requiring the raw matrix checks (`PG 16 · Ruby 3.3 · Rails 7.2`, …) would mean hand-editing branch protection on every Ruby/Rails/PG matrix change, and would risk pinning the Rails-main canary as a required check. `ci-gate` sidesteps both: it `needs: [unit, postgresql, mysql, sqlite]` and passes only when all succeed (or are skipped under a scoped `workflow_dispatch` — which never happens on the `pull_request` events that gate merges).

## Also: Rails-main canary fix

`rails: main` runs in the `unit` matrix but had **no** `continue-on-error`, despite `CLAUDE.md` documenting it as a canary ("Rails main is a canary (continue-on-error)"). As-is, a red main cell fails `unit` — and would then block every merge through `ci-gate`. This marks that one cell `continue-on-error: ${{ matrix.rails == 'main' }}`, so a canary breakage neither fails the job nor flips `needs.unit.result`.

## Notes

- Job results reach the gate via `env:` rather than being interpolated into `run:`, so the shell never evaluates workflow context directly (workflow-injection hygiene).
- Gate logic verified across `success` / `failure` / `skipped` / `cancelled` states.
- Follow-up (separate, by the maintainer): a `main` ruleset requires `ci-gate` and consolidates review + CI enforcement off the legacy classic branch-protection rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
