### PR TITLE
Feat(v4): honest pool connection-budget knobs (max_tenant_pools / max_tenant_connections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,19 @@ All options are set in `config/initializers/apartment.rb` inside an `Apartment.c
 
 ### Pool Settings
 
-`tenant_pool_size`: max connections per tenant pool. Default `nil` — each tenant pool inherits the app's base pool size (`DB_POOL_SIZE` / `pool:` in `database.yml`). Set it to size tenant pools independently of the app pool (e.g. to bound total connections across many schema-per-tenant pools).
+`tenant_pool_size`: max connections per tenant pool. Default `nil` — each tenant pool inherits the app's base pool size (`DB_POOL_SIZE` / `pool:` in `database.yml`). **Set it to at least the peak number of threads/fibers in one process that can touch the _same_ tenant at once** (e.g. a Sidekiq role's concurrency for a same-tenant job fan-out); a smaller pool makes those threads block on connection checkout. It is a lazy ceiling — connections are created on demand and idle pools are reaped — so sizing for peak does not hold that many connections open at steady state.
 
 `pool_idle_timeout`: seconds an idle tenant pool must exceed before it is eligible for reaping (default: 300).
 
 `reaper_interval`: seconds between background reap passes. Default `nil` — derives from `pool_idle_timeout`. Set it lower to reap more often without shrinking the idle window.
 
-`max_total_connections`: ceiling on the number of live tenant pools; `nil` for unlimited (default: `nil`). Enforced synchronously at pool-creation time (see `pool_overflow_policy`) and trimmed continuously by the background reaper. Total backend connections ≈ `max_total_connections × tenant_pool_size`.
+`max_tenant_pools`: ceiling on the number of live tenant pools per process; `nil` for unlimited (default: `nil`). Enforced synchronously at pool-creation time (see `pool_overflow_policy`) and trimmed continuously by the background reaper.
 
-`pool_overflow_policy`: behavior when a new pool would breach `max_total_connections` and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
+`max_tenant_connections`: ceiling on total *tenant-pool* connections per process (default: `nil`); requires `tenant_pool_size`. The admission controller derives the pool budget as `floor(max_tenant_connections / tenant_pool_size)`. Per-process tenant-pool connections ≈ `effective_pool_budget × tenant_pool_size`, where `effective_pool_budget = min(max_tenant_pools, floor(max_tenant_connections / tenant_pool_size))`; the default pool and any separate pinned pool are additional. A tenant using multiple roles (e.g. `writing` + `reading`) holds one pool per role (`tenant:role` keys), counting once per role against the budget. For a hard external-pooler budget, pair this with `pool_overflow_policy: :raise` (the ceiling is soft under the default `:evict_idle`).
+
+`max_total_connections`: **deprecated** (removed in v5) — it capped tenant-pool *count*, not connections. It now aliases `max_tenant_pools`; rename it. For a true connection ceiling, set `max_tenant_connections`.
+
+`pool_overflow_policy`: behavior when a new pool would breach the pool budget (`max_tenant_pools` / `max_tenant_connections`) and every existing pool is pinned or in use (no idle pool to evict). `:evict_idle` (default) — allow the new pool, emit a `cap_unmet` notification (soft cap, prioritizes availability). `:raise` — raise `Apartment::PoolCapacityReached` (hard cap, sheds load). When an idle pool *is* available it is always evicted inline regardless of policy. See `docs/designs/pool-admission-control.md`.
 
 `reap_in_test`: keep the background reaper running under `Rails.env.test?` (default `false` — the Railtie stops it in test, where fixture transactions make mid-example eviction a liability). Set `true` if a deployed process can run under test-env semantics and must keep reaping — that's cleaner than guarding `RAILS_ENV` at boot to avoid silently leaking connections. It applies to *every* `Rails.env.test?` process, including CI, so enable it only when a real deployment needs it.
 

--- a/docs/designs/pool-admission-control.md
+++ b/docs/designs/pool-admission-control.md
@@ -12,6 +12,13 @@ before establishing the new one. When no pool can be evicted (all pinned/in-use)
 emit `:cap_unmet`) or **`:raise`** (`PoolCapacityReached`, hard fail). The reaper keeps
 running as the steady-state trimmer.
 
+> **Naming update.** The cap knob is now `max_tenant_pools` (with `max_total_connections`
+> deprecated as its alias, removed in v5), and a connection ceiling `max_tenant_connections`
+> derives a pool budget on top of it. The bound this document calls `max_total` is
+> `Config#effective_pool_budget` = `min(max_tenant_pools, floor(max_tenant_connections /
+> tenant_pool_size))`. See [`pool-connection-budget.md`](pool-connection-budget.md). The
+> admission mechanism below is unchanged — only the knob names and the derived bound differ.
+
 ## Problem
 
 `PoolManager#fetch_or_create` uses `Concurrent::Map#compute_if_absent`: a new tenant
@@ -121,7 +128,7 @@ silent drop. `:evict_idle` (default) never fails a request.
 ## Configuration
 
 - `pool_overflow_policy` — `:evict_idle` (default) or `:raise`. Only meaningful with
-  `max_total_connections` set.
+  a pool budget set (`max_tenant_pools` / `max_tenant_connections`).
 
 ## Scope / out of scope
 

--- a/docs/designs/pool-connection-budget.md
+++ b/docs/designs/pool-connection-budget.md
@@ -1,0 +1,287 @@
+# Pool Connection Budget + Checkout-Pressure Observability
+
+## TLDR
+
+`max_total_connections` is misnamed: it bounds **pool count**, not connections. `admit!`
+checks `stats[:total_pools] < @max_total` ([pool_reaper.rb](../../lib/apartment/pool_reaper.rb)),
+so the real per-process ceiling is `pool_count × tenant_pool_size`. An adopter who set
+`max_total_connections: 8` at `tenant_pool_size: 2` got a true ceiling of 16 connections, not 8.
+A separate v4 property surfaced the same week: a same-tenant job fan-out concentrates on **one**
+small tenant pool and starves it (checkout timeouts), where v3's shared pool absorbed it.
+
+Three changes, none touching the tenant data path or isolation — this is capacity, ergonomics,
+and honesty:
+
+1. **Honest connection-budget knobs** — split the one lying knob into `max_tenant_pools`
+   (pool-count cap) and `max_tenant_connections` (a true tenant-pool connection ceiling);
+   deprecate `max_total_connections` as an alias of `max_tenant_pools`. The admission seam
+   enforces `min(max_tenant_pools, floor(max_tenant_connections / tenant_pool_size))`.
+2. **Sizing + ceiling docs** — the rule `tenant_pool_size ≥ peak same-tenant per-process
+   concurrency`, the true ceiling formula, and the lazy-allocation clarification.
+3. **Checkout-pressure observability** — extend the opt-in `PoolObserver` gauge sampler with
+   `pools_waiting`, `pools_saturated`, and `max_checkout_waiting` so same-tenant starvation is a
+   metric, not a multi-hour debug.
+
+Validated by a five-model panel (Codex, Gemini, Cursor, Mistral, Bedrock/DeepSeek): unanimous on
+the naming split, on `derive + min` as the minimal correct enforcement at a pool-count seam, and
+on shipping gauges now while deferring an AR-checkout monkeypatch.
+
+## Contents
+
+- [Background](#background)
+- [Item 1 — honest connection-budget knobs](#item-1--honest-connection-budget-knobs)
+- [Item 2 — sizing and ceiling documentation](#item-2--sizing-and-ceiling-documentation)
+- [Item 3 — checkout-pressure observability](#item-3--checkout-pressure-observability)
+- [Testing](#testing)
+- [Scope and non-goals](#scope-and-non-goals)
+- [Alternatives considered](#alternatives-considered)
+
+## Background
+
+### The name lies once pool size exceeds 1
+
+v4 is pool-per-tenant: each `tenant:role` key gets its own ActiveRecord connection pool sized to
+`tenant_pool_size`, with `search_path` baked into the config. A background admission controller
+(`PoolReaper`, wired when a cap is configured) bounds how many pools exist per process. That bound
+is **pool count** — `admit!` and the timer LRU path both compare `stats[:total_pools]` against
+`@max_total`. The knob feeding it is named `max_total_connections`. So the number an adopter reads
+as a connection ceiling is actually a pool ceiling; the real connection ceiling is
+`pool_count × tenant_pool_size` and is invisible in the config. See
+[pool-admission-control.md](pool-admission-control.md) for the admission mechanism this builds on.
+
+### Same-tenant fan-out starves one pool
+
+A Sidekiq role (concurrency ~5) received a fan-out of dozens of jobs for a **single** tenant. Each
+job leased a connection from that one tenant's pool. With `tenant_pool_size: 2`, three threads
+blocked on checkout and hit the 5s `ConnectionTimeoutError`; the reaper's `skip_evict(in_use)`
+fired because the pool was mid-transaction and could not be evicted. DB headroom stayed ample —
+this was intra-pool checkout contention, not a connection-count problem. v3's shared thread-local
+pool absorbed the same fan-out because every thread drew from one large shared pool; v4 partitions
+per tenant, so a same-tenant burst concentrates on one small pool. This is the pool-per-tenant
+model doing exactly what it says (isolation moves contention into the tenant's own pool), not a
+regression — but the safe `tenant_pool_size` was undocumented and the default too small for a
+fan-out workload.
+
+The admission cap does **not** address this incident: `total_pools` was 1. Intra-pool starvation
+is purely `tenant_pool_size` versus same-tenant process concurrency (Item 2). Items 1 and 3 make
+the connection budget honest and the pressure visible; Item 2 states the rule that actually
+prevents the starvation.
+
+## Item 1 — honest connection-budget knobs
+
+### Three keys
+
+| Key | Meaning | Status |
+|---|---|---|
+| `max_tenant_pools` | Pool-count cap. Exactly today's `max_total_connections` behavior, renamed. | New |
+| `max_tenant_connections` | True **tenant-pool** connection ceiling. The primary safety knob. | New |
+| `max_total_connections` | Deprecated alias of `max_tenant_pools` (its current pool-count meaning). | Deprecated; removed in v5 |
+
+The `tenant_` prefix is deliberate: the ceiling bounds only tenant-pool connections. The default
+(primary) pool and an optional separate pinned pool are additional, small, and fixed — the name
+says `tenant`, so excluding them is honest rather than a footnote.
+
+### Derive + min
+
+Admission enforces a single **effective pool budget**, the stricter of whichever knobs are set:
+
+```
+effective_pool_budget = [
+  max_tenant_pools,                                   # if set
+  (max_tenant_connections / tenant_pool_size).floor   # if max_tenant_connections set
+].compact.min          # neither set → nil → uncapped (current lock-free fast path)
+```
+
+With a global `tenant_pool_size` (every tenant pool the same size), max tenant-pool connections
+`≤ effective_pool_budget × tenant_pool_size ≤ max_tenant_connections`. Because the admission seam
+only sees pool creation — never per-connection checkout — a derived pool budget is the only hard
+connection ceiling enforceable there. `floor` is conservative on purpose: `ceil` would over-admit
+past the connection budget.
+
+### Derivation lives in `Apartment.configure`, not the reaper
+
+`@max_total` feeds two reaper paths — `admit!` (synchronous admission) and the timer LRU eviction
+(`evict_lru`, `excess = total - @max_total`). Rather than teach both about two knobs, compute
+`effective_pool_budget` once at wiring time and pass the reaper a single number via its existing
+`max_total:` constructor argument. Both paths then enforce the same derived bound automatically,
+and `PoolReaper` stays agnostic about the knobs. Expose the computation as
+`Config#effective_pool_budget` so it is unit-testable in isolation and `Apartment.configure` simply
+reads it.
+
+### Validation (`Config#validate!`)
+
+- `max_tenant_pools` — positive integer or `nil` (mirrors the current `max_total_connections`
+  check).
+- `max_tenant_connections` — positive integer or `nil`.
+- `max_tenant_connections` set but `tenant_pool_size` `nil` → `ConfigurationError`. Without a known
+  per-pool size the pool budget cannot be derived (`tenant_pool_size: nil` means "inherit the base
+  pool size," which is not knowable at config-validation time).
+- `max_tenant_connections < tenant_pool_size` → `ConfigurationError`. Otherwise
+  `floor(ceiling / size)` is 0 and the admission controller would reject every tenant pool
+  permanently. Evaluate after `apply_defaults!` so any derived values are in place.
+- `max_total_connections` **and** `max_tenant_pools` both explicitly set and unequal →
+  `ConfigurationError`. They are the same concept under two names; an unequal double-spec is
+  ambiguous, so fail loudly rather than silently pick one. The check reads the user-provided values
+  and runs *after* the alias step (below), which only fills `max_tenant_pools` when it was unset —
+  so a lone `max_total_connections` leaves the two equal and passes, while an explicit unequal pair
+  still differs and raises.
+
+### Deprecation and migration
+
+When `max_total_connections` is set, emit a one-time deprecation warning naming its replacement,
+and alias it to `max_tenant_pools` (its **current** pool-count meaning — no behavior change). An
+existing `max_total_connections: 8` keeps meaning "8 pools." Normalize this during config load
+(in the mutating `apply_defaults!` step, before the read-only `validate!`) so `max_tenant_pools`
+is the single source of truth afterward. **Alias only when `max_tenant_pools` is unset** — never
+overwrite an explicit value — so the both-set-unequal guard above can still fire on a genuine
+double-spec. Removal is scheduled for v5, matching
+the existing `excluded_models` deprecation pattern. The gem is pre-beta (alpha) with one test-only
+adopter, so the migration cost is a warning and a rename; the clarity gain is permanent. This
+deliberately avoids repurposing `max_total_connections` to mean connections — that would change an
+existing key's production behavior under the same spelling (see
+[Alternatives](#alternatives-considered)).
+
+### Honesty scope and its limits (documented, not hidden)
+
+- **`tenant:role` pools.** Pool keys are `tenant:role`, so a pool is per tenant-role. One tenant
+  using `writing` + `reading` roles holds two pools. `max_tenant_pools` caps tenant-role pools;
+  the ceiling formula multiplies accordingly. Docs must say "pools," not "tenants."
+- **Soft cap under `:evict_idle`.** When every pool is pinned or in use, `admit!` admits anyway and
+  emits `:cap_unmet` (the existing behavior). The connection ceiling is then also soft. Adopters
+  who need a hard ceiling set `pool_overflow_policy: :raise`.
+- **Excluded pools.** The default pool and any separate pinned pool sit outside the tenant ceiling.
+
+## Item 2 — sizing and ceiling documentation
+
+The sizing rule is the actual fix for the starvation incident and cannot be validated at config
+time (peak concurrency is runtime-dependent), so it must be documented prominently.
+
+### The sizing rule
+
+> `tenant_pool_size ≥ peak same-tenant per-process concurrency` — the maximum number of threads or
+> fibers in one process that can touch the **same** tenant pool at once. For a Sidekiq role that is
+> its `concurrency`; for a fan-out of same-tenant jobs on one role, it is that role's concurrency.
+
+Explain the v3→v4 shift: v3's shared pool spread a same-tenant burst across one large pool; v4
+concentrates it on that tenant's own pool. Recommend the application-level mitigations too (job
+batching / concurrency-limit middleware) — a same-tenant thundering herd is an application pattern,
+not a framework bug — with sizing as the gem-level lever.
+
+### The true ceiling formula
+
+```
+tenant_pool_connections ≤ effective_pool_budget × tenant_pool_size
+total_process_connections ≈ (effective_pool_budget × tenant_pool_size) + default_pool + pinned_pool
+where effective_pool_budget = min(max_tenant_pools, floor(max_tenant_connections / tenant_pool_size))
+```
+
+Include a worked example spanning both knobs and a multi-role tenant.
+
+### Required notes
+
+- **Lazy ceiling, not reservation.** `tenant_pool_size` is an upper bound; AR creates connections
+  on demand and the reaper evicts idle pools. Sizing for peak does **not** hold that many
+  connections open at steady state. This directly answers the adopter's likely fear that
+  "`tenant_pool_size: 5` means five open connections forever."
+- **Pessimism of the derived budget.** `floor(ceiling / size)` assumes every admitted pool is
+  saturated. An oversized `tenant_pool_size` therefore reduces the number of concurrent tenants the
+  budget allows — a real tradeoff to state.
+- **`:raise` for hard budgets.** Adopters sizing an external pooler (PgBouncer / RDS Proxy) to
+  `max_tenant_connections` should pair it with `pool_overflow_policy: :raise` if they cannot
+  tolerate the soft-overflow transient.
+
+### Documentation locations
+
+`README` / config reference, `pool-admission-control.md` (the knob rename), `upgrading-to-v4.md`
+(the deprecation), `lib/apartment/CLAUDE.md`, and `v4-connection-model-rationale.md`.
+
+## Item 3 — checkout-pressure observability
+
+Extend `PoolObserver#sample!`. Today it emits `tenant_pools_live` (and an optional adopter
+`backend_connections`) on a `Concurrent::TimerTask`, forwarding `Sample`s to a caller sink. Add a
+per-tenant-pool walk that reads each pool's AR `ConnectionPool#stat` and emits **low-cardinality
+gauges**:
+
+| Gauge | Kind | Value |
+|---|---|---|
+| `pools_waiting` | gauge | Count of tenant pools with `stat[:waiting] > 0` (threads blocked on checkout) |
+| `pools_saturated` | gauge | Count of tenant pools with `busy >= size` |
+| `max_checkout_waiting` | gauge | The single largest `waiting` across pools this tick |
+
+`pools_waiting` is the direct starvation signal — it is exactly what was non-zero during the
+incident (the writer pool had `waiting = 3`). The walk is O(pools), which is cheap because pool
+count is bounded by the admission cap.
+
+### Cardinality: tenant in payload, not a metric dimension
+
+`max_checkout_waiting` carries the offending tenant, but in the `Sample#payload` (for log/debug
+sinks), **not** as a metric dimension by default. A gauge whose dimension **value** churns every
+tick — a different worst tenant each sample — produces unbounded time-series in CloudWatch/StatsD.
+A tenant-labeled dimension is available as a documented, opt-in high-cardinality mode. The
+aggregate gauges are dimensionless.
+
+### Sampling is a pressure indicator, not a timeout counter
+
+`stat[:waiting]` is **instantaneous**, not peak-held, so a short episode can fall between samples;
+timer alignment means even a 5s interval can miss a 5s episode. The gauge reliably surfaces
+**sustained** pressure (a fan-out lasting seconds) but is not lossless timeout accounting. Docs
+recommend a short `sample_interval` (5–10s) on job/worker roles, keeping web at the default if
+desired, and state this limitation plainly.
+
+### Deferred: discrete checkout-timeout event
+
+A lossless per-timeout event would require monkeypatching
+`ActiveRecord::ConnectionAdapters::ConnectionPool#checkout` across Rails 7.2 / 8.0 / 8.1 / main,
+where the pool internals and `stat` shape already vary. That maintenance cost is not justified by
+current evidence, and standard APM already captures the resulting `ConnectionTimeoutError`. Revisit
+only if an adopter needs lossless incident accounting that sampling cannot provide.
+
+## Testing
+
+- **Config / derivation:** `effective_pool_budget` returns the `min` over set knobs; `nil` when
+  neither is set; `floor` rounding; the deprecation alias maps `max_total_connections` →
+  `max_tenant_pools`; the one-time warning fires once.
+- **Validation:** `max_tenant_connections` without `tenant_pool_size` raises; `max_tenant_connections
+  < tenant_pool_size` raises; `max_total_connections` + `max_tenant_pools` unequal raises;
+  positive-integer-or-nil checks on both new knobs.
+- **Admission wiring:** with `max_tenant_connections` set, the reaper receives the derived budget;
+  both `admit!` and the LRU path enforce it; the count stays `≤ effective_pool_budget` across a
+  create fan-out with idle pools. Reuses the existing admission-control specs with the derived
+  bound.
+- **Observability:** `sample!` emits `pools_waiting` / `pools_saturated` / `max_checkout_waiting`
+  with correct counts against constructed pool stats; the tenant appears in `payload`, not
+  `dimensions`, by default; the sampler stays error-isolated (a raising `#stat` does not break the
+  pass).
+
+## Scope and non-goals
+
+**Phasing** (settled in the implementation plan): likely (1) Item 1 knobs + validation + derivation
++ deprecation; (2) Item 2 docs — may share the Item 1 PR since the docs describe the knobs; (3)
+Item 3 observability, separable.
+
+**Non-goals:**
+
+- **Live cross-pool connection counting.** Enforcing a connection ceiling by summing active
+  connections at admission would need a different seam (per-checkout throttle) and severe lock
+  contention. `derive + min` is the minimal correct transform given a fixed pool size.
+- **`:block` overflow policy.** Already deferred in [pool-admission-control.md](pool-admission-control.md).
+- **Per-tenant dynamic pool sizing / shared-overflow / hybrid shared-pool mode.** These fight the
+  pool-per-tenant model (which exists for fiber safety, PgBouncer transaction-mode compatibility,
+  and no thread-local tenant leakage). The incident is a consequence of that model, addressed by
+  sizing and visibility — not by blurring tenant pools again.
+- **W4 / libpq `options`.** Separate, docs-only (see the beta-readiness roadmap).
+
+## Alternatives considered
+
+- **(A) Repurpose `max_total_connections` to mean connections.** Rejected (panel: Codex p≈0.17,
+  Cursor p≈0.12, all five preferred B). It changes an existing key's production behavior under the
+  same spelling — the most dangerous form of the very ambiguity this work removes. Example:
+  `max_total_connections: 20` at `tenant_pool_size: 5` silently drops from 20 pools to 4 on upgrade,
+  causing eviction thrash. Alpha status encodes the ambiguity rather than removing it.
+- **Independent runtime caps (pool count AND live connection count).** Rejected — needs live
+  connection accounting under the admission lock; with a global `tenant_pool_size` it collapses to
+  `derive + min` anyway.
+- **Discrete checkout-timeout event now.** Deferred (see Item 3) — AR-version-fragile monkeypatch
+  not justified by current evidence.
+- **Longer literal name `max_tenant_connection_pools`.** Considered (Codex) for precision about
+  `tenant:role` pools; rejected in favor of `max_tenant_pools` plus a docs note, for brevity.

--- a/docs/designs/v4-connection-model-rationale.md
+++ b/docs/designs/v4-connection-model-rationale.md
@@ -155,11 +155,18 @@ The gem ships the mechanisms to bound it (all cross-linked, not restated here):
 
 - **`tenant_pool_size`** — cap connections per tenant pool; injected into each pool's
   config (`AbstractAdapter#apply_tenant_pool_size`). Defaults to `nil` (Rails' own
-  default applies) for back-compat.
-- **`max_total_connections` + synchronous admission control** — a hard-ish ceiling on
-  total pools: a cold create at capacity evicts the LRU idle pool inline before
-  establishing the new one, with `pool_overflow_policy` (`:evict_idle` soft cap /
-  `:raise` hard cap) governing the all-busy case. See
+  default applies) for back-compat. Must be ≥ the peak same-tenant per-process
+  concurrency, or a same-tenant fan-out starves the pool on checkout; it is a lazy
+  ceiling, so sizing for peak does not hold that many connections open at steady state.
+- **`max_tenant_pools` / `max_tenant_connections` + synchronous admission control** —
+  a hard-ish ceiling: `max_tenant_pools` caps live pool count directly, `max_tenant_connections`
+  caps tenant-pool connections and is enforced as the derived pool budget
+  `floor(max_tenant_connections / tenant_pool_size)` (`Config#effective_pool_budget` takes
+  the stricter of the two). A cold create at capacity evicts the LRU idle pool inline
+  before establishing the new one, with `pool_overflow_policy` (`:evict_idle` soft cap /
+  `:raise` hard cap) governing the all-busy case. (`max_total_connections` is the
+  deprecated alias of `max_tenant_pools`.) See
+  [`pool-connection-budget.md`](pool-connection-budget.md) and
   [`pool-admission-control.md`](pool-admission-control.md).
 - **`PoolReaper`** — background idle + LRU eviction so cold tenants don't hold pools
   forever (`lib/apartment/pool_reaper.rb`); reap cadence is decoupled from the idle

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -147,6 +147,20 @@ Apartment::PoolObserver::Sample
 `PoolManager#stats[:total_pools]`), `:backend_connections` (`value` = your
 `backend_count` callable result; omitted when the callable returns `nil`).
 
+**Checkout-pressure gauges** (per pass, from each tenant pool's AR
+`ConnectionPool#stat`): `:pools_waiting` (count of pools with threads blocked on
+checkout — the same-tenant fan-out starvation signal), `:pools_saturated` (count
+with `busy >= size`), and `:max_checkout_waiting` (the worst pool's `waiting`
+count). The offending tenant is carried in `:max_checkout_waiting`'s **payload**,
+not as a metric dimension, to avoid unbounded time-series churn — promote it to a
+dimension only in a sink you know can absorb the cardinality.
+
+These gauges are sampled **instantaneously** (not peak-held), so a short
+starvation episode can fall between passes. Use a short `sample_interval` (5–10s)
+on Sidekiq/job roles to catch sustained same-tenant fan-out; keep web at the
+default if desired. They show *pressure*, not lossless timeout accounting —
+standard APM captures the resulting `ActiveRecord::ConnectionTimeoutError` itself.
+
 **Dimensions** are curated for cardinality. `reason:` is promoted from payload
 into `dimensions` for any counter event that carries it (currently `:evict`,
 `:skip_evict`, and `:reaper_stopped`). Everything else stays in `payload`.
@@ -178,7 +192,8 @@ sink = lambda do |sample|
 
   case sample.name
   when :cap_unmet
-    # Pool cap is being breached; investigate pool sizing or max_total_connections.
+    # Pool budget is being breached; investigate tenant_pool_size or the
+    # max_tenant_pools / max_tenant_connections ceiling.
     MyAlerts.trigger(:pool_cap_breach, payload: sample.payload)
   when :skip_evict
     # A pool is being skipped repeatedly; may indicate a long-running transaction.

--- a/docs/plans/pool-connection-budget/plan.md
+++ b/docs/plans/pool-connection-budget/plan.md
@@ -1,0 +1,656 @@
+# Pool Connection Budget + Checkout-Pressure Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the tenant connection budget honest (two clear knobs replacing the misnamed `max_total_connections`), document the anti-starvation sizing rule, and surface checkout pressure as metrics.
+
+**Architecture:** `Config` gains `max_tenant_pools` (pool-count cap) and `max_tenant_connections` (connection ceiling); `Config#effective_pool_budget` derives `min(max_tenant_pools, floor(max_tenant_connections / tenant_pool_size))` and is passed once to the `PoolReaper` at `Apartment.configure` time, so admission stays a pure pool-count check. `max_total_connections` is deprecated to an alias of `max_tenant_pools`. `PoolObserver#sample!` grows a checkout-pressure pass over each tenant pool's AR `ConnectionPool#stat`.
+
+**Tech Stack:** Ruby (3.3/3.4/4.0), ActiveRecord (Rails 7.2/8.0/8.1), RSpec, `concurrent-ruby`.
+
+**Design spec:** [docs/designs/pool-connection-budget.md](../../designs/pool-connection-budget.md)
+
+## Global Constraints
+
+- **OSS gem — no CampusESP or other private references** in code, tests, docs, or commit messages.
+- **`max_total_connections` is deprecated, not removed** — it keeps working as an alias of `max_tenant_pools` and prints a deprecation warning; removal is scheduled for v5. Do not delete its existing validation.
+- **`Apartment.config` is frozen after `configure`** — tests reconfigure via `Apartment.configure`; never stub the frozen config object.
+- **RuboCop must pass on every changed Ruby file** (implementation and specs) before each commit: `bundle exec rubocop <files>`.
+- **Run the unit suite** for each task: `bundle exec rspec spec/unit/`. No database is required for any task in this plan.
+- **Every commit message ends with the two repo trailers** (`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` and the `Claude-Session:` line). Commit subjects below show the first line only; append the trailers.
+- **Global pool size assumption:** every tenant pool is sized to `tenant_pool_size`; the derived budget relies on this uniformity.
+
+## File Structure
+
+- `lib/apartment/config.rb` — new accessors, defaults, validations, deprecation alias, `effective_pool_budget`.
+- `lib/apartment.rb` — `setup_pools!` reads `effective_pool_budget` instead of `max_total_connections`.
+- `lib/apartment/pool_observer.rb` — `sample!` emits checkout-pressure gauges.
+- `lib/apartment/pool_reaper.rb` — **unchanged** (receives the derived budget via its existing `max_total:` argument).
+- `spec/unit/config_spec.rb` — Tasks 1–3 tests.
+- `spec/unit/apartment_spec.rb` — Task 4 wiring test.
+- `spec/unit/pool_observer_spec.rb` — Task 5 tests.
+- Docs (Task 6): `README.md`, `docs/designs/pool-admission-control.md`, `docs/upgrading-to-v4.md`, `docs/observability.md`, `docs/designs/v4-connection-model-rationale.md`, `lib/apartment/CLAUDE.md`, `lib/generators/apartment/install/templates/apartment.rb`.
+
+---
+
+### Task 1: Config knobs `max_tenant_pools` + `max_tenant_connections` (accessors, defaults, type validation)
+
+**Files:**
+- Modify: `lib/apartment/config.rb`
+- Test: `spec/unit/config_spec.rb`
+
+**Interfaces:**
+- Produces: `Config#max_tenant_pools`, `Config#max_tenant_pools=`, `Config#max_tenant_connections`, `Config#max_tenant_connections=` (each `Integer | nil`, default `nil`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/unit/config_spec.rb`. Put the two default expectations alongside the existing `tenant_pool_size` / `max_total_connections` default examples (near line 13), and the two validation examples in the `validate!` group (near line 180):
+
+```ruby
+    # defaults group (near the existing `max_total_connections` default at ~line 16)
+    it { expect(config.max_tenant_pools).to(be_nil) }
+    it { expect(config.max_tenant_connections).to(be_nil) }
+```
+
+```ruby
+    # validate! group (near the existing `max_total_connections` invalid case at ~line 180)
+    it 'raises when max_tenant_pools is not a positive integer' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.max_tenant_pools = 0
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_tenant_pools/))
+    end
+
+    it 'raises when max_tenant_connections is not a positive integer' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.max_tenant_connections = 0
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_tenant_connections/))
+    end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e max_tenant`
+Expected: FAIL (`NoMethodError: undefined method 'max_tenant_pools='` and the two default examples failing).
+
+- [ ] **Step 3: Add the accessors and defaults**
+
+In `lib/apartment/config.rb`, extend the `attr_accessor` list — insert after the existing `:max_total_connections,` entry (currently on the line with `:pool_overflow_policy`):
+
+```ruby
+                  :max_total_connections, :max_tenant_pools, :max_tenant_connections,
+                  :pool_overflow_policy,
+```
+
+In `initialize`, immediately after `@max_total_connections = nil`, add:
+
+```ruby
+      @max_tenant_pools = nil
+      @max_tenant_connections = nil
+```
+
+- [ ] **Step 4: Add the type validations**
+
+In `validate!`, immediately after the existing `max_total_connections` block (the one raising `"max_total_connections must be a positive integer or nil..."`), add:
+
+```ruby
+      if @max_tenant_pools && (!@max_tenant_pools.is_a?(Integer) || @max_tenant_pools < 1)
+        raise(ConfigurationError,
+              "max_tenant_pools must be a positive integer or nil, got: #{@max_tenant_pools.inspect}")
+      end
+
+      if @max_tenant_connections && (!@max_tenant_connections.is_a?(Integer) || @max_tenant_connections < 1)
+        raise(ConfigurationError,
+              "max_tenant_connections must be a positive integer or nil, got: #{@max_tenant_connections.inspect}")
+      end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e max_tenant`
+Expected: PASS.
+
+- [ ] **Step 6: RuboCop + full unit suite**
+
+Run: `bundle exec rubocop lib/apartment/config.rb spec/unit/config_spec.rb && bundle exec rspec spec/unit/`
+Expected: no offenses; all examples pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/apartment/config.rb spec/unit/config_spec.rb
+git commit -m "Feat(v4): add max_tenant_pools + max_tenant_connections config knobs"
+```
+
+---
+
+### Task 2: `Config#effective_pool_budget` + derive validations
+
+**Files:**
+- Modify: `lib/apartment/config.rb`
+- Test: `spec/unit/config_spec.rb`
+
+**Interfaces:**
+- Consumes: `max_tenant_pools`, `max_tenant_connections`, `tenant_pool_size` (Task 1 + existing).
+- Produces: `Config#effective_pool_budget` → `Integer | nil` — the pool-count bound admission enforces; `nil` when neither knob is set.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new describe block to `spec/unit/config_spec.rb` (top level, after the `validate!` group):
+
+```ruby
+  describe '#effective_pool_budget' do
+    it 'returns nil when neither knob is set' do
+      expect(config.effective_pool_budget).to(be_nil)
+    end
+
+    it 'returns max_tenant_pools when only it is set' do
+      config.max_tenant_pools = 8
+      expect(config.effective_pool_budget).to(eq(8))
+    end
+
+    it 'derives the pool budget from the connection ceiling with floor division' do
+      config.tenant_pool_size = 3
+      config.max_tenant_connections = 20
+      expect(config.effective_pool_budget).to(eq(6)) # floor(20 / 3)
+    end
+
+    it 'takes the stricter of the explicit pool cap and the derived budget' do
+      config.tenant_pool_size = 2
+      config.max_tenant_connections = 20 # -> 10 pools
+      config.max_tenant_pools = 4
+      expect(config.effective_pool_budget).to(eq(4))
+    end
+  end
+```
+
+And two validation examples in the `validate!` group:
+
+```ruby
+    it 'raises when max_tenant_connections is set without tenant_pool_size' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_pool_size = nil
+      config.max_tenant_connections = 10
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /tenant_pool_size/))
+    end
+
+    it 'raises when max_tenant_connections is below tenant_pool_size' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_pool_size = 5
+      config.max_tenant_connections = 3
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /tenant_pool_size/))
+    end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e effective_pool_budget -e "max_tenant_connections is"`
+Expected: FAIL (`NoMethodError: undefined method 'effective_pool_budget'`; the two validations do not yet raise).
+
+- [ ] **Step 3: Add the `effective_pool_budget` method**
+
+In `lib/apartment/config.rb`, add a public method (e.g. directly after `rails_env_name`):
+
+```ruby
+    # The pool-count bound the admission controller enforces: the stricter of the
+    # explicit pool cap (max_tenant_pools) and the pool budget derived from the
+    # connection ceiling (max_tenant_connections / tenant_pool_size, floored).
+    # Returns nil (uncapped) when neither knob is set. Relies on a global
+    # tenant_pool_size, so tenant-pool connections <= budget * tenant_pool_size.
+    def effective_pool_budget
+      derived = @max_tenant_connections && @tenant_pool_size ? @max_tenant_connections / @tenant_pool_size : nil
+      [@max_tenant_pools, derived].compact.min
+    end
+```
+
+- [ ] **Step 4: Add the derive validations**
+
+In `validate!`, after the Task 1 `max_tenant_connections` type check, add:
+
+```ruby
+      if @max_tenant_connections && @tenant_pool_size.nil?
+        raise(ConfigurationError,
+              'max_tenant_connections requires tenant_pool_size to be set (the pool budget is ' \
+              'derived as max_tenant_connections / tenant_pool_size)')
+      end
+
+      if @max_tenant_connections && @tenant_pool_size && @max_tenant_connections < @tenant_pool_size
+        raise(ConfigurationError,
+              "max_tenant_connections (#{@max_tenant_connections}) must be >= tenant_pool_size " \
+              "(#{@tenant_pool_size}); it cannot fit a single tenant pool")
+      end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e effective_pool_budget -e "max_tenant_connections is"`
+Expected: PASS.
+
+- [ ] **Step 6: RuboCop + full unit suite**
+
+Run: `bundle exec rubocop lib/apartment/config.rb spec/unit/config_spec.rb && bundle exec rspec spec/unit/`
+Expected: no offenses; all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/apartment/config.rb spec/unit/config_spec.rb
+git commit -m "Feat(v4): derive effective_pool_budget from the connection ceiling"
+```
+
+---
+
+### Task 3: Deprecate `max_total_connections` → alias of `max_tenant_pools`
+
+**Files:**
+- Modify: `lib/apartment/config.rb`
+- Test: `spec/unit/config_spec.rb`
+
+**Interfaces:**
+- Consumes: `max_total_connections` (existing), `max_tenant_pools` (Task 1).
+- Behavior: `apply_defaults!` warns once and sets `max_tenant_pools ||= max_total_connections`; `validate!` raises when both are explicitly set to unequal values.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/unit/config_spec.rb`:
+
+```ruby
+  describe 'max_total_connections deprecation' do
+    it 'warns and aliases max_total_connections to max_tenant_pools' do
+      config.max_total_connections = 8
+      expect { config.apply_defaults! }.to(output(/DEPRECATION.*max_total_connections/).to_stderr)
+      expect(config.max_tenant_pools).to(eq(8))
+    end
+
+    it 'does not overwrite an explicitly set max_tenant_pools' do
+      config.max_total_connections = 8
+      config.max_tenant_pools = 8
+      config.apply_defaults!
+      expect(config.max_tenant_pools).to(eq(8))
+    end
+
+    it 'raises when max_total_connections and max_tenant_pools disagree' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.max_total_connections = 8
+      config.max_tenant_pools = 4
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_total_connections/))
+    end
+  end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e "max_total_connections deprecation"`
+Expected: FAIL (no warning emitted; alias not applied; no raise on disagreement).
+
+- [ ] **Step 3: Add the deprecation alias to `apply_defaults!`**
+
+In `lib/apartment/config.rb`, inside `apply_defaults!`, add (after the existing `reaper_interval` default line):
+
+```ruby
+      # max_total_connections is deprecated: the name said "connections" but it
+      # always capped tenant-pool COUNT. Alias it to its true meaning without
+      # changing behavior. Only fill when max_tenant_pools was not set explicitly,
+      # so validate!'s both-set guard can still catch a genuine double-spec.
+      if @max_total_connections
+        warn '[Apartment] DEPRECATION: config.max_total_connections is deprecated and will be ' \
+             'removed in v5. It caps tenant-pool COUNT, not connections; rename it to ' \
+             'max_tenant_pools. For a true connection ceiling, set max_tenant_connections.'
+        @max_tenant_pools = @max_total_connections if @max_tenant_pools.nil?
+      end
+```
+
+- [ ] **Step 4: Add the both-set guard to `validate!`**
+
+In `validate!`, after the `max_tenant_pools` type check, add:
+
+```ruby
+      if @max_total_connections && @max_tenant_pools && @max_total_connections != @max_tenant_pools
+        raise(ConfigurationError,
+              'max_total_connections and max_tenant_pools are the same setting under two names; ' \
+              "set only one. Got max_total_connections=#{@max_total_connections}, " \
+              "max_tenant_pools=#{@max_tenant_pools}")
+      end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/config_spec.rb -e "max_total_connections deprecation"`
+Expected: PASS.
+
+- [ ] **Step 6: RuboCop + full unit suite**
+
+Run: `bundle exec rubocop lib/apartment/config.rb spec/unit/config_spec.rb && bundle exec rspec spec/unit/`
+Expected: no offenses; all pass. (The existing `max_total_connections = 0` validation example still passes — it is unchanged.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/apartment/config.rb spec/unit/config_spec.rb
+git commit -m "Feat(v4): deprecate max_total_connections as an alias of max_tenant_pools"
+```
+
+---
+
+### Task 4: Wire `effective_pool_budget` into the reaper
+
+**Files:**
+- Modify: `lib/apartment.rb` (`setup_pools!`, currently lines ~271-284)
+- Test: `spec/unit/apartment_spec.rb`
+
+**Interfaces:**
+- Consumes: `Config#effective_pool_budget` (Task 2).
+- Behavior: the reaper receives the derived budget as `max_total:`; the admission controller is wired iff `effective_pool_budget` is non-nil. `PoolReaper` is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `spec/unit/apartment_spec.rb`, in the same group as the existing admission-wiring examples (near line 317, which end with `after { described_class.clear_config }`):
+
+```ruby
+    it 'wires admission from a derived connection ceiling (max_tenant_connections)' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.tenant_pool_size = 2
+        config.max_tenant_connections = 10 # -> floor(10/2) = 5 pools
+      end
+      expect(described_class.pool_manager.admission_controller).to(eq(described_class.pool_reaper))
+    end
+
+    it 'leaves the pool manager uncapped when no budget knob is set' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+      end
+      expect(described_class.pool_manager.admission_controller).to(be_nil)
+    end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bundle exec rspec spec/unit/apartment_spec.rb -e "derived connection ceiling"`
+Expected: FAIL (admission controller is `nil` because `setup_pools!` still reads `max_total_connections`, which is unset here).
+
+- [ ] **Step 3: Update `setup_pools!`**
+
+In `lib/apartment.rb`, change the `max_total:` argument and the admission-controller guard to read the derived budget:
+
+```ruby
+      budget = new_config.effective_pool_budget
+      @pool_manager = PoolManager.new
+      @pool_reaper = PoolReaper.new(
+        pool_manager: @pool_manager,
+        interval: new_config.reaper_interval,
+        idle_timeout: new_config.pool_idle_timeout,
+        max_total: budget,
+        default_tenant: new_config.default_tenant,
+        shard_key_prefix: new_config.shard_key_prefix,
+        overflow_policy: new_config.pool_overflow_policy
+      )
+      @pool_manager.admission_controller = @pool_reaper if budget
+      @pool_reaper.start
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bundle exec rspec spec/unit/apartment_spec.rb -e "derived connection ceiling" -e "uncapped when no budget"`
+Expected: PASS.
+
+- [ ] **Step 5: RuboCop + full unit suite**
+
+Run: `bundle exec rubocop lib/apartment.rb spec/unit/apartment_spec.rb && bundle exec rspec spec/unit/`
+Expected: no offenses; all pass. (The existing `max_total_connections = 5` wiring example still passes via the deprecation alias.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/apartment.rb spec/unit/apartment_spec.rb
+git commit -m "Feat(v4): admission control enforces the derived effective_pool_budget"
+```
+
+---
+
+### Task 5: Checkout-pressure gauges in `PoolObserver#sample!`
+
+**Files:**
+- Modify: `lib/apartment/pool_observer.rb`
+- Test: `spec/unit/pool_observer_spec.rb`
+
+**Interfaces:**
+- Consumes: `Apartment.pool_manager.each_pair { |tenant_key, pool| ... }` (existing) and each pool's AR `ConnectionPool#stat` (`{ size:, busy:, waiting:, ... }`).
+- Produces three additional gauges per `sample!` pass: `pools_waiting`, `pools_saturated`, `max_checkout_waiting` (tenant key in the Sample `payload`, not `dimensions`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/unit/pool_observer_spec.rb`:
+
+```ruby
+  describe '#sample! checkout pressure' do
+    def fake_pool(size:, busy:, waiting:)
+      instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool,
+                      stat: { size: size, busy: busy, waiting: waiting })
+    end
+
+    let(:pools) do
+      {
+        'acme:writing' => fake_pool(size: 2, busy: 2, waiting: 3),
+        'beta:writing' => fake_pool(size: 5, busy: 1, waiting: 0),
+      }
+    end
+
+    let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 2, tenants: [] }) }
+
+    before do
+      allow(Apartment).to(receive(:pool_manager).and_return(stub_manager))
+      allow(stub_manager).to(receive(:each_pair)) { |&blk| pools.each(&blk) }
+    end
+
+    it 'counts pools with threads waiting on checkout' do
+      described_class.new(sink: sink).sample!
+      expect(samples.find { |s| s.name == :pools_waiting }.value).to(eq(1))
+    end
+
+    it 'counts saturated pools where busy >= size' do
+      described_class.new(sink: sink).sample!
+      expect(samples.find { |s| s.name == :pools_saturated }.value).to(eq(1))
+    end
+
+    it 'reports the worst waiting count with the tenant in payload, not dimensions' do
+      described_class.new(sink: sink).sample!
+      sample = samples.find { |s| s.name == :max_checkout_waiting }
+      expect(sample).to(have_attributes(kind: :gauge, value: 3, dimensions: {}, payload: { tenant: 'acme:writing' }))
+    end
+
+    it 'skips a pool whose #stat raises without breaking the pass' do
+      broken = instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool)
+      allow(broken).to(receive(:stat).and_raise(StandardError, 'pool tearing down'))
+      pools['broken:writing'] = broken
+      described_class.new(sink: sink).sample!
+      expect(samples.map(&:name)).to(include(:pools_waiting, :pools_saturated, :max_checkout_waiting))
+    end
+  end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb -e "checkout pressure"`
+Expected: FAIL (no `pools_waiting` / `pools_saturated` / `max_checkout_waiting` samples emitted).
+
+- [ ] **Step 3: Emit the gauges from `sample!`**
+
+In `lib/apartment/pool_observer.rb`, call a new private method at the end of `sample!`'s body — insert immediately before the `rescue StandardError => e` line:
+
+```ruby
+      emit_checkout_pressure!
+```
+
+Then add the private method (e.g. after `sample!`):
+
+```ruby
+    # Per-tenant-pool checkout pressure, aggregated to low cardinality. waiting>0
+    # means threads are blocked acquiring a connection (the same-tenant fan-out
+    # starvation signal). The worst tenant is carried in payload, NOT as a metric
+    # dimension, to avoid unbounded time-series churn. Per-pool #stat is rescued
+    # so a pool tearing down mid-sample can't abort the whole pass.
+    def emit_checkout_pressure!
+      manager = Apartment.pool_manager
+      return unless manager
+
+      waiting = 0
+      saturated = 0
+      max_wait = 0
+      max_wait_tenant = nil
+
+      manager.each_pair do |tenant_key, pool|
+        stat = pool.stat
+        pending = stat[:waiting].to_i
+        waiting += 1 if pending.positive?
+        saturated += 1 if stat[:busy].to_i >= stat[:size].to_i
+        if pending > max_wait
+          max_wait = pending
+          max_wait_tenant = tenant_key
+        end
+      rescue StandardError
+        next # a pool mid-teardown can raise; skip it, keep the pass
+      end
+
+      emit(Sample.new(name: :pools_waiting, kind: :gauge, value: waiting, dimensions: {}, payload: {}))
+      emit(Sample.new(name: :pools_saturated, kind: :gauge, value: saturated, dimensions: {}, payload: {}))
+      emit(Sample.new(name: :max_checkout_waiting, kind: :gauge, value: max_wait,
+                      dimensions: {}, payload: max_wait_tenant ? { tenant: max_wait_tenant } : {}))
+    end
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/unit/pool_observer_spec.rb -e "checkout pressure"`
+Expected: PASS.
+
+- [ ] **Step 5: RuboCop + full unit suite**
+
+Run: `bundle exec rubocop lib/apartment/pool_observer.rb spec/unit/pool_observer_spec.rb && bundle exec rspec spec/unit/`
+Expected: no offenses; all pass. (The existing `sample!` examples that stub `pool_manager` without `each_pair` still pass — those stubs return a manager whose `each_pair` is unstubbed only where the new group adds it; if an existing example fails because `each_pair` is now called, stub it to yield nothing: `allow(stub_manager).to(receive(:each_pair))`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/apartment/pool_observer.rb spec/unit/pool_observer_spec.rb
+git commit -m "Feat(v4): emit checkout-pressure gauges from PoolObserver#sample!"
+```
+
+---
+
+### Task 6: Documentation (Item 2)
+
+**Files:**
+- Modify: `README.md`, `docs/designs/pool-admission-control.md`, `docs/upgrading-to-v4.md`, `docs/observability.md`, `docs/designs/v4-connection-model-rationale.md`, `lib/apartment/CLAUDE.md`, `lib/generators/apartment/install/templates/apartment.rb`
+
+**Interfaces:** none (documentation + a generator template comment).
+
+- [ ] **Step 1: README + generator template — the knobs and the sizing rule**
+
+In `README.md` (config-options section) and the generator template `lib/generators/apartment/install/templates/apartment.rb`, replace `max_total_connections` guidance with the two knobs and add the sizing rule. Template comment to add near the pool settings:
+
+```ruby
+  # Pool sizing (v4). tenant_pool_size MUST be >= the peak number of threads/fibers
+  # in one process that can touch the SAME tenant at once (e.g. a Sidekiq role's
+  # concurrency for a same-tenant job fan-out); otherwise those threads block on
+  # connection checkout. tenant_pool_size is a lazy ceiling — connections are
+  # created on demand and idle pools are reaped, so it does not hold that many
+  # connections open at steady state.
+  # config.tenant_pool_size = 5
+  #
+  # Bound how many tenant pools exist per process:
+  # config.max_tenant_pools = 50
+  # ...or bound total tenant-pool CONNECTIONS (requires tenant_pool_size); the
+  # admission controller derives the pool budget as floor(value / tenant_pool_size):
+  # config.max_tenant_connections = 250
+  #
+  # max_total_connections is DEPRECATED (alias of max_tenant_pools; removed in v5).
+```
+
+- [ ] **Step 2: The true ceiling formula + worked example**
+
+Add to `README.md` and `docs/designs/v4-connection-model-rationale.md`:
+
+```
+Per-process tenant-pool connections <= effective_pool_budget * tenant_pool_size
+where effective_pool_budget = min(max_tenant_pools, floor(max_tenant_connections / tenant_pool_size))
+Total process connections ~= (effective_pool_budget * tenant_pool_size) + default_pool + pinned_pool
+
+Worked example: tenant_pool_size=5, max_tenant_connections=250
+  -> effective_pool_budget = floor(250/5) = 50 pools
+  -> up to 250 tenant-pool connections, + the default pool + any separate pinned pool.
+A tenant using writing+reading roles holds TWO pools ("tenant:role" keys), so it
+counts twice against max_tenant_pools and halves how many tenants fit in the budget.
+For a hard external-pooler budget, pair max_tenant_connections with
+pool_overflow_policy: :raise (the ceiling is soft under the default :evict_idle).
+```
+
+- [ ] **Step 3: Upgrading guide — the deprecation**
+
+Add a section to `docs/upgrading-to-v4.md`:
+
+```markdown
+### `max_total_connections` renamed
+
+`max_total_connections` always capped tenant-pool **count**, not connections. It is
+deprecated (removed in v5) and now aliases `max_tenant_pools`; rename it. For a true
+connection ceiling, set `max_tenant_connections` (requires `tenant_pool_size`); the
+admission controller derives the pool budget as
+`floor(max_tenant_connections / tenant_pool_size)`.
+```
+
+- [ ] **Step 4: Observability doc — the new gauges and sampling guidance**
+
+Add to `docs/observability.md`: document `pools_waiting`, `pools_saturated`, and `max_checkout_waiting` (tenant in `payload`, opt-in as a high-cardinality dimension). Add the sampling note:
+
+```markdown
+Checkout-pressure gauges are sampled instantaneously (not peak-held), so a short
+starvation episode can fall between samples. Use a short `sample_interval` (5-10s)
+on Sidekiq/job roles to catch sustained same-tenant fan-out; the gauges show
+pressure, not lossless timeout accounting (standard APM captures the
+`ConnectionTimeoutError` itself).
+```
+
+- [ ] **Step 5: Cross-reference docs — admission-control design + implementation guide**
+
+- In `docs/designs/pool-admission-control.md`, add a note that the cap knob is now `max_tenant_pools` (with `max_total_connections` deprecated) and that the enforced bound is `Config#effective_pool_budget`; link to `docs/designs/pool-connection-budget.md`.
+- In `lib/apartment/CLAUDE.md`, update the `config.rb` and `pool_manager.rb` / `pool_reaper.rb` entries to mention `max_tenant_pools` / `max_tenant_connections` / `effective_pool_budget` and the new `pool_observer.rb` gauges.
+
+- [ ] **Step 6: RuboCop the template + verify references**
+
+Run: `bundle exec rubocop lib/generators/apartment/install/templates/apartment.rb`
+Run: `grep -rn "max_tenant_pools\|max_tenant_connections\|effective_pool_budget" README.md docs/ lib/apartment/CLAUDE.md`
+Expected: no offenses; the new names appear in every doc touched above; no lingering claim that `max_total_connections` bounds connections.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md docs/ lib/apartment/CLAUDE.md lib/generators/apartment/install/templates/apartment.rb
+git commit -m "Docs(v4): document the connection-budget knobs, ceiling formula, and checkout gauges"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Item 1 — three keys → Tasks 1 (new knobs), 3 (deprecated alias); `derive + min` → Task 2; derivation in `configure` → Task 4; all five validations → Tasks 1–3; honesty scope (`tenant:role`, default/pinned, soft cap) → Task 6 docs. ✅
+- Item 2 — sizing rule, ceiling formula, lazy-ceiling note, `:raise` pairing, role multiplier, doc locations → Task 6. ✅
+- Item 3 — `pools_waiting` / `pools_saturated` / `max_checkout_waiting`, tenant-in-payload, error isolation, sampling honesty → Task 5 (code) + Task 6 (sampling docs). Deferred checkout-timeout event → intentionally not implemented. ✅
+- Testing section of spec — config/derivation/validation/deprecation → Tasks 1–3; admission wiring → Task 4; observability incl. raising `#stat` → Task 5. ✅
+
+**Placeholder scan:** every code step shows the exact code; every command shows the exact invocation and expected result. No TBD/TODO. ✅
+
+**Type consistency:** `effective_pool_budget` (defined Task 2) is consumed with that exact name in Task 4; `max_tenant_pools` / `max_tenant_connections` accessor names are consistent across Tasks 1–4 and Task 6; gauge names `pools_waiting` / `pools_saturated` / `max_checkout_waiting` match between Task 5 code and tests and Task 6 docs. ✅
+
+## Phasing
+
+- **PR 1 (Item 1 + Item 2):** Tasks 1–4 (knobs, budget, deprecation, wiring) + Task 6 (docs describe those knobs).
+- **PR 2 (Item 3):** Task 5 (observability), independent of the config changes.

--- a/docs/upgrading-to-v4.md
+++ b/docs/upgrading-to-v4.md
@@ -215,7 +215,9 @@ Key config options for pool tuning:
 | `tenant_pool_size` | nil | Max connections per tenant pool; nil inherits the app's base pool size |
 | `pool_idle_timeout` | 300 | Seconds an idle pool must exceed before it is eligible for reaping |
 | `reaper_interval` | nil | Seconds between reap passes; nil derives from `pool_idle_timeout` |
-| `max_total_connections` | nil | Ceiling on live tenant pools; enforced synchronously at create time |
+| `max_tenant_pools` | nil | Ceiling on live tenant pools per process; enforced synchronously at create time |
+| `max_tenant_connections` | nil | Ceiling on tenant-pool connections (requires `tenant_pool_size`); pool budget = `floor(value / tenant_pool_size)` |
+| `max_total_connections` | nil | **Deprecated** (removed in v5); aliases `max_tenant_pools` |
 | `pool_overflow_policy` | `:evict_idle` | At-capacity-with-no-idle-pool behavior: `:evict_idle` (soft) or `:raise` (hard) |
 | `reap_in_test` | `false` | Keep the reaper running under `Rails.env.test?`; `true` avoids a boot guard for deployments that run test-env semantics |
 
@@ -390,16 +392,22 @@ Ensure these names match exactly what `Apartment::Tenant.create` received (case-
 
 ### Connection pool sizing
 
-By default (`tenant_pool_size = nil`) each tenant pool inherits the app's base pool size. For apps with many tenants, set `tenant_pool_size` to size tenant pools independently and `max_total_connections` to bound the live pool count — total backend connections ≈ `max_total_connections × tenant_pool_size`:
+By default (`tenant_pool_size = nil`) each tenant pool inherits the app's base pool size. **Set `tenant_pool_size` to at least the peak number of threads/fibers in one process that can touch the _same_ tenant at once** — a Sidekiq role's concurrency for a same-tenant job fan-out, for example. A smaller pool makes those threads block on connection checkout (v3's shared pool absorbed this; v4 partitions per tenant, so a same-tenant burst concentrates on one pool). It is a lazy ceiling — connections are created on demand and idle pools are reaped — so sizing for peak does not hold that many connections open at steady state.
+
+Bound the fleet with either `max_tenant_pools` (a live-pool-count cap) or `max_tenant_connections` (a true tenant-pool connection ceiling; requires `tenant_pool_size`):
 
 ```ruby
 Apartment.configure do |config|
-  config.tenant_pool_size = 3
-  config.max_total_connections = 100
+  config.tenant_pool_size = 5          # >= peak same-tenant per-process concurrency
+  config.max_tenant_connections = 250  # -> floor(250 / 5) = 50 tenant pools
 end
 ```
 
-`max_total_connections` is enforced synchronously at pool-creation time: a new pool that would breach the cap first evicts the least-recently-used *idle* pool inline. When every pool is pinned or in use, `pool_overflow_policy` decides — `:evict_idle` (default) allows the pool and emits a `cap_unmet` notification; `:raise` raises `Apartment::PoolCapacityReached`. Idle pools are also reaped in the background after `pool_idle_timeout` seconds (on the `reaper_interval` cadence, which defaults to `pool_idle_timeout`). The `PoolReaper` never evicts the default tenant's pool.
+The admission controller enforces `effective_pool_budget = min(max_tenant_pools, floor(max_tenant_connections / tenant_pool_size))`. Per-process tenant-pool connections ≤ `effective_pool_budget × tenant_pool_size`; the default pool and any separate pinned pool are additional. A tenant using multiple roles (`writing` + `reading`) holds one pool per role (`tenant:role` keys) and counts once per role against the budget.
+
+Enforcement is synchronous at pool-creation time: a new pool that would breach the budget first evicts the least-recently-used *idle* pool inline. When every pool is pinned or in use, `pool_overflow_policy` decides — `:evict_idle` (default) allows the pool and emits a `cap_unmet` notification; `:raise` raises `Apartment::PoolCapacityReached`. For a hard external-pooler budget, pair `max_tenant_connections` with `:raise`. Idle pools are also reaped in the background after `pool_idle_timeout` seconds (on the `reaper_interval` cadence, which defaults to `pool_idle_timeout`). The `PoolReaper` never evicts the default tenant's pool.
+
+> **`max_total_connections` is deprecated** (removed in v5). It always capped tenant-pool *count*, not connections, and now aliases `max_tenant_pools` — rename it. For a true connection ceiling, use `max_tenant_connections`.
 
 ### Thread safety
 

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -265,21 +265,23 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     end
 
     # Build the pool manager + reaper for a freshly-validated config and start
-    # the background reaper. When max_total_connections is set, wire the reaper
-    # as the pool manager's admission controller so cold creates are bounded
-    # synchronously; otherwise the manager keeps its lock-free create path.
+    # the background reaper. When a pool budget is configured (max_tenant_pools
+    # and/or max_tenant_connections, via Config#effective_pool_budget), wire the
+    # reaper as the pool manager's admission controller so cold creates are
+    # bounded synchronously; otherwise the manager keeps its lock-free create path.
     def setup_pools!(new_config)
+      budget = new_config.effective_pool_budget
       @pool_manager = PoolManager.new
       @pool_reaper = PoolReaper.new(
         pool_manager: @pool_manager,
         interval: new_config.reaper_interval,
         idle_timeout: new_config.pool_idle_timeout,
-        max_total: new_config.max_total_connections,
+        max_total: budget,
         default_tenant: new_config.default_tenant,
         shard_key_prefix: new_config.shard_key_prefix,
         overflow_policy: new_config.pool_overflow_policy
       )
-      @pool_manager.admission_controller = @pool_reaper if new_config.max_total_connections
+      @pool_manager.admission_controller = @pool_reaper if budget
       @pool_reaper.start
     end
 

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -59,7 +59,7 @@ lib/apartment/
 
 ### pool_manager.rb — Pool Cache
 
-`Concurrent::Map` storing connection pools by tenant key. Monotonic clock timestamps for idle/LRU tracking. `stats_for` returns `{ seconds_idle: N }`. `clear` disconnects all pools before clearing. When `max_total_connections` is set, `Apartment.configure` wires an `admission_controller` (the reaper) so cold creates route through a serialized, capacity-bounded path; otherwise the lock-free `compute_if_absent` fast path is used. See `docs/designs/pool-admission-control.md`.
+`Concurrent::Map` storing connection pools by tenant key. Monotonic clock timestamps for idle/LRU tracking. `stats_for` returns `{ seconds_idle: N }`. `clear` disconnects all pools before clearing. When a pool budget is configured (`max_tenant_pools` and/or `max_tenant_connections`, resolved by `Config#effective_pool_budget`; `max_total_connections` is the deprecated alias of `max_tenant_pools`), `Apartment.configure` wires an `admission_controller` (the reaper) so cold creates route through a serialized, capacity-bounded path; otherwise the lock-free `compute_if_absent` fast path is used. See `docs/designs/pool-connection-budget.md` and `docs/designs/pool-admission-control.md`.
 
 ### pool_reaper.rb — Pool Eviction + Admission
 
@@ -97,7 +97,7 @@ All inherit from `AbstractAdapter`. Override `resolve_connection_config`, `creat
 
 ### pool_observer.rb — Observability (opt-in)
 
-Sink-agnostic subscriber for the pool events (`create`/`evict`/`cap_unmet`/`skip_evict`/`reaper_stopped`) + an optional `Concurrent::TimerTask` gauge sampler (`tenant_pools_live`, optional adopter `backend_count`). Normalizes each to a `Sample` and forwards to a caller `sink`; ships no transport. Error-isolated — never raises into instrumentation. See `docs/observability.md`.
+Sink-agnostic subscriber for the pool events (`create`/`evict`/`cap_unmet`/`skip_evict`/`reaper_stopped`) + an optional `Concurrent::TimerTask` gauge sampler. Gauges: `tenant_pools_live`, optional adopter `backend_count`, and per-pass checkout-pressure gauges from each tenant pool's AR `ConnectionPool#stat` — `pools_waiting` (blocked on checkout), `pools_saturated` (`busy >= size`), `max_checkout_waiting` (worst pool's `waiting`, tenant in payload not a dimension). Per-pool `#stat` is rescued so one tearing-down pool can't abort the pass. Normalizes each to a `Sample` via the shared `emit_gauge` helper and forwards to a caller `sink`; ships no transport. Error-isolated — never raises into instrumentation. See `docs/observability.md`.
 
 ### railtie.rb — v4 Rails Integration
 

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -127,6 +127,17 @@ module Apartment
       # Reap on the idle-timeout cadence unless an explicit interval decouples
       # the two (reap more often without shrinking the idle window).
       @reaper_interval = @pool_idle_timeout if @reaper_interval.nil?
+
+      # max_total_connections is deprecated: the name said "connections" but it
+      # always capped tenant-pool COUNT. Alias it to its true meaning without
+      # changing behavior. Only fill when max_tenant_pools was not set explicitly,
+      # so validate!'s both-set guard can still catch a genuine double-spec.
+      return unless @max_total_connections
+
+      warn '[Apartment] DEPRECATION: config.max_total_connections is deprecated and will be ' \
+           'removed in v5. It caps tenant-pool COUNT, not connections; rename it to ' \
+           'max_tenant_pools. For a true connection ceiling, set max_tenant_connections.'
+      @max_tenant_pools = @max_total_connections if @max_tenant_pools.nil?
     end
 
     # Validate configuration completeness and consistency.
@@ -177,6 +188,13 @@ module Apartment
       if @max_tenant_pools && (!@max_tenant_pools.is_a?(Integer) || @max_tenant_pools < 1)
         raise(ConfigurationError,
               "max_tenant_pools must be a positive integer or nil, got: #{@max_tenant_pools.inspect}")
+      end
+
+      if @max_total_connections && @max_tenant_pools && @max_total_connections != @max_tenant_pools
+        raise(ConfigurationError,
+              'max_total_connections and max_tenant_pools are the same setting under two names; ' \
+              "set only one. Got max_total_connections=#{@max_total_connections}, " \
+              "max_tenant_pools=#{@max_tenant_pools}")
       end
 
       if @max_tenant_connections && (!@max_tenant_connections.is_a?(Integer) || @max_tenant_connections < 1)

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -17,7 +17,8 @@ module Apartment
     attr_accessor :tenants_provider, :default_tenant,
                   :default_tenant_switch_allowed,
                   :tenant_pool_size, :pool_idle_timeout, :reaper_interval,
-                  :max_total_connections, :pool_overflow_policy,
+                  :max_total_connections, :max_tenant_pools, :max_tenant_connections,
+                  :pool_overflow_policy,
                   :seed_after_create, :seed_data_file,
                   :schema_load_strategy, :schema_file,
                   :parallel_migration_threads,
@@ -38,6 +39,8 @@ module Apartment
       @pool_idle_timeout = 300
       @reaper_interval = nil
       @max_total_connections = nil
+      @max_tenant_pools = nil
+      @max_tenant_connections = nil
       @pool_overflow_policy = :evict_idle
       @seed_after_create = false
       @seed_data_file = nil
@@ -169,6 +172,16 @@ module Apartment
       if @max_total_connections && (!@max_total_connections.is_a?(Integer) || @max_total_connections < 1)
         raise(ConfigurationError,
               "max_total_connections must be a positive integer or nil, got: #{@max_total_connections.inspect}")
+      end
+
+      if @max_tenant_pools && (!@max_tenant_pools.is_a?(Integer) || @max_tenant_pools < 1)
+        raise(ConfigurationError,
+              "max_tenant_pools must be a positive integer or nil, got: #{@max_tenant_pools.inspect}")
+      end
+
+      if @max_tenant_connections && (!@max_tenant_connections.is_a?(Integer) || @max_tenant_connections < 1)
+        raise(ConfigurationError,
+              "max_tenant_connections must be a positive integer or nil, got: #{@max_tenant_connections.inspect}")
       end
 
       unless %i[evict_idle raise].include?(@pool_overflow_policy)

--- a/lib/apartment/config.rb
+++ b/lib/apartment/config.rb
@@ -184,6 +184,18 @@ module Apartment
               "max_tenant_connections must be a positive integer or nil, got: #{@max_tenant_connections.inspect}")
       end
 
+      if @max_tenant_connections && @tenant_pool_size.nil?
+        raise(ConfigurationError,
+              'max_tenant_connections requires tenant_pool_size to be set (the pool budget is ' \
+              'derived as max_tenant_connections / tenant_pool_size)')
+      end
+
+      if @max_tenant_connections && @tenant_pool_size && @max_tenant_connections < @tenant_pool_size
+        raise(ConfigurationError,
+              "max_tenant_connections (#{@max_tenant_connections}) must be >= tenant_pool_size " \
+              "(#{@tenant_pool_size}); it cannot fit a single tenant pool")
+      end
+
       unless %i[evict_idle raise].include?(@pool_overflow_policy)
         raise(ConfigurationError,
               'pool_overflow_policy must be :evict_idle or :raise, ' \
@@ -250,6 +262,16 @@ module Apartment
     # Returns the current Rails environment name, falling back to env vars and a safe default.
     def rails_env_name
       (Rails.env if defined?(Rails.env)) || ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'default_env'
+    end
+
+    # The pool-count bound the admission controller enforces: the stricter of the
+    # explicit pool cap (max_tenant_pools) and the pool budget derived from the
+    # connection ceiling (max_tenant_connections / tenant_pool_size, floored).
+    # Returns nil (uncapped) when neither knob is set. Relies on a global
+    # tenant_pool_size, so tenant-pool connections <= budget * tenant_pool_size.
+    def effective_pool_budget
+      derived = @max_tenant_connections && @tenant_pool_size ? @max_tenant_connections / @tenant_pool_size : nil
+      [@max_tenant_pools, derived].compact.min
     end
   end
 end

--- a/lib/apartment/errors.rb
+++ b/lib/apartment/errors.rb
@@ -33,22 +33,31 @@ module Apartment
   # Raised when the tenant connection pool is exhausted.
   class PoolExhausted < ApartmentError; end
 
-  # Raised when admitting a new tenant pool would exceed max_total_connections
-  # and no idle pool can be evicted to make room, under the :raise overflow
-  # policy. Distinct from PoolExhausted (a single pool's connections) — this is
-  # the process-wide pool-count ceiling. See docs/designs/pool-admission-control.md.
+  # Raised when admitting a new tenant pool would exceed the effective pool
+  # budget (Config#effective_pool_budget) and no idle pool can be evicted to make
+  # room, under the :raise overflow policy. Distinct from PoolExhausted (a single
+  # pool's connections) — this is the process-wide pool-COUNT ceiling. The message
+  # names the knobs that set it, never the deprecated max_total_connections: that
+  # name is what made the budget look like a connection count in the first place.
+  # See docs/designs/pool-connection-budget.md and pool-admission-control.md.
   class PoolCapacityReached < ApartmentError
+    # +max_total+ is the effective POOL budget, not a connection count. The
+    # reader keeps its name for compatibility with anything already rescuing this.
     attr_reader :max_total, :current
+
+    alias pool_budget max_total
 
     def initialize(max_total: nil, current: nil)
       @max_total = max_total
       @current = current
       super(
-        "Tenant pool capacity reached: #{current.inspect} pools open, " \
-        "max_total_connections is #{max_total.inspect}, and no idle pool could " \
-        'be evicted to admit another (all pinned or in use). Raise ' \
-        'max_total_connections, reduce concurrent tenants, or set ' \
-        'pool_overflow_policy to :evict_idle to allow soft overflow.'
+        "Tenant pool capacity reached: #{current.inspect} tenant pools open, " \
+        "the effective pool budget is #{max_total.inspect}, and no idle pool " \
+        'could be evicted to admit another (all pinned or in use). Raise ' \
+        'max_tenant_pools, or raise max_tenant_connections (which derives the ' \
+        'pool budget as max_tenant_connections / tenant_pool_size), reduce ' \
+        'concurrent tenants, or set pool_overflow_policy to :evict_idle to ' \
+        'allow soft overflow.'
       )
     end
   end

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -66,14 +66,15 @@ module Apartment
     # when supplied. Safe to call from start_sampler! or an external scheduler.
     def sample!
       total = Apartment.pool_manager&.stats&.fetch(:total_pools, 0) || 0
-      emit(Sample.new(name: :tenant_pools_live, kind: :gauge, value: total, dimensions: {}, payload: {}))
+      emit_gauge(:tenant_pools_live, total)
+      emit_checkout_pressure!
 
       return unless @backend_count
 
       backends = @backend_count.call
       return if backends.nil?
 
-      emit(Sample.new(name: :backend_connections, kind: :gauge, value: backends, dimensions: {}, payload: {}))
+      emit_gauge(:backend_connections, backends)
     rescue StandardError => e
       warn_failure('sample!', e)
     end
@@ -102,6 +103,43 @@ module Apartment
       @sampler.shutdown
       @sampler.wait_for_termination(5)
       @sampler = nil
+    end
+
+    # Per-tenant-pool checkout pressure, aggregated to low cardinality. waiting>0
+    # means threads are blocked acquiring a connection (the same-tenant fan-out
+    # starvation signal). The worst tenant is carried in the Sample payload, NOT
+    # as a metric dimension, to avoid unbounded time-series churn. Per-pool #stat
+    # is rescued so a pool tearing down mid-sample can't abort the whole pass.
+    def emit_checkout_pressure!
+      manager = Apartment.pool_manager
+      return unless manager
+
+      stats = collect_pool_stats(manager)
+      worst = stats.max_by { |s| s[:pending] } || { tenant: nil, pending: 0 }
+      payload = worst[:pending].positive? ? { tenant: worst[:tenant] } : {}
+
+      emit_gauge(:pools_waiting, stats.count { |s| s[:pending].positive? })
+      emit_gauge(:pools_saturated, stats.count { |s| s[:saturated] })
+      emit_gauge(:max_checkout_waiting, worst[:pending], payload: payload)
+    end
+
+    def emit_gauge(name, value, payload: {})
+      emit(Sample.new(name: name, kind: :gauge, value: value, dimensions: {}, payload: payload))
+    end
+
+    # Read each tenant pool's checkout stats into [{ tenant:, pending:, saturated: }],
+    # skipping any pool whose #stat raises (mid-teardown) so one bad pool can't
+    # abort the whole pass.
+    def collect_pool_stats(manager)
+      stats = []
+      manager.each_pair do |tenant_key, pool|
+        stat = pool.stat
+        stats << { tenant: tenant_key, pending: stat[:waiting].to_i,
+                   saturated: stat[:busy].to_i >= stat[:size].to_i }
+      rescue StandardError
+        next
+      end
+      stats
     end
 
     def record_event(event, payload)

--- a/lib/generators/apartment/install/templates/apartment.rb
+++ b/lib/generators/apartment/install/templates/apartment.rb
@@ -37,9 +37,20 @@ Apartment.configure do |config|
 
   # == Connection Pool =====================================================
 
-  # config.tenant_pool_size      = 5
-  # config.pool_idle_timeout     = 300
-  # config.max_total_connections = nil
+  # tenant_pool_size MUST be >= the peak number of threads/fibers in one process
+  # that can touch the SAME tenant at once (e.g. a Sidekiq role's concurrency for a
+  # same-tenant job fan-out); otherwise those threads block on connection checkout.
+  # It is a lazy ceiling — connections are created on demand and idle pools reaped.
+  # config.tenant_pool_size       = 5
+  # config.pool_idle_timeout      = 300
+  #
+  # Bound how many tenant pools exist per process:
+  # config.max_tenant_pools       = nil
+  # ...or bound total tenant-pool CONNECTIONS (requires tenant_pool_size); the
+  # admission controller derives the pool budget as floor(value / tenant_pool_size):
+  # config.max_tenant_connections = nil
+  #
+  # config.max_total_connections  = nil # DEPRECATED: alias of max_tenant_pools; removed in v5
 
   # == Elevator (Request Tenant Detection) =================================
 

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -322,6 +322,16 @@ RSpec.describe(Apartment) do
       end
       expect(described_class.pool_manager.admission_controller).to(eq(described_class.pool_reaper))
     end
+
+    it 'wires admission from a derived connection ceiling (max_tenant_connections)' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+        config.tenant_pool_size = 2
+        config.max_tenant_connections = 10 # -> floor(10 / 2) = 5 pools
+      end
+      expect(described_class.pool_manager.admission_controller).to(eq(described_class.pool_reaper))
+    end
   end
 
   describe '.configure teardown protection' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -143,6 +143,29 @@ RSpec.describe(Apartment::Config) do
     end
   end
 
+  describe 'max_total_connections deprecation' do
+    it 'warns and aliases max_total_connections to max_tenant_pools' do
+      config.max_total_connections = 8
+      expect { config.apply_defaults! }.to(output(/DEPRECATION.*max_total_connections/).to_stderr)
+      expect(config.max_tenant_pools).to(eq(8))
+    end
+
+    it 'does not overwrite an explicitly set max_tenant_pools' do
+      config.max_total_connections = 8
+      config.max_tenant_pools = 8
+      config.apply_defaults!
+      expect(config.max_tenant_pools).to(eq(8))
+    end
+
+    it 'raises when max_total_connections and max_tenant_pools disagree' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.max_total_connections = 8
+      config.max_tenant_pools = 4
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_total_connections/))
+    end
+  end
+
   describe '#validate!' do
     it 'raises when tenant_strategy is missing' do
       expect { config.validate! }.to(raise_error(

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -141,6 +141,23 @@ RSpec.describe(Apartment::Config) do
       config.max_tenant_pools = 4
       expect(config.effective_pool_budget).to(eq(4))
     end
+
+    # The deprecated knob reaches the budget through the max_tenant_pools alias
+    # apply_defaults! installs, so it participates in the same min() as an
+    # explicit pool cap. An adopter who keeps max_total_connections and ALSO
+    # adopts the connection ceiling gets the stricter of the two -- the old knob
+    # is not silently outranked by the new one.
+    it 'lets the deprecated max_total_connections bind the budget via its alias' do
+      config.max_total_connections = 3 # -> max_tenant_pools = 3
+      config.tenant_pool_size = 2
+      config.max_tenant_connections = 20 # -> 10 pools
+      # apply_defaults! emits the deprecation notice; consume it so the
+      # expectation below reads against a quiet stderr.
+      expect { config.apply_defaults! }.to(output(/DEPRECATION/).to_stderr)
+
+      expect(config.max_tenant_pools).to(eq(3))
+      expect(config.effective_pool_budget).to(eq(3))
+    end
   end
 
   describe 'max_total_connections deprecation' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -119,6 +119,30 @@ RSpec.describe(Apartment::Config) do
     end
   end
 
+  describe '#effective_pool_budget' do
+    it 'returns nil when neither knob is set' do
+      expect(config.effective_pool_budget).to(be_nil)
+    end
+
+    it 'returns max_tenant_pools when only it is set' do
+      config.max_tenant_pools = 8
+      expect(config.effective_pool_budget).to(eq(8))
+    end
+
+    it 'derives the pool budget from the connection ceiling with floor division' do
+      config.tenant_pool_size = 3
+      config.max_tenant_connections = 20
+      expect(config.effective_pool_budget).to(eq(6)) # floor(20 / 3)
+    end
+
+    it 'takes the stricter of the explicit pool cap and the derived budget' do
+      config.tenant_pool_size = 2
+      config.max_tenant_connections = 20 # -> 10 pools
+      config.max_tenant_pools = 4
+      expect(config.effective_pool_budget).to(eq(4))
+    end
+  end
+
   describe '#validate!' do
     it 'raises when tenant_strategy is missing' do
       expect { config.validate! }.to(raise_error(
@@ -198,6 +222,22 @@ RSpec.describe(Apartment::Config) do
       config.tenants_provider = -> { [] }
       config.max_tenant_connections = 0
       expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_tenant_connections/))
+    end
+
+    it 'raises when max_tenant_connections is set without tenant_pool_size' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_pool_size = nil
+      config.max_tenant_connections = 10
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /tenant_pool_size/))
+    end
+
+    it 'raises when max_tenant_connections is below tenant_pool_size' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.tenant_pool_size = 5
+      config.max_tenant_connections = 3
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /tenant_pool_size/))
     end
 
     it 'raises when reaper_interval is not a positive number' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe(Apartment::Config) do
     it { expect(config.pool_idle_timeout).to(eq(300)) }
     it { expect(config.reaper_interval).to(be_nil) }
     it { expect(config.max_total_connections).to(be_nil) }
+    it { expect(config.max_tenant_pools).to(be_nil) }
+    it { expect(config.max_tenant_connections).to(be_nil) }
     it { expect(config.pool_overflow_policy).to(eq(:evict_idle)) }
     it { expect(config.seed_after_create).to(be(false)) }
     it { expect(config.seed_data_file).to(be_nil) }
@@ -182,6 +184,20 @@ RSpec.describe(Apartment::Config) do
       config.tenants_provider = -> { [] }
       config.max_total_connections = 0
       expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_total_connections/))
+    end
+
+    it 'raises when max_tenant_pools is not a positive integer' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.max_tenant_pools = 0
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_tenant_pools/))
+    end
+
+    it 'raises when max_tenant_connections is not a positive integer' do
+      config.tenant_strategy = :schema
+      config.tenants_provider = -> { [] }
+      config.max_tenant_connections = 0
+      expect { config.validate! }.to(raise_error(Apartment::ConfigurationError, /max_tenant_connections/))
     end
 
     it 'raises when reaper_interval is not a positive number' do

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -106,4 +106,27 @@ RSpec.describe('Apartment error hierarchy') do
       expect(error.message).to(include('default_tenant'))
     end
   end
+
+  describe Apartment::PoolCapacityReached do
+    subject(:error) { described_class.new(max_total: 5, current: 5) }
+
+    it 'reports the pool budget and the open pool count' do
+      expect(error.message).to(include('5 tenant pools open'))
+      expect(error.message).to(include('effective pool budget is 5'))
+    end
+
+    # The knob names ARE the fix: max_total_connections is deprecated precisely
+    # because it named a pool count "connections". An error that tells the reader
+    # to raise it would re-tell the lie the rename exists to end.
+    it 'names the current knobs and never the deprecated one' do
+      expect(error.message).to(include('max_tenant_pools'))
+      expect(error.message).to(include('max_tenant_connections'))
+      expect(error.message).not_to(include('max_total_connections'))
+    end
+
+    it 'exposes the budget under both readers' do
+      expect(error.max_total).to(eq(5))
+      expect(error.pool_budget).to(eq(5))
+    end
+  end
 end

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe(Apartment::PoolObserver) do
   describe '#sample!' do
     let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 3, tenants: [] }) }
 
-    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+    before do
+      allow(Apartment).to(receive(:pool_manager).and_return(stub_manager))
+      allow(stub_manager).to(receive(:each_pair))
+    end
 
     it 'emits a tenant_pools_live gauge from PoolManager#stats' do
       observer = described_class.new(sink: sink)
@@ -64,10 +67,58 @@ RSpec.describe(Apartment::PoolObserver) do
     end
   end
 
+  describe '#sample! checkout pressure' do
+    def fake_pool(size:, busy:, waiting:)
+      instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool,
+                      stat: { size: size, busy: busy, waiting: waiting })
+    end
+
+    let(:pools) do
+      {
+        'acme:writing' => fake_pool(size: 2, busy: 2, waiting: 3),
+        'beta:writing' => fake_pool(size: 5, busy: 1, waiting: 0),
+      }
+    end
+
+    let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 2, tenants: [] }) }
+
+    before do
+      allow(Apartment).to(receive(:pool_manager).and_return(stub_manager))
+      allow(stub_manager).to(receive(:each_pair)) { |&blk| pools.each(&blk) }
+    end
+
+    it 'counts pools with threads waiting on checkout' do
+      described_class.new(sink: sink).sample!
+      expect(samples.find { |s| s.name == :pools_waiting }.value).to(eq(1))
+    end
+
+    it 'counts saturated pools where busy >= size' do
+      described_class.new(sink: sink).sample!
+      expect(samples.find { |s| s.name == :pools_saturated }.value).to(eq(1))
+    end
+
+    it 'reports the worst waiting count with the tenant in payload, not dimensions' do
+      described_class.new(sink: sink).sample!
+      sample = samples.find { |s| s.name == :max_checkout_waiting }
+      expect(sample).to(have_attributes(kind: :gauge, value: 3, dimensions: {}, payload: { tenant: 'acme:writing' }))
+    end
+
+    it 'skips a pool whose #stat raises without breaking the pass' do
+      broken = instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool)
+      allow(broken).to(receive(:stat).and_raise(StandardError, 'pool tearing down'))
+      pools['broken:writing'] = broken
+      described_class.new(sink: sink).sample!
+      expect(samples.map(&:name)).to(include(:pools_waiting, :pools_saturated, :max_checkout_waiting))
+    end
+  end
+
   describe '#start_sampler! / #stop!' do
     let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 2, tenants: [] }) }
 
-    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+    before do
+      allow(Apartment).to(receive(:pool_manager).and_return(stub_manager))
+      allow(stub_manager).to(receive(:each_pair))
+    end
 
     it 'runs sample! on the configured interval' do
       observer = described_class.new(sink: sink)
@@ -116,14 +167,16 @@ RSpec.describe(Apartment::PoolObserver) do
 
     it 'does not propagate when the sink raises during sample!' do
       allow(Apartment).to(receive(:pool_manager)
-        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] },
+                                                            each_pair: nil)))
       @observer = described_class.new(sink: boom_sink)
       expect { @observer.sample! }.not_to(raise_error)
     end
 
     it 'does not propagate when backend_count raises' do
       allow(Apartment).to(receive(:pool_manager)
-        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] },
+                                                            each_pair: nil)))
       @observer = described_class.new(sink: sink, backend_count: -> { raise('backend boom') })
       expect { @observer.sample! }.not_to(raise_error)
     end

--- a/spec/unit/pool_reaper_spec.rb
+++ b/spec/unit/pool_reaper_spec.rb
@@ -113,6 +113,46 @@ RSpec.describe(Apartment::PoolReaper) do
     end
   end
 
+  # Ties Config's derivation to the admission seam that enforces it. The other
+  # derived-budget specs assert the arithmetic (config_spec) or that admission is
+  # wired at all (apartment_spec); this one asserts the number actually BOUNDS
+  # pool creation -- i.e. that a connection ceiling really is a connection
+  # ceiling, which is the whole claim of the max_tenant_connections knob.
+  describe 'derived connection-budget enforcement' do
+    let(:config) do
+      Apartment::Config.new.tap do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [] }
+        c.tenant_pool_size = 2
+        c.max_tenant_connections = 10 # -> floor(10 / 2) = 5 pools
+        c.apply_defaults!
+        c.validate!
+      end
+    end
+
+    let(:reaper) do
+      described_class.new(
+        pool_manager: pool_manager,
+        interval: 999, # timer must not race the admission path under test
+        idle_timeout: 999,
+        max_total: config.effective_pool_budget,
+        on_evict: on_evict
+      )
+    end
+
+    it 'admits at most floor(max_tenant_connections / tenant_pool_size) pools' do
+      pool_manager.admission_controller = reaper
+
+      8.times { |i| pool_manager.fetch_or_create("tenant_#{i}") { "pool_#{i}" } }
+
+      expect(config.effective_pool_budget).to(eq(5))
+      expect(pool_manager.stats[:total_pools]).to(eq(5))
+      # Admission evicted the LRU pools to stay inside the budget, so the
+      # tenant-pool connection ceiling holds: 5 pools * tenant_pool_size 2 = 10.
+      expect(disconnect_calls).to(include('tenant_0'))
+    end
+  end
+
   describe 'pinned pool protection' do
     # A pool Rails' transactional-fixture machinery has pinned to a single
     # connection. Evicting it would strand the fixture transaction.


### PR DESCRIPTION
## Summary

`max_total_connections` is misnamed: it bounds **pool count**, not connections — `admit!` checks `stats[:total_pools] < @max_total`, so the real per-process ceiling is `pool_count × tenant_pool_size`. An adopter who set `max_total_connections: 8` at `tenant_pool_size: 2` got a true ceiling of 16 connections, not 8. This PR makes the connection budget honest and documents the sizing rule that prevents same-tenant checkout starvation.

Design + plan: `docs/designs/pool-connection-budget.md`, `docs/plans/pool-connection-budget/`.

## What changed

- **Two honest knobs.** `max_tenant_pools` (pool-count cap) and `max_tenant_connections` (a true tenant-pool connection ceiling). Admission enforces `Config#effective_pool_budget = min(max_tenant_pools, floor(max_tenant_connections / tenant_pool_size))`, derived once in `Apartment.configure` so both `admit!` and the timer LRU path use the same bound. `PoolReaper` is unchanged.
- **Validation.** `max_tenant_connections` requires `tenant_pool_size` and must be ≥ it; the two new knobs are positive-integer-or-nil.
- **Deprecation.** `max_total_connections` now aliases `max_tenant_pools` (its true pool-count meaning) with a one-time warning; removed in v5. No behavior change for existing configs.
- **Docs.** The sizing rule (`tenant_pool_size ≥ peak same-tenant per-process concurrency`), the true ceiling formula, the `tenant:role` pool multiplier, lazy-ceiling semantics, and the `:raise` pairing for hard external-pooler budgets.

## Testing

Unit suite green (986 examples, 0 failures) and SQLite integration green (165, 0). RuboCop clean.

## Notes

Not a correctness change — no tenant data-path or isolation impact; capacity, ergonomics, and naming honesty. Checkout-pressure observability follows in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)