### PR TITLE
Chore: adopt mise for local Ruby version management (rbenv-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ This gem is a maintained fork of the original [Apartment gem](https://github.com
 - Rails 7.2+
 - PostgreSQL 14+, MySQL 8.4+, or SQLite3
 
+### Ruby version manager
+
+`.ruby-version` is the single source of truth for the local Ruby version (the
+same file `ruby/setup-ruby` reads in CI). Both [mise](https://mise.jdx.dev) and
+[rbenv](https://github.com/rbenv/rbenv) honor it — use whichever you prefer:
+
+```bash
+# mise (recommended)
+brew install mise                 # then add `eval "$(mise activate zsh)"` to ~/.zshrc
+mise trust && mise install        # one-time trust per clone, then install the pinned Ruby
+
+# rbenv (also works, unchanged)
+rbenv install "$(cat .ruby-version)"
+```
+
+The committed `mise.toml` carries settings only (never a version): it tells mise
+to honor `.ruby-version` without any per-developer global config. `mise trust`
+is required once per clone; `bin/dev/setup-worktree` handles it for new worktrees.
+
 ### Setup
 
 ```ruby

--- a/bin/dev/setup-worktree
+++ b/bin/dev/setup-worktree
@@ -76,6 +76,22 @@ cd "$WORKTREE_PATH" || { log_error "Failed to cd into $WORKTREE_PATH"; exit 1; }
 ABS_WORKTREE_PATH=$(pwd)
 
 # ---------------------------------------------------------------------------
+# mise trust
+# ---------------------------------------------------------------------------
+# mise refuses to apply an untrusted project config, keyed per absolute path,
+# so the committed mise.toml (which makes mise honor .ruby-version) is inert in
+# a fresh worktree until trusted. Trust it here so the developer's first `cd`
+# into the worktree applies the pin with no interactive prompt. No-op for rbenv
+# holdouts (mise absent) — rbenv reads .ruby-version directly and ignores this.
+if command -v mise >/dev/null 2>&1; then
+    if mise trust "$ABS_WORKTREE_PATH" >/dev/null 2>&1; then
+        log_info "mise: trusted $ABS_WORKTREE_PATH"
+    else
+        log_warn "mise: failed to trust $ABS_WORKTREE_PATH — run 'mise trust' there manually"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # Serena registration
 # ---------------------------------------------------------------------------
 # Two failure modes this prevents:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,28 @@
+# Project mise configuration.
+#
+# Enables mise's "idiomatic version file" support so `mise install` and
+# `mise activate`'s directory switching honor the checked-in `.ruby-version`
+# pin with NO per-developer global config. mise disables idiomatic files by
+# default, and this project setting REPLACES (does not merge with) any global
+# `idiomatic_version_file_enable_tools`.
+#
+# All three tools are listed deliberately even though this repo only pins ruby:
+# scoping the list to ruby alone would REPLACE a developer's global list and
+# silently stop honoring their .node-version / .python-version in this repo.
+# - ruby:   the pinned toolchain (see .ruby-version). Read by mise here and by
+#           rbenv for holdouts; both managers honor the same file.
+# - node:   listed for cross-repo consistency; no .node-version, so it no-ops.
+# - python: listed for cross-repo consistency; .python-version pins 3.13 for
+#           ad hoc tooling, otherwise harmless.
+#
+# The version lives in `.ruby-version`, not here, so a single `.ruby-version`
+# bump stays the one place to change Ruby — the same file `ruby/setup-ruby`
+# reads in CI. This file carries settings only, never a version.
+#
+# Trust: mise requires a one-time `mise trust` per clone/worktree before
+# applying this file. `bin/dev/setup-worktree` trusts new worktrees; for the
+# main clone run `mise trust && mise install` once (see README).
+#
+# rbenv is unaffected — it reads `.ruby-version` directly and ignores this file.
+[settings]
+idiomatic_version_file_enable_tools = ["node", "ruby", "python"]


### PR DESCRIPTION
## Summary

Developer-tooling only — **no gem behavior and no CI runtime change**. Lets contributors manage the local Ruby with [mise](https://mise.jdx.dev) while keeping [rbenv](https://github.com/rbenv/rbenv) working unchanged. `.ruby-version` stays the single source of truth.

## Why

mise disables "idiomatic version files" (`.ruby-version`, `.node-version`, …) **by default**, so without a committed config it silently does *not* honor this repo's `.ruby-version`. A one-line `mise.toml` opts the repo in, so a mise user gets the pinned Ruby with zero per-developer global config — and an rbenv user is entirely unaffected (rbenv reads `.ruby-version` directly and ignores `mise.toml`). One file, `.ruby-version`, stays the one place to bump the version.

## Technical changes

- **`mise.toml`** (new) — settings only, never a version:
  ```toml
  [settings]
  idiomatic_version_file_enable_tools = ["node", "ruby", "python"]
  ```
  All three tools are listed deliberately even though this repo only pins Ruby: a **project setting REPLACES (does not merge with)** the developer's global `idiomatic_version_file_enable_tools`, so scoping to ruby-only would silently stop honoring a teammate's `.node-version`/`.python-version` in this repo. `node`/`python` no-op here (no `.node-version`; `.python-version` is an ad hoc hint).
- **`bin/dev/setup-worktree`** — `mise trust`es each new worktree. mise refuses an untrusted project config, keyed per absolute path, so a fresh worktree's `mise.toml` is inert until trusted; this closes that gap with no interactive prompt on first `cd`. Guarded on `command -v mise` → a complete no-op for rbenv holdouts.
- **`README.md`** — documents the mise-*or*-rbenv setup and names `.ruby-version` as the one place to bump.

## CI is untouched, by design

All workflows use `ruby/setup-ruby@v1`, which already pins Ruby from `.ruby-version` (and the Ruby×Rails matrix) on a clean machine. Runners are ephemeral and single-runtime; mise buys nothing there. `.github/workflows/` has **zero diff** in this PR.

## Testing

Verified locally:

- `mise` resolves `ruby 4.0.2` from `.ruby-version` (`mise which ruby` → the mise install; `mise exec ruby -- ruby --version` → `4.0.2`).
- `rbenv version` resolves the identical `4.0.2` from the same file — holdouts unaffected.
- `bundle --version` runs on the resolved Ruby.
- `bash -n bin/dev/setup-worktree` passes.
- `git diff origin/main -- .github/` is empty.

## Adopt on your machine

```bash
brew install mise                 # then add `eval "$(mise activate zsh)"` to ~/.zshrc
mise trust && mise install        # trust once per clone, then install the pinned Ruby
```

Already on rbenv? Nothing breaks — keep it, or switch when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)