### PR TITLE
Feat(v4): instrument tenant-migration failures + isolated emission

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -24,6 +24,15 @@ All events are namespaced `<name>.apartment` and published through
 | `skip_evict.apartment` | When a candidate pool is skipped during eviction | `tenant:`, `reason:` (`:pinned`, `:in_use`), `eviction_reason:` (`:idle`, `:lru`, `:admission`); plus `busy_connections:` and `open_transactions:` when `reason: :in_use` |
 | `reaper_stopped.apartment` | When the background reaper is deactivated in the test environment | `reason:` (`:test_env`) |
 | `migrate_tenant.apartment` | After migrations run for one tenant | `tenant:`, `versions:` (array of migration version integers) |
+| `migrate_tenant_failed.apartment` | When a tenant (or the primary) migration raises | `tenant:`, `error:` (the raised exception), `duration:` (seconds) |
+
+> **`PoolObserver` does not forward the migrate events.** The observer below covers
+> pool-lifecycle events only; `migrate_tenant` / `migrate_tenant_failed` are not in
+> its counter set. Installing it alone does **not** close migration error tracking —
+> subscribe to `migrate_tenant_failed.apartment` directly. Keep that subscriber
+> non-raising: it runs inline on the migration thread, and a raising subscriber to
+> the failure event is isolated by the Migrator (logged, not propagated) but still
+> loses your notification.
 
 **`cap_unmet` fires on two paths:** from the synchronous admission path (when a
 new pool would breach the cap and no idle pool can be freed) and from the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -30,9 +30,13 @@ All events are namespaced `<name>.apartment` and published through
 > pool-lifecycle events only; `migrate_tenant` / `migrate_tenant_failed` are not in
 > its counter set. Installing it alone does **not** close migration error tracking —
 > subscribe to `migrate_tenant_failed.apartment` directly. Keep that subscriber
-> non-raising: it runs inline on the migration thread, and a raising subscriber to
-> the failure event is isolated by the Migrator (logged, not propagated) but still
-> loses your notification.
+> non-raising: it runs inline on the migration thread (a worker thread under
+> parallel migration). A subscriber raising a `StandardError` is isolated by the
+> Migrator — logged and swallowed, not propagated (you lose that one notification,
+> not the run). Process-control exceptions (`SystemExit`, `Interrupt`) and bare
+> `Exception` subclasses are **not** swallowed and will surface. The **success**
+> event `migrate_tenant.apartment` is *not* isolated — a raising success subscriber
+> can still break the run — so keep both subscribers defensive.
 
 **`cap_unmet` fires on two paths:** from the synchronous admission path (when a
 new pool would breach the cap and no idle pool can be freed) and from the

--- a/lib/apartment/cli/migrations.rb
+++ b/lib/apartment/cli/migrations.rb
@@ -5,6 +5,13 @@ require 'thor'
 module Apartment
   class CLI < Thor
     class Migrations < Thor
+      # The raised Thor::Error message is the low-context surface a monitor or
+      # CI-log tail captures even when the stdout summary is dropped/unindexed.
+      # Name a few failed tenants there (capped, so a 600-tenant run does not
+      # produce a wall of text); the full per-tenant detail is in the summary
+      # and in the migrate_tenant_failed.apartment events.
+      FAILED_TENANTS_PREVIEW = 5
+
       def self.exit_on_failure? = true
 
       desc 'migrate [TENANT]', 'Run migrations for tenants'
@@ -62,7 +69,15 @@ module Apartment
         say(result.summary)
 
         trigger_schema_dump if result.success?
-        raise(Thor::Error, "Migration failed for #{result.failed.size} tenant(s)") unless result.success?
+        raise(Thor::Error, migration_failure_message(result.failed)) unless result.success?
+      end
+
+      def migration_failure_message(failures)
+        names = failures.map(&:tenant)
+        shown = names.first(FAILED_TENANTS_PREVIEW)
+        more = names.size - shown.size
+        suffix = more.positive? ? ", and #{more} more" : ''
+        "Migration failed for #{names.size} tenant(s): #{shown.join(', ')}#{suffix} (see summary above)"
       end
 
       # Rollback bypasses the Migrator's parallelism and Result tracking but

--- a/lib/apartment/instrumentation.rb
+++ b/lib/apartment/instrumentation.rb
@@ -3,8 +3,8 @@
 require 'active_support/notifications'
 
 module Apartment
-  # Thin wrapper around ActiveSupport::Notifications.
-  # Known events: create, drop, evict (all namespaced as *.apartment).
+  # Thin wrapper around ActiveSupport::Notifications. All events are namespaced
+  # *.apartment; see docs/observability.md for the authoritative event catalog.
   module Instrumentation
     def self.instrument(event, payload = {}, &block)
       event_name = "#{event}.apartment"

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -121,9 +121,15 @@ module Apartment
         duration: monotonic_now - start, error: nil, versions_run: versions
       )
     rescue StandardError => e
+      duration = monotonic_now - start
+      # Symmetric with the :migrate_tenant success event above: the gem holds the
+      # full structured error here, so emit it for subscribers rather than
+      # stranding it in the returned Result. See migrate_tenant's rescue.
+      instrument_failure(tenant_name, e, duration)
+
       Result.new(
         tenant: tenant_name, status: :failed,
-        duration: monotonic_now - start, error: e, versions_run: []
+        duration: duration, error: e, versions_run: []
       )
     end
 
@@ -166,9 +172,17 @@ module Apartment
         end
       end
     rescue StandardError => e
+      duration = monotonic_now - start
+      # Failure counterpart to the :migrate_tenant success event. On SUCCESS the
+      # gem instruments; on FAILURE it previously only returned a failed Result,
+      # leaving adopters no hook to observe the (structured) error. This closes
+      # that asymmetry — generic payload (tenant + error + duration); routing to
+      # an error tracker is the subscriber's job.
+      instrument_failure(tenant, e, duration)
+
       Result.new(
         tenant: tenant, status: :failed,
-        duration: monotonic_now - start, error: e, versions_run: []
+        duration: duration, error: e, versions_run: []
       )
     ensure
       Apartment::Current.migrating = false
@@ -240,6 +254,20 @@ module Apartment
       yield
     ensure
       conn.instance_variable_set(ADVISORY_LOCKS_IVAR, original) if conn&.instance_variable_defined?(ADVISORY_LOCKS_IVAR)
+    end
+
+    # Emit the failure event without letting a raising subscriber break the
+    # Migrator's non-raising contract: the failed Result MUST still be returned.
+    # ActiveSupport::Notifications propagates subscriber exceptions through
+    # instrument (verified against AS 8.0), and this fires from inside a rescue
+    # block, so an un-isolated call would convert a captured per-tenant failure
+    # into an unhandled raise out of #run. The success-path instrumentation is
+    # left un-isolated by design — only the failure path carries the hard
+    # no-raise guarantee, and swallowing there would mask real subscriber bugs.
+    def instrument_failure(tenant, error, duration)
+      Instrumentation.instrument(:migrate_tenant_failed, tenant: tenant, error: error, duration: duration)
+    rescue StandardError => e
+      warn "[Apartment::Migrator] migrate_tenant_failed subscriber raised #{e.class}: #{e.message}"
     end
 
     def monotonic_now

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -261,13 +261,27 @@ module Apartment
     # ActiveSupport::Notifications propagates subscriber exceptions through
     # instrument (verified against AS 8.0), and this fires from inside a rescue
     # block, so an un-isolated call would convert a captured per-tenant failure
-    # into an unhandled raise out of #run. The success-path instrumentation is
-    # left un-isolated by design — only the failure path carries the hard
-    # no-raise guarantee, and swallowing there would mask real subscriber bugs.
+    # into an unhandled raise out of #run.
+    #
+    # Scope of the guarantee: a subscriber raising a StandardError is swallowed
+    # and warned. Process-control exceptions (SystemExit, SignalException /
+    # Interrupt) are deliberately NOT rescued — they must propagate so exit and
+    # Ctrl-C still work mid-migration; a subscriber raising a bare Exception
+    # subclass is itself a bug (Ruby errors should descend from StandardError).
+    # The warn is nested-rescued so a broken $stderr (IOError is a StandardError)
+    # cannot re-escape the handler. Success-path instrumentation is left
+    # un-isolated by design — only the failure path carries the hard no-raise
+    # guarantee, and swallowing there would mask real subscriber bugs.
     def instrument_failure(tenant, error, duration)
       Instrumentation.instrument(:migrate_tenant_failed, tenant: tenant, error: error, duration: duration)
     rescue StandardError => e
-      warn "[Apartment::Migrator] migrate_tenant_failed subscriber raised #{e.class}: #{e.message}"
+      # Nested rescue: a sibling `rescue` on this method would NOT catch an
+      # exception raised by warn (a broken $stderr), so the warn gets its own.
+      begin
+        warn "[Apartment::Migrator] migrate_tenant_failed subscriber raised #{e.class}: #{e.message}"
+      rescue StandardError
+        nil
+      end
     end
 
     def monotonic_now

--- a/lib/apartment/tasks/v4.rake
+++ b/lib/apartment/tasks/v4.rake
@@ -34,6 +34,13 @@ namespace :apartment do
     else
       Apartment::CLI::Migrations.new.invoke(:migrate)
     end
+    # Parity with apartment:drop: `.new.invoke` bypasses Thor.start's
+    # exit_on_failure? handling, so an unrescued Thor::Error (raised on
+    # migration failure) would surface as a raw `rake aborted!` backtrace that
+    # buries the actionable message. abort re-emits it as a clean one-liner
+    # with a non-zero exit.
+  rescue Thor::Error => e
+    abort(e.message)
   end
 
   desc 'Seed all tenants'

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha6'
+  VERSION = '4.0.0.alpha7'
 end

--- a/spec/unit/cli/migrations_spec.rb
+++ b/spec/unit/cli/migrations_spec.rb
@@ -101,6 +101,28 @@ RSpec.describe(Apartment::CLI::Migrations) do
         allow(Apartment::Migrator).to(receive(:new).and_return(double(run: failed_run)))
         expect { run_command('migrate') }.to(raise_error(SystemExit))
       end
+
+      it 'names failed tenants (capped) in the raised error message' do
+        failures = (1..8).map do |i|
+          Apartment::Migrator::Result.new(
+            tenant: "tenant_#{i}", status: :failed, duration: 0.1,
+            error: StandardError.new('boom'), versions_run: []
+          )
+        end
+        run = Apartment::Migrator::MigrationRun.new(results: failures, total_duration: 1.0, threads: 4)
+
+        cmd = described_class.new
+        allow(Apartment::Migrator).to(receive(:new).and_return(double(run: run)))
+        allow(cmd).to(receive(:say))
+        allow(cmd).to(receive(:trigger_schema_dump))
+
+        expect { cmd.send(:migrate_all) }.to(raise_error(Thor::Error)) do |error|
+          expect(error.message).to(include('Migration failed for 8 tenant(s)'))
+          expect(error.message).to(include('tenant_1, tenant_2, tenant_3, tenant_4, tenant_5'))
+          expect(error.message).to(include('and 3 more'))
+          expect(error.message).not_to(include('tenant_6'))
+        end
+      end
     end
 
     context 'with tenant argument (single tenant)' do

--- a/spec/unit/cli/migrations_spec.rb
+++ b/spec/unit/cli/migrations_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe(Apartment::CLI::Migrations) do
     $stdout = STDOUT
   end
 
+  it 'exposes only migrate and rollback as Thor commands (helpers stay private)' do
+    # Thor registers public instance methods as commands. Locks migrate_all /
+    # migration_failure_message under `private` so a future refactor that moves
+    # one above `private` doesn't silently expose it as `apartment:...`.
+    expect(described_class.commands.keys).to(include('migrate', 'rollback'))
+    expect(described_class.commands.keys).not_to(include('migrate_all', 'migration_failure_message'))
+  end
+
   describe 'migrate' do
     let(:migration_run) do
       Apartment::Migrator::MigrationRun.new(

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -338,6 +338,31 @@ RSpec.describe(Apartment::Migrator) do
       ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
     end
 
+    it 'emits the failure event from worker threads on the parallel path' do
+      # The production path is parallel; a subscriber's StandardError here must
+      # not pollute run_parallel's fatal_errors (which would make #run raise),
+      # and the event must still fire from the worker thread. Primary runs first
+      # (sequential) and succeeds; the failure is one of the two parallel tenants.
+      call_count = Concurrent::AtomicFixnum.new(0)
+      allow(mock_migration_context).to(receive(:migrate)) do
+        raise(StandardError, 'boom') if call_count.increment == 2
+
+        []
+      end
+
+      events = Concurrent::Array.new
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| events << e }
+
+      run = described_class.new(threads: 2).run
+
+      expect(run.failed.size).to(eq(1))
+      expect(events.size).to(eq(1))
+      expect(events.first.payload[:error]).to(be_a(StandardError))
+      expect(events.first.payload[:tenant]).to(eq(run.failed.first.tenant))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
     it 'emits migrate_tenant_failed.apartment when the primary migration fails' do
       allow(mock_migration_context).to(receive(:migrate).and_raise(StandardError, 'db down'))
 

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -258,6 +258,104 @@ RSpec.describe(Apartment::Migrator) do
     end
   end
 
+  describe 'failure instrumentation' do
+    # The success path instruments :migrate_tenant; failures must be symmetric so
+    # an adopter can subscribe to them and route the structured error (tenant +
+    # exception) to their error tracker, instead of it being stranded on stdout.
+    # These use real ActiveSupport::Notifications (no Instrumentation stub) and
+    # also assert the Migrator's non-raising return contract is unchanged.
+    let(:mock_migration_context) { instance_double('ActiveRecord::MigrationContext') }
+    let(:mock_pool) { instance_double('ActiveRecord::ConnectionAdapters::ConnectionPool') }
+    let(:mock_connection) { double('connection') }
+
+    before do
+      allow(ActiveRecord::Base).to(receive_messages(connection_pool: mock_pool, lease_connection: mock_connection))
+      allow(mock_connection).to(receive(:instance_variable_get).and_return(true))
+      allow(mock_connection).to(receive(:instance_variable_set))
+      allow(mock_connection).to(receive(:instance_variable_defined?)
+        .with(:@advisory_locks_enabled).and_return(true))
+      allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
+      allow(mock_migration_context).to(receive(:needs_migration?).and_return(true))
+      allow(Apartment::Tenant).to(receive(:switch)) { |_tenant, &block| block.call }
+    end
+
+    it 'emits migrate_tenant_failed.apartment with tenant, error, and duration when a tenant migration fails' do
+      boom = StandardError.new('boom')
+      allow(mock_migration_context).to(receive(:migrate).and_raise(boom))
+
+      events = []
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| events << e }
+
+      described_class.new(threads: 0).send(:migrate_tenant, 'acme')
+
+      expect(events.size).to(eq(1))
+      payload = events.first.payload
+      expect(payload[:tenant]).to(eq('acme'))
+      expect(payload[:error]).to(be(boom))
+      expect(payload[:duration]).to(be_a(Numeric))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
+    it 'still returns a failed Result and surfaces in MigrationRun#failed (contract unchanged)' do
+      call_count = 0
+      allow(mock_migration_context).to(receive(:migrate)) do
+        call_count += 1
+        raise(StandardError, 'boom') if call_count == 2
+
+        []
+      end
+
+      failed_events = []
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| failed_events << e }
+
+      run = described_class.new(threads: 0).run
+
+      expect(run.failed.size).to(eq(1))
+      expect(run.results.size).to(eq(3))
+      expect(failed_events.map { |e| e.payload[:tenant] }).to(eq(run.failed.map(&:tenant)))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
+    it 'does not let a raising subscriber break the non-raising contract' do
+      # ActiveSupport::Notifications propagates subscriber exceptions through
+      # instrument, and the failure event fires inside migrate_tenant's rescue
+      # block. Without isolation, a raising subscriber would turn a captured
+      # per-tenant failure into an unhandled raise out of the Migrator.
+      allow(mock_migration_context).to(receive(:migrate).and_raise(StandardError, 'boom'))
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { raise('subscriber blew up') }
+
+      migrator = described_class.new(threads: 0)
+      allow(migrator).to(receive(:warn))
+
+      result = nil
+      expect { result = migrator.send(:migrate_tenant, 'acme') }.not_to(raise_error)
+      expect(result.status).to(eq(:failed))
+      expect(result.error.message).to(eq('boom'))
+      expect(migrator).to(have_received(:warn).with(/subscriber raised/i))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
+    it 'emits migrate_tenant_failed.apartment when the primary migration fails' do
+      allow(mock_migration_context).to(receive(:migrate).and_raise(StandardError, 'db down'))
+
+      events = []
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| events << e }
+
+      run = described_class.new(threads: 0).run
+
+      # Primary failure aborts the run, so exactly one failed event (the primary).
+      expect(events.size).to(eq(1))
+      expect(events.first.payload[:tenant]).to(eq('public'))
+      expect(events.first.payload[:error]).to(be_a(StandardError))
+      expect(run.results.map(&:status)).to(eq([:failed]))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+  end
+
   describe '#migrate_tenant Current.migrating lifecycle' do
     let(:mock_pool) { double('pool', migration_context: double(needs_migration?: false)) }
 


### PR DESCRIPTION
## Problem

v4 tenant-migration **failures were invisible to an adopter's error tracker**. On SUCCESS, `Apartment::Migrator` emits `migrate_tenant.apartment`; on FAILURE it emitted **nothing** — the structured per-tenant exception was stranded in the returned `Result` and on stdout via `say(result.summary)`. An adopter running `apartment:migrate` in a release step (e.g. 8 threads × ~600 tenants) whose tracker only captured exceptions saw just the count-only `Thor::Error: Migration failed for N tenant(s)` — no tenant names, no error classes. Diagnosing meant digging through raw build logs.

The gap was **asymmetric instrumentation**: the gem holds the full structured error at the rescue point but emitted no event there.

## The fix

Emit a symmetric event `migrate_tenant_failed.apartment` from **both** rescue paths (`migrate_tenant` and `migrate_primary`):

| Key | Value |
|---|---|
| `tenant:` | the tenant name |
| `error:` | the raised exception object |
| `duration:` | seconds (monotonic) |

- **Additive only.** `#run` still collects all failures into `MigrationRun` and remains **non-raising** at the Migrator layer. The event fires alongside the existing failed-`Result` return, not instead of it.
- **Zero error-tracker coupling.** Generic payload; routing to Sentry/CloudWatch/etc. is the adopter's job via a subscriber. Naming (`migrate_tenant_failed`, a distinct sibling of the `migrate_tenant` success event) lets subscribers filter failures directly.

## Contract protection (the load-bearing part)

`ActiveSupport::Notifications` **propagates subscriber exceptions** through `instrument` (verified against AS 8.0), and the failure event fires *inside* the rescue block, *before* the failed `Result` is returned. An un-isolated call would let one raising adopter subscriber convert a captured per-tenant failure into an **unhandled raise out of `#run`** — breaking the non-raising contract. `instrument_failure` isolates the failure emission (logs via `warn`, does not propagate). The success path is left un-isolated by design (no hard no-raise guarantee there; swallowing would mask real subscriber bugs on the happy path).

## Polish (surfaced by an AI-panel review)

- **CLI message** now names the first 5 failed tenants (capped) + "and N more" — the low-context surface a monitor/CI-log tail captures even when the stdout summary is dropped. Full detail stays in the summary and the events.
- **rake `apartment:migrate`** now `rescue Thor::Error => e; abort(e.message)`, matching `apartment:drop`. `.new.invoke` bypasses Thor's `exit_on_failure?`, so a failure previously surfaced as a raw `rake aborted!` backtrace burying the message.
- **`docs/observability.md`** documents the event, notes `PoolObserver` does not forward migrate events (subscribe directly), and that failure subscribers must stay non-raising.

## Deliberately NOT done

A typed `Apartment::CLI::MigrationError < Thor::Error` exposing `#failures` was **considered and skipped**. The programmatic API for structured failures is already `Apartment::Migrator#run → MigrationRun#failed`; hanging domain data off a presentation-layer `Thor::Error` is the wrong layer, and the event delivers strictly more (per-failure, at the point of failure). Confirmed by a 4/5 AI-panel majority.

## Version

Bumps `4.0.0.alpha6 → alpha7` (new public instrumentation event) so the fix ships in a release.

## Tests

- Failing tenant migration **emits** `migrate_tenant_failed.apartment` with tenant + error + duration.
- Contract unchanged: failure still returns a failed `Result` and surfaces in `MigrationRun#failed`; emitted-event tenants equal `run.failed` tenants.
- Primary-migration failure emits the event and aborts the run.
- **Raising subscriber does not break the non-raising contract** (Result still returned/failed; warning logged).
- CLI raised message names failed tenants, capped at 5 with "and N more".

Full unit suite: **970 examples, 0 failures**. Rubocop clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011q1GpsjSmFxbeiJCeB2HuL