### PR TITLE
Docs(v4): note migrate_tenant.apartment also fires for the primary

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,7 +23,7 @@ All events are namespaced `<name>.apartment` and published through
 | `cap_unmet.apartment` | When the pool cap cannot be met by eviction (soft-cap breach) | `max_total:`, `current:`, `unevicted:` |
 | `skip_evict.apartment` | When a candidate pool is skipped during eviction | `tenant:`, `reason:` (`:pinned`, `:in_use`), `eviction_reason:` (`:idle`, `:lru`, `:admission`); plus `busy_connections:` and `open_transactions:` when `reason: :in_use` |
 | `reaper_stopped.apartment` | When the background reaper is deactivated in the test environment | `reason:` (`:test_env`) |
-| `migrate_tenant.apartment` | After migrations run for one tenant | `tenant:`, `versions:` (array of migration version integers) |
+| `migrate_tenant.apartment` | After migrations run for one tenant (or the primary) | `tenant:`, `versions:` (array of migration version integers) |
 | `migrate_tenant_failed.apartment` | When a tenant (or the primary) migration raises | `tenant:`, `error:` (the raised exception), `duration:` (seconds) |
 
 > **`PoolObserver` does not forward the migrate events.** The observer below covers


### PR DESCRIPTION
One-line doc accuracy fix in the observability event catalog.

`migrate_tenant.apartment`'s "When fired" cell said "After migrations run for one tenant", but `Migrator#migrate_primary` emits the same event on primary success ([`migrator.rb:117`](https://github.com/rails-on-services/apartment/blob/main/lib/apartment/migrator.rb#L117)) — just like the failure event `migrate_tenant_failed.apartment`, whose row already reads "(or the primary)". Added "(or the primary)" so the success and failure rows are symmetric and match the code.

Pre-existing drift (not introduced by alpha7); surfaced while verifying the alpha7 failure-event documentation. Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011q1GpsjSmFxbeiJCeB2HuL