### PR TITLE
Bump version to 4.0.0.alpha9

### DIFF
--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha8'
+  VERSION = '4.0.0.alpha9'
 end


### PR DESCRIPTION
## TLDR

Step 1 of the release flow (`RELEASING.md`): bump `main` to **4.0.0.alpha9**. Merging this PR does **not** publish; the publish is the follow-up `main` → `4-0-alpha` merge PR.

## Why now

alpha9 carries the `deregister_shard` pool-lifecycle fix (#473) for the parallel-migration race: under concurrent tenant migration, the eviction seam could race a concurrent `Tenant.switch` and wedge a tenant with `ConnectionNotEstablished` before any migration SQL ran.

## Content since alpha8 (all already on `main`, CI-green together)

- **#473** W3 / member 9 — `deregister_shard` is now manager-first and does the whole operation; `PoolManager` mutators marked `@api private` (the fix)
- **#471** W1 / member 7 — heal `PQTRANS_INERROR` tenant connections at pool checkin
- **#470** docs — connection-pooler guidance (PgBouncer works, RDS Proxy doesn't)
- **#472** docs — beta readiness after W1

## Diff

Only `lib/apartment/version.rb`: `4.0.0.alpha8` → `4.0.0.alpha9`.

## Next step

After this merges, open the release PR (base `4-0-alpha`, head `main`, **merge commit — never squash** per `RELEASING.md`). That merge triggers `gem-publish.yml` → `rake release` → tag `v4.0.0.alpha9` + push to RubyGems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2GspgZ4PsPQL4Tni4ocf6