### PR TITLE
Release v4.0.0.alpha7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
   unit:
     name: Unit · Ruby ${{ matrix.ruby }} · Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    # Rails main is a canary: it tracks an unreleased edge and is allowed to
+    # fail. continue-on-error keeps a red main cell from failing the `unit` job,
+    # so it neither blocks the workflow nor flips needs.unit.result for ci-gate.
+    continue-on-error: ${{ matrix.rails == 'main' }}
     strategy:
       fail-fast: false
       matrix:
@@ -245,3 +249,34 @@ jobs:
         run: bundle exec rspec spec/integration/v4/ --format progress
         env:
           DATABASE_ENGINE: sqlite
+
+  # ── CI gate ────────────────────────────────────────────────────────
+  # Single aggregation check for branch protection: require just `ci-gate`
+  # rather than every matrix cell by name (which would break whenever the
+  # matrix changes and risk pinning the Rails-main canary). Passes only when
+  # every required job succeeded or was skipped — skipped happens only under a
+  # scoped workflow_dispatch, never on the pull_request events that gate merges.
+  # Job results arrive via env (not interpolated into run:) so the shell never
+  # evaluates workflow context directly.
+  ci-gate:
+    if: always()
+    needs: [unit, postgresql, mysql, sqlite]
+    runs-on: ubuntu-latest
+    env:
+      UNIT: ${{ needs.unit.result }}
+      POSTGRESQL: ${{ needs.postgresql.result }}
+      MYSQL: ${{ needs.mysql.result }}
+      SQLITE: ${{ needs.sqlite.result }}
+    steps:
+      - name: Require all CI jobs to have passed
+        run: |
+          failed=0
+          for job in UNIT POSTGRESQL MYSQL SQLITE; do
+            result="${!job}"
+            if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
+              echo "::error::Required CI job '$job' concluded '$result'"
+              failed=1
+            fi
+          done
+          if [ "$failed" -eq 0 ]; then echo "All required CI jobs passed."; fi
+          exit "$failed"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ This gem is a maintained fork of the original [Apartment gem](https://github.com
 - Rails 7.2+
 - PostgreSQL 14+, MySQL 8.4+, or SQLite3
 
+### Ruby version manager
+
+`.ruby-version` is the single source of truth for the local Ruby version (the
+same file `ruby/setup-ruby` reads in CI). Both [mise](https://mise.jdx.dev) and
+[rbenv](https://github.com/rbenv/rbenv) honor it — use whichever you prefer:
+
+```bash
+# mise (recommended)
+brew install mise                 # then add `eval "$(mise activate zsh)"` to ~/.zshrc
+mise trust && mise install        # one-time trust per clone, then install the pinned Ruby
+
+# rbenv (also works, unchanged)
+rbenv install "$(cat .ruby-version)"
+```
+
+The committed `mise.toml` carries settings only (never a version): it tells mise
+to honor `.ruby-version` without any per-developer global config. `mise trust`
+is required once per clone; `bin/dev/setup-worktree` handles it for new worktrees.
+
 ### Setup
 
 ```ruby

--- a/bin/dev/setup-worktree
+++ b/bin/dev/setup-worktree
@@ -76,6 +76,22 @@ cd "$WORKTREE_PATH" || { log_error "Failed to cd into $WORKTREE_PATH"; exit 1; }
 ABS_WORKTREE_PATH=$(pwd)
 
 # ---------------------------------------------------------------------------
+# mise trust
+# ---------------------------------------------------------------------------
+# mise refuses to apply an untrusted project config, keyed per absolute path,
+# so the committed mise.toml (which makes mise honor .ruby-version) is inert in
+# a fresh worktree until trusted. Trust it here so the developer's first `cd`
+# into the worktree applies the pin with no interactive prompt. No-op for rbenv
+# holdouts (mise absent) — rbenv reads .ruby-version directly and ignores this.
+if command -v mise >/dev/null 2>&1; then
+    if mise trust "$ABS_WORKTREE_PATH" >/dev/null 2>&1; then
+        log_info "mise: trusted $ABS_WORKTREE_PATH"
+    else
+        log_warn "mise: failed to trust $ABS_WORKTREE_PATH — run 'mise trust' there manually"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # Serena registration
 # ---------------------------------------------------------------------------
 # Two failure modes this prevents:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -24,6 +24,19 @@ All events are namespaced `<name>.apartment` and published through
 | `skip_evict.apartment` | When a candidate pool is skipped during eviction | `tenant:`, `reason:` (`:pinned`, `:in_use`), `eviction_reason:` (`:idle`, `:lru`, `:admission`); plus `busy_connections:` and `open_transactions:` when `reason: :in_use` |
 | `reaper_stopped.apartment` | When the background reaper is deactivated in the test environment | `reason:` (`:test_env`) |
 | `migrate_tenant.apartment` | After migrations run for one tenant | `tenant:`, `versions:` (array of migration version integers) |
+| `migrate_tenant_failed.apartment` | When a tenant (or the primary) migration raises | `tenant:`, `error:` (the raised exception), `duration:` (seconds) |
+
+> **`PoolObserver` does not forward the migrate events.** The observer below covers
+> pool-lifecycle events only; `migrate_tenant` / `migrate_tenant_failed` are not in
+> its counter set. Installing it alone does **not** close migration error tracking —
+> subscribe to `migrate_tenant_failed.apartment` directly. Keep that subscriber
+> non-raising: it runs inline on the migration thread (a worker thread under
+> parallel migration). A subscriber raising a `StandardError` is isolated by the
+> Migrator — logged and swallowed, not propagated (you lose that one notification,
+> not the run). Process-control exceptions (`SystemExit`, `Interrupt`) and bare
+> `Exception` subclasses are **not** swallowed and will surface. The **success**
+> event `migrate_tenant.apartment` is *not* isolated — a raising success subscriber
+> can still break the run — so keep both subscribers defensive.
 
 **`cap_unmet` fires on two paths:** from the synchronous admission path (when a
 new pool would breach the cap and no idle pool can be freed) and from the

--- a/lib/apartment/cli/migrations.rb
+++ b/lib/apartment/cli/migrations.rb
@@ -5,6 +5,13 @@ require 'thor'
 module Apartment
   class CLI < Thor
     class Migrations < Thor
+      # The raised Thor::Error message is the low-context surface a monitor or
+      # CI-log tail captures even when the stdout summary is dropped/unindexed.
+      # Name a few failed tenants there (capped, so a 600-tenant run does not
+      # produce a wall of text); the full per-tenant detail is in the summary
+      # and in the migrate_tenant_failed.apartment events.
+      FAILED_TENANTS_PREVIEW = 5
+
       def self.exit_on_failure? = true
 
       desc 'migrate [TENANT]', 'Run migrations for tenants'
@@ -62,7 +69,15 @@ module Apartment
         say(result.summary)
 
         trigger_schema_dump if result.success?
-        raise(Thor::Error, "Migration failed for #{result.failed.size} tenant(s)") unless result.success?
+        raise(Thor::Error, migration_failure_message(result.failed)) unless result.success?
+      end
+
+      def migration_failure_message(failures)
+        names = failures.map(&:tenant)
+        shown = names.first(FAILED_TENANTS_PREVIEW)
+        more = names.size - shown.size
+        suffix = more.positive? ? ", and #{more} more" : ''
+        "Migration failed for #{names.size} tenant(s): #{shown.join(', ')}#{suffix} (see summary above)"
       end
 
       # Rollback bypasses the Migrator's parallelism and Result tracking but

--- a/lib/apartment/instrumentation.rb
+++ b/lib/apartment/instrumentation.rb
@@ -3,8 +3,8 @@
 require 'active_support/notifications'
 
 module Apartment
-  # Thin wrapper around ActiveSupport::Notifications.
-  # Known events: create, drop, evict (all namespaced as *.apartment).
+  # Thin wrapper around ActiveSupport::Notifications. All events are namespaced
+  # *.apartment; see docs/observability.md for the authoritative event catalog.
   module Instrumentation
     def self.instrument(event, payload = {}, &block)
       event_name = "#{event}.apartment"

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -121,9 +121,15 @@ module Apartment
         duration: monotonic_now - start, error: nil, versions_run: versions
       )
     rescue StandardError => e
+      duration = monotonic_now - start
+      # Symmetric with the :migrate_tenant success event above: the gem holds the
+      # full structured error here, so emit it for subscribers rather than
+      # stranding it in the returned Result. See migrate_tenant's rescue.
+      instrument_failure(tenant_name, e, duration)
+
       Result.new(
         tenant: tenant_name, status: :failed,
-        duration: monotonic_now - start, error: e, versions_run: []
+        duration: duration, error: e, versions_run: []
       )
     end
 
@@ -166,9 +172,17 @@ module Apartment
         end
       end
     rescue StandardError => e
+      duration = monotonic_now - start
+      # Failure counterpart to the :migrate_tenant success event. On SUCCESS the
+      # gem instruments; on FAILURE it previously only returned a failed Result,
+      # leaving adopters no hook to observe the (structured) error. This closes
+      # that asymmetry — generic payload (tenant + error + duration); routing to
+      # an error tracker is the subscriber's job.
+      instrument_failure(tenant, e, duration)
+
       Result.new(
         tenant: tenant, status: :failed,
-        duration: monotonic_now - start, error: e, versions_run: []
+        duration: duration, error: e, versions_run: []
       )
     ensure
       Apartment::Current.migrating = false
@@ -240,6 +254,34 @@ module Apartment
       yield
     ensure
       conn.instance_variable_set(ADVISORY_LOCKS_IVAR, original) if conn&.instance_variable_defined?(ADVISORY_LOCKS_IVAR)
+    end
+
+    # Emit the failure event without letting a raising subscriber break the
+    # Migrator's non-raising contract: the failed Result MUST still be returned.
+    # ActiveSupport::Notifications propagates subscriber exceptions through
+    # instrument (verified against AS 8.0), and this fires from inside a rescue
+    # block, so an un-isolated call would convert a captured per-tenant failure
+    # into an unhandled raise out of #run.
+    #
+    # Scope of the guarantee: a subscriber raising a StandardError is swallowed
+    # and warned. Process-control exceptions (SystemExit, SignalException /
+    # Interrupt) are deliberately NOT rescued — they must propagate so exit and
+    # Ctrl-C still work mid-migration; a subscriber raising a bare Exception
+    # subclass is itself a bug (Ruby errors should descend from StandardError).
+    # The warn is nested-rescued so a broken $stderr (IOError is a StandardError)
+    # cannot re-escape the handler. Success-path instrumentation is left
+    # un-isolated by design — only the failure path carries the hard no-raise
+    # guarantee, and swallowing there would mask real subscriber bugs.
+    def instrument_failure(tenant, error, duration)
+      Instrumentation.instrument(:migrate_tenant_failed, tenant: tenant, error: error, duration: duration)
+    rescue StandardError => e
+      # Nested rescue: a sibling `rescue` on this method would NOT catch an
+      # exception raised by warn (a broken $stderr), so the warn gets its own.
+      begin
+        warn "[Apartment::Migrator] migrate_tenant_failed subscriber raised #{e.class}: #{e.message}"
+      rescue StandardError
+        nil
+      end
     end
 
     def monotonic_now

--- a/lib/apartment/tasks/v4.rake
+++ b/lib/apartment/tasks/v4.rake
@@ -34,6 +34,13 @@ namespace :apartment do
     else
       Apartment::CLI::Migrations.new.invoke(:migrate)
     end
+    # Parity with apartment:drop: `.new.invoke` bypasses Thor.start's
+    # exit_on_failure? handling, so an unrescued Thor::Error (raised on
+    # migration failure) would surface as a raw `rake aborted!` backtrace that
+    # buries the actionable message. abort re-emits it as a clean one-liner
+    # with a non-zero exit.
+  rescue Thor::Error => e
+    abort(e.message)
   end
 
   desc 'Seed all tenants'

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha6'
+  VERSION = '4.0.0.alpha7'
 end

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,28 @@
+# Project mise configuration.
+#
+# Enables mise's "idiomatic version file" support so `mise install` and
+# `mise activate`'s directory switching honor the checked-in `.ruby-version`
+# pin with NO per-developer global config. mise disables idiomatic files by
+# default, and this project setting REPLACES (does not merge with) any global
+# `idiomatic_version_file_enable_tools`.
+#
+# All three tools are listed deliberately even though this repo only pins ruby:
+# scoping the list to ruby alone would REPLACE a developer's global list and
+# silently stop honoring their .node-version / .python-version in this repo.
+# - ruby:   the pinned toolchain (see .ruby-version). Read by mise here and by
+#           rbenv for holdouts; both managers honor the same file.
+# - node:   listed for cross-repo consistency; no .node-version, so it no-ops.
+# - python: listed for cross-repo consistency; .python-version pins 3.13 for
+#           ad hoc tooling, otherwise harmless.
+#
+# The version lives in `.ruby-version`, not here, so a single `.ruby-version`
+# bump stays the one place to change Ruby — the same file `ruby/setup-ruby`
+# reads in CI. This file carries settings only, never a version.
+#
+# Trust: mise requires a one-time `mise trust` per clone/worktree before
+# applying this file. `bin/dev/setup-worktree` trusts new worktrees; for the
+# main clone run `mise trust && mise install` once (see README).
+#
+# rbenv is unaffected — it reads `.ruby-version` directly and ignores this file.
+[settings]
+idiomatic_version_file_enable_tools = ["node", "ruby", "python"]

--- a/spec/unit/cli/migrations_spec.rb
+++ b/spec/unit/cli/migrations_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe(Apartment::CLI::Migrations) do
     $stdout = STDOUT
   end
 
+  it 'exposes only migrate and rollback as Thor commands (helpers stay private)' do
+    # Thor registers public instance methods as commands. Locks migrate_all /
+    # migration_failure_message under `private` so a future refactor that moves
+    # one above `private` doesn't silently expose it as `apartment:...`.
+    expect(described_class.commands.keys).to(include('migrate', 'rollback'))
+    expect(described_class.commands.keys).not_to(include('migrate_all', 'migration_failure_message'))
+  end
+
   describe 'migrate' do
     let(:migration_run) do
       Apartment::Migrator::MigrationRun.new(
@@ -100,6 +108,28 @@ RSpec.describe(Apartment::CLI::Migrations) do
         )
         allow(Apartment::Migrator).to(receive(:new).and_return(double(run: failed_run)))
         expect { run_command('migrate') }.to(raise_error(SystemExit))
+      end
+
+      it 'names failed tenants (capped) in the raised error message' do
+        failures = (1..8).map do |i|
+          Apartment::Migrator::Result.new(
+            tenant: "tenant_#{i}", status: :failed, duration: 0.1,
+            error: StandardError.new('boom'), versions_run: []
+          )
+        end
+        run = Apartment::Migrator::MigrationRun.new(results: failures, total_duration: 1.0, threads: 4)
+
+        cmd = described_class.new
+        allow(Apartment::Migrator).to(receive(:new).and_return(double(run: run)))
+        allow(cmd).to(receive(:say))
+        allow(cmd).to(receive(:trigger_schema_dump))
+
+        expect { cmd.send(:migrate_all) }.to(raise_error(Thor::Error)) do |error|
+          expect(error.message).to(include('Migration failed for 8 tenant(s)'))
+          expect(error.message).to(include('tenant_1, tenant_2, tenant_3, tenant_4, tenant_5'))
+          expect(error.message).to(include('and 3 more'))
+          expect(error.message).not_to(include('tenant_6'))
+        end
       end
     end
 

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -258,6 +258,129 @@ RSpec.describe(Apartment::Migrator) do
     end
   end
 
+  describe 'failure instrumentation' do
+    # The success path instruments :migrate_tenant; failures must be symmetric so
+    # an adopter can subscribe to them and route the structured error (tenant +
+    # exception) to their error tracker, instead of it being stranded on stdout.
+    # These use real ActiveSupport::Notifications (no Instrumentation stub) and
+    # also assert the Migrator's non-raising return contract is unchanged.
+    let(:mock_migration_context) { instance_double('ActiveRecord::MigrationContext') }
+    let(:mock_pool) { instance_double('ActiveRecord::ConnectionAdapters::ConnectionPool') }
+    let(:mock_connection) { double('connection') }
+
+    before do
+      allow(ActiveRecord::Base).to(receive_messages(connection_pool: mock_pool, lease_connection: mock_connection))
+      allow(mock_connection).to(receive(:instance_variable_get).and_return(true))
+      allow(mock_connection).to(receive(:instance_variable_set))
+      allow(mock_connection).to(receive(:instance_variable_defined?)
+        .with(:@advisory_locks_enabled).and_return(true))
+      allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
+      allow(mock_migration_context).to(receive(:needs_migration?).and_return(true))
+      allow(Apartment::Tenant).to(receive(:switch)) { |_tenant, &block| block.call }
+    end
+
+    it 'emits migrate_tenant_failed.apartment with tenant, error, and duration when a tenant migration fails' do
+      boom = StandardError.new('boom')
+      allow(mock_migration_context).to(receive(:migrate).and_raise(boom))
+
+      events = []
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| events << e }
+
+      described_class.new(threads: 0).send(:migrate_tenant, 'acme')
+
+      expect(events.size).to(eq(1))
+      payload = events.first.payload
+      expect(payload[:tenant]).to(eq('acme'))
+      expect(payload[:error]).to(be(boom))
+      expect(payload[:duration]).to(be_a(Numeric))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
+    it 'still returns a failed Result and surfaces in MigrationRun#failed (contract unchanged)' do
+      call_count = 0
+      allow(mock_migration_context).to(receive(:migrate)) do
+        call_count += 1
+        raise(StandardError, 'boom') if call_count == 2
+
+        []
+      end
+
+      failed_events = []
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| failed_events << e }
+
+      run = described_class.new(threads: 0).run
+
+      expect(run.failed.size).to(eq(1))
+      expect(run.results.size).to(eq(3))
+      expect(failed_events.map { |e| e.payload[:tenant] }).to(eq(run.failed.map(&:tenant)))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
+    it 'does not let a raising subscriber break the non-raising contract' do
+      # ActiveSupport::Notifications propagates subscriber exceptions through
+      # instrument, and the failure event fires inside migrate_tenant's rescue
+      # block. Without isolation, a raising subscriber would turn a captured
+      # per-tenant failure into an unhandled raise out of the Migrator.
+      allow(mock_migration_context).to(receive(:migrate).and_raise(StandardError, 'boom'))
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { raise('subscriber blew up') }
+
+      migrator = described_class.new(threads: 0)
+      allow(migrator).to(receive(:warn))
+
+      result = nil
+      expect { result = migrator.send(:migrate_tenant, 'acme') }.not_to(raise_error)
+      expect(result.status).to(eq(:failed))
+      expect(result.error.message).to(eq('boom'))
+      expect(migrator).to(have_received(:warn).with(/subscriber raised/i))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
+    it 'emits the failure event from worker threads on the parallel path' do
+      # The production path is parallel; a subscriber's StandardError here must
+      # not pollute run_parallel's fatal_errors (which would make #run raise),
+      # and the event must still fire from the worker thread. Primary runs first
+      # (sequential) and succeeds; the failure is one of the two parallel tenants.
+      call_count = Concurrent::AtomicFixnum.new(0)
+      allow(mock_migration_context).to(receive(:migrate)) do
+        raise(StandardError, 'boom') if call_count.increment == 2
+
+        []
+      end
+
+      events = Concurrent::Array.new
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| events << e }
+
+      run = described_class.new(threads: 2).run
+
+      expect(run.failed.size).to(eq(1))
+      expect(events.size).to(eq(1))
+      expect(events.first.payload[:error]).to(be_a(StandardError))
+      expect(events.first.payload[:tenant]).to(eq(run.failed.first.tenant))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+
+    it 'emits migrate_tenant_failed.apartment when the primary migration fails' do
+      allow(mock_migration_context).to(receive(:migrate).and_raise(StandardError, 'db down'))
+
+      events = []
+      ActiveSupport::Notifications.subscribe('migrate_tenant_failed.apartment') { |e| events << e }
+
+      run = described_class.new(threads: 0).run
+
+      # Primary failure aborts the run, so exactly one failed event (the primary).
+      expect(events.size).to(eq(1))
+      expect(events.first.payload[:tenant]).to(eq('public'))
+      expect(events.first.payload[:error]).to(be_a(StandardError))
+      expect(run.results.map(&:status)).to(eq([:failed]))
+    ensure
+      ActiveSupport::Notifications.unsubscribe('migrate_tenant_failed.apartment')
+    end
+  end
+
   describe '#migrate_tenant Current.migrating lifecycle' do
     let(:mock_pool) { double('pool', migration_context: double(needs_migration?: false)) }
 


### PR DESCRIPTION
Publishes **v4.0.0.alpha7** to RubyGems. Merging this PR pushes `main` onto `4-0-alpha`, triggering `gem-publish.yml` → `rake release` (tags `v4.0.0.alpha7`, publishes via trusted publishing).

## ⚠️ Merge with a **merge commit** — never squash/rebase
`4-0-alpha` tracks `main`; a squash diverges history and breaks the release-notes generator (see RELEASING.md).

## Ships since v4.0.0.alpha6 (3 commits)
- **#463** Feat(v4): instrument tenant-migration failures + isolated emission — new `migrate_tenant_failed.apartment` notification (`{ tenant:, error:, duration: }`) emitted symmetrically on failure; subscriber-exception isolation preserves the Migrator's non-raising contract; capped CLI failure message; rake `apartment:migrate` abort parity.
- **#462** Chore: adopt mise for local Ruby (dev tooling; no gem-runtime change)
- **#461** CI: ci-gate aggregation job (`.github/` only; not in the published gem)

Headline for adopters: **subscribe to `migrate_tenant_failed.apartment`** to route per-tenant migration failures to your error tracker (see `docs/observability.md`).

## After merge
1. Confirm live: `gem list -r --prerelease ros-apartment`
2. Create the GitHub Release from the `v4.0.0.alpha7` tag ("Set as a pre-release"), highlighting the new failure event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011q1GpsjSmFxbeiJCeB2HuL