### PR TITLE
Feat(v4): checkout-pressure observability gauges

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -147,6 +147,20 @@ Apartment::PoolObserver::Sample
 `PoolManager#stats[:total_pools]`), `:backend_connections` (`value` = your
 `backend_count` callable result; omitted when the callable returns `nil`).
 
+**Checkout-pressure gauges** (per pass, from each tenant pool's AR
+`ConnectionPool#stat`): `:pools_waiting` (count of pools with threads blocked on
+checkout — the same-tenant fan-out starvation signal), `:pools_saturated` (count
+with `busy >= size`), and `:max_checkout_waiting` (the worst pool's `waiting`
+count). The offending tenant is carried in `:max_checkout_waiting`'s **payload**,
+not as a metric dimension, to avoid unbounded time-series churn — promote it to a
+dimension only in a sink you know can absorb the cardinality.
+
+These gauges are sampled **instantaneously** (not peak-held), so a short
+starvation episode can fall between passes. Use a short `sample_interval` (5–10s)
+on Sidekiq/job roles to catch sustained same-tenant fan-out; keep web at the
+default if desired. They show *pressure*, not lossless timeout accounting —
+standard APM captures the resulting `ActiveRecord::ConnectionTimeoutError` itself.
+
 **Dimensions** are curated for cardinality. `reason:` is promoted from payload
 into `dimensions` for any counter event that carries it (currently `:evict`,
 `:skip_evict`, and `:reaper_stopped`). Everything else stays in `payload`.
@@ -178,7 +192,8 @@ sink = lambda do |sample|
 
   case sample.name
   when :cap_unmet
-    # Pool cap is being breached; investigate pool sizing or max_total_connections.
+    # Pool budget is being breached; investigate tenant_pool_size or the
+    # max_tenant_pools / max_tenant_connections ceiling.
     MyAlerts.trigger(:pool_cap_breach, payload: sample.payload)
   when :skip_evict
     # A pool is being skipped repeatedly; may indicate a long-running transaction.

--- a/lib/apartment/CLAUDE.md
+++ b/lib/apartment/CLAUDE.md
@@ -59,7 +59,7 @@ lib/apartment/
 
 ### pool_manager.rb — Pool Cache
 
-`Concurrent::Map` storing connection pools by tenant key. Monotonic clock timestamps for idle/LRU tracking. `stats_for` returns `{ seconds_idle: N }`. `clear` disconnects all pools before clearing. When `max_total_connections` is set, `Apartment.configure` wires an `admission_controller` (the reaper) so cold creates route through a serialized, capacity-bounded path; otherwise the lock-free `compute_if_absent` fast path is used. See `docs/designs/pool-admission-control.md`.
+`Concurrent::Map` storing connection pools by tenant key. Monotonic clock timestamps for idle/LRU tracking. `stats_for` returns `{ seconds_idle: N }`. `clear` disconnects all pools before clearing. When a pool budget is configured (`max_tenant_pools` and/or `max_tenant_connections`, resolved by `Config#effective_pool_budget`; `max_total_connections` is the deprecated alias of `max_tenant_pools`), `Apartment.configure` wires an `admission_controller` (the reaper) so cold creates route through a serialized, capacity-bounded path; otherwise the lock-free `compute_if_absent` fast path is used. See `docs/designs/pool-connection-budget.md` and `docs/designs/pool-admission-control.md`.
 
 ### pool_reaper.rb — Pool Eviction + Admission
 
@@ -97,7 +97,7 @@ All inherit from `AbstractAdapter`. Override `resolve_connection_config`, `creat
 
 ### pool_observer.rb — Observability (opt-in)
 
-Sink-agnostic subscriber for the pool events (`create`/`evict`/`cap_unmet`/`skip_evict`/`reaper_stopped`) + an optional `Concurrent::TimerTask` gauge sampler (`tenant_pools_live`, optional adopter `backend_count`). Normalizes each to a `Sample` and forwards to a caller `sink`; ships no transport. Error-isolated — never raises into instrumentation. See `docs/observability.md`.
+Sink-agnostic subscriber for the pool events (`create`/`evict`/`cap_unmet`/`skip_evict`/`reaper_stopped`) + an optional `Concurrent::TimerTask` gauge sampler. Gauges: `tenant_pools_live`, optional adopter `backend_count`, and per-pass checkout-pressure gauges from each tenant pool's AR `ConnectionPool#stat` — `pools_waiting` (blocked on checkout), `pools_saturated` (`busy >= size`), `max_checkout_waiting` (worst pool's `waiting`, tenant in payload not a dimension). Per-pool `#stat` is rescued so one tearing-down pool can't abort the pass. Normalizes each to a `Sample` via the shared `emit_gauge` helper and forwards to a caller `sink`; ships no transport. Error-isolated — never raises into instrumentation. See `docs/observability.md`.
 
 ### railtie.rb — v4 Rails Integration
 

--- a/lib/apartment/pool_observer.rb
+++ b/lib/apartment/pool_observer.rb
@@ -66,14 +66,15 @@ module Apartment
     # when supplied. Safe to call from start_sampler! or an external scheduler.
     def sample!
       total = Apartment.pool_manager&.stats&.fetch(:total_pools, 0) || 0
-      emit(Sample.new(name: :tenant_pools_live, kind: :gauge, value: total, dimensions: {}, payload: {}))
+      emit_gauge(:tenant_pools_live, total)
+      emit_checkout_pressure!
 
       return unless @backend_count
 
       backends = @backend_count.call
       return if backends.nil?
 
-      emit(Sample.new(name: :backend_connections, kind: :gauge, value: backends, dimensions: {}, payload: {}))
+      emit_gauge(:backend_connections, backends)
     rescue StandardError => e
       warn_failure('sample!', e)
     end
@@ -102,6 +103,43 @@ module Apartment
       @sampler.shutdown
       @sampler.wait_for_termination(5)
       @sampler = nil
+    end
+
+    # Per-tenant-pool checkout pressure, aggregated to low cardinality. waiting>0
+    # means threads are blocked acquiring a connection (the same-tenant fan-out
+    # starvation signal). The worst tenant is carried in the Sample payload, NOT
+    # as a metric dimension, to avoid unbounded time-series churn. Per-pool #stat
+    # is rescued so a pool tearing down mid-sample can't abort the whole pass.
+    def emit_checkout_pressure!
+      manager = Apartment.pool_manager
+      return unless manager
+
+      stats = collect_pool_stats(manager)
+      worst = stats.max_by { |s| s[:pending] } || { tenant: nil, pending: 0 }
+      payload = worst[:pending].positive? ? { tenant: worst[:tenant] } : {}
+
+      emit_gauge(:pools_waiting, stats.count { |s| s[:pending].positive? })
+      emit_gauge(:pools_saturated, stats.count { |s| s[:saturated] })
+      emit_gauge(:max_checkout_waiting, worst[:pending], payload: payload)
+    end
+
+    def emit_gauge(name, value, payload: {})
+      emit(Sample.new(name: name, kind: :gauge, value: value, dimensions: {}, payload: payload))
+    end
+
+    # Read each tenant pool's checkout stats into [{ tenant:, pending:, saturated: }],
+    # skipping any pool whose #stat raises (mid-teardown) so one bad pool can't
+    # abort the whole pass.
+    def collect_pool_stats(manager)
+      stats = []
+      manager.each_pair do |tenant_key, pool|
+        stat = pool.stat
+        stats << { tenant: tenant_key, pending: stat[:waiting].to_i,
+                   saturated: stat[:busy].to_i >= stat[:size].to_i }
+      rescue StandardError
+        next
+      end
+      stats
     end
 
     def record_event(event, payload)

--- a/spec/unit/pool_observer_spec.rb
+++ b/spec/unit/pool_observer_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe(Apartment::PoolObserver) do
   describe '#sample!' do
     let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 3, tenants: [] }) }
 
-    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+    before do
+      allow(Apartment).to(receive(:pool_manager).and_return(stub_manager))
+      allow(stub_manager).to(receive(:each_pair))
+    end
 
     it 'emits a tenant_pools_live gauge from PoolManager#stats' do
       observer = described_class.new(sink: sink)
@@ -64,10 +67,58 @@ RSpec.describe(Apartment::PoolObserver) do
     end
   end
 
+  describe '#sample! checkout pressure' do
+    def fake_pool(size:, busy:, waiting:)
+      instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool,
+                      stat: { size: size, busy: busy, waiting: waiting })
+    end
+
+    let(:pools) do
+      {
+        'acme:writing' => fake_pool(size: 2, busy: 2, waiting: 3),
+        'beta:writing' => fake_pool(size: 5, busy: 1, waiting: 0),
+      }
+    end
+
+    let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 2, tenants: [] }) }
+
+    before do
+      allow(Apartment).to(receive(:pool_manager).and_return(stub_manager))
+      allow(stub_manager).to(receive(:each_pair)) { |&blk| pools.each(&blk) }
+    end
+
+    it 'counts pools with threads waiting on checkout' do
+      described_class.new(sink: sink).sample!
+      expect(samples.find { |s| s.name == :pools_waiting }.value).to(eq(1))
+    end
+
+    it 'counts saturated pools where busy >= size' do
+      described_class.new(sink: sink).sample!
+      expect(samples.find { |s| s.name == :pools_saturated }.value).to(eq(1))
+    end
+
+    it 'reports the worst waiting count with the tenant in payload, not dimensions' do
+      described_class.new(sink: sink).sample!
+      sample = samples.find { |s| s.name == :max_checkout_waiting }
+      expect(sample).to(have_attributes(kind: :gauge, value: 3, dimensions: {}, payload: { tenant: 'acme:writing' }))
+    end
+
+    it 'skips a pool whose #stat raises without breaking the pass' do
+      broken = instance_double(ActiveRecord::ConnectionAdapters::ConnectionPool)
+      allow(broken).to(receive(:stat).and_raise(StandardError, 'pool tearing down'))
+      pools['broken:writing'] = broken
+      described_class.new(sink: sink).sample!
+      expect(samples.map(&:name)).to(include(:pools_waiting, :pools_saturated, :max_checkout_waiting))
+    end
+  end
+
   describe '#start_sampler! / #stop!' do
     let(:stub_manager) { instance_double(Apartment::PoolManager, stats: { total_pools: 2, tenants: [] }) }
 
-    before { allow(Apartment).to(receive(:pool_manager).and_return(stub_manager)) }
+    before do
+      allow(Apartment).to(receive(:pool_manager).and_return(stub_manager))
+      allow(stub_manager).to(receive(:each_pair))
+    end
 
     it 'runs sample! on the configured interval' do
       observer = described_class.new(sink: sink)
@@ -116,14 +167,16 @@ RSpec.describe(Apartment::PoolObserver) do
 
     it 'does not propagate when the sink raises during sample!' do
       allow(Apartment).to(receive(:pool_manager)
-        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] },
+                                                            each_pair: nil)))
       @observer = described_class.new(sink: boom_sink)
       expect { @observer.sample! }.not_to(raise_error)
     end
 
     it 'does not propagate when backend_count raises' do
       allow(Apartment).to(receive(:pool_manager)
-        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] })))
+        .and_return(instance_double(Apartment::PoolManager, stats: { total_pools: 1, tenants: [] },
+                                                            each_pair: nil)))
       @observer = described_class.new(sink: sink, backend_count: -> { raise('backend boom') })
       expect { @observer.sample! }.not_to(raise_error)
     end


### PR DESCRIPTION
## Summary

Adds low-cardinality checkout-pressure gauges so same-tenant pool starvation is a metric, not a multi-hour debug. Extends the existing opt-in `PoolObserver` gauge sampler.

**Stacked on #466** (connection-budget knobs) — review/merge that first; base is `feat/pool-connection-budget`.

## What changed

`PoolObserver#sample!` now walks each tenant pool's AR `ConnectionPool#stat` and emits:

- **`pools_waiting`** — count of pools with `waiting > 0` (threads blocked on checkout — the same-tenant fan-out starvation signal).
- **`pools_saturated`** — count with `busy >= size`.
- **`max_checkout_waiting`** — the worst pool's `waiting`, with the offending tenant in the Sample **payload**, not a metric dimension (a churning tenant label would create unbounded time-series).

Per-pool `#stat` is rescued so a pool tearing down mid-sample can't abort the pass. The existing `tenant_pools_live` / `backend_connections` emits are DRYed through a shared `emit_gauge` helper.

Docs: `docs/observability.md` gauges + sampling guidance (gauges are instantaneous, not peak-held — use a short `sample_interval` on job roles; they show pressure, not lossless timeout counting).

## Testing

Full unit suite green (990 examples, 0 failures) including 4 new checkout-pressure specs. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)