### PR TITLE
Release v4.0.0.alpha10

### DIFF
--- a/docs/designs/v4-migrator-per-tenant-connection-release.md
+++ b/docs/designs/v4-migrator-per-tenant-connection-release.md
@@ -1,0 +1,205 @@
+# Migrator: release each tenant's connection after migrating
+
+**Status**: designed 2026-07-21, from a deploy-time pool-pressure incident
+(2026-07-20). Ships in `4.0.0.alpha10`.
+
+## Verdict
+
+- **The Migrator leaks a leased connection per tenant.**
+  `Apartment::Tenant.switch(tenant) { }` restores `Current.tenant` on block exit
+  but never checks the connection back in. In a rake process (no Rails executor to
+  release on request end), each worker thread's connection to the just-migrated
+  tenant's pool stays `in_use?` until end of run.
+- **That leak is the deploy-flood amplifier.** A leased pool is non-evictable:
+  `PoolReaper#pool_in_use?` → `protected_pool?` skips it (`:skip_evict`), and
+  admission can't meet the cap (`:cap_unmet`). Finished-but-leased pools are
+  re-scanned on every cold admission — 34,879 `skip_evict` + 314 `cap_unmet` in
+  ~2 min during the 2026-07-20 deploy.
+- **Fix: release the worker's own lease after each tenant.** In `migrate_tenant`'s
+  existing `ensure`, best-effort `tenant_pool&.release_connection` on the pool
+  captured inside the `switch` block. Execution-context scoped — releases only the
+  calling worker's lease, cannot touch another thread's active pool (the hard
+  constraint). See [decisions](#decisions).
+- **Targeted release, not handler-wide `clear_active_connections!(:all)`.**
+  `migrate_tenant` is shared by the parallel, sequential, and single-tenant
+  (`migrate_one`) paths; the latter two run on a **caller-owned** execution context
+  that may hold other leases. Handler-wide `:all` would release the caller's
+  unrelated connections there. Targeted per-pool release is safe on every path.
+- **No per-tenant pool teardown.** Release makes the pool evictable; admission /
+  the reaper / the end-of-run `evict_migration_pools` remove it. Mid-run per-tenant
+  removal has a TOCTOU (another context can re-acquire the key before removal) and
+  a shared-role hazard — deliberately excluded.
+- **The card's acceptance was mis-stated and is corrected here.**
+  `TenantPoolsLive` counts *registered* pools, not leased ones, so release alone
+  does not drive that gauge to thread-count. See
+  [acceptance](#acceptance-corrected).
+
+## Mechanism
+
+`migrate_tenant` leases a connection on the worker thread and never releases it:
+
+```ruby
+def migrate_tenant(tenant)
+  Apartment::Current.migrating = true
+  with_migration_role do                       # connected_to(role: migration_role)
+    Apartment::Tenant.switch(tenant) do
+      context = ActiveRecord::Base.connection_pool.migration_context
+      # ... context.migrate leases a connection on THIS thread ...
+    end
+  end
+ensure
+  Apartment::Current.migrating = false         # connection is NEVER checked back in
+end
+```
+
+`switch` only sets/restores `Current.tenant`; `with_migration_role` /
+`connected_to` only swap the active role. Neither checks a connection in. Under a
+web request the Rails executor releases on request end; a rake process has no such
+boundary, so the lease persists to end of run.
+
+The amplifier, in `PoolReaper`:
+
+```ruby
+def pool_in_use?(pool)
+  pool.connections.any? { |c| c.in_use? || c.open_transactions.positive? }
+end
+# true => protected_pool? emits :skip_evict and refuses eviction;
+#         cap can't be met => :cap_unmet, re-evaluated on every cold admission.
+```
+
+## Design
+
+Single change, in `lib/apartment/migrator.rb`, `migrate_tenant` only:
+
+1. Capture the tenant pool as the **first statement inside the `switch` block**
+   (before the `needs_migration?` check, so the skip path is covered too), then
+   **lease it eagerly**:
+
+   ```ruby
+   tenant_pool = ActiveRecord::Base.connection_pool
+   tenant_pool.lease_connection
+   context = tenant_pool.migration_context
+   ```
+
+   The eager lease closes a capture→lease window (see [the race](#the-capture-lease-race)):
+   it keeps the pool `in_use?` for the whole method, so a parallel admission pass
+   cannot evict it mid-flight, and it guarantees the release below targets the pool
+   that actually holds the lease.
+2. In the existing `ensure`, after `Apartment::Current.migrating = false`, call a
+   best-effort private helper `release_tenant_pool_connection(tenant, tenant_pool)`.
+   It `release_connection`s the captured pool, rescues any error, and `warn`s with
+   the tenant name inside a nested rescue (a broken `$stderr` raises `IOError`, a
+   `StandardError`) — the same guard `instrument_failure` applies to its own warn,
+   so a release failure can never mask the migration error or the returned `Result`.
+
+`release_connection` / `lease_connection` are public
+`ActiveRecord::ConnectionAdapters::ConnectionPool` API across the supported Rails
+7.2–8.1 matrix. `release_connection` releases the current execution context's lease
+on that specific pool and no-ops when nothing is leased.
+
+### The capture→lease race
+
+Without the eager lease, there is a window between capturing the pool and the
+sticky lease taken in `with_advisory_locks_disabled` where the pool holds zero
+leased connections. Under a parallel migrate with a cap, another worker's admission
+pass could evict that idle pool; the subsequent `lease_connection` would then
+resolve a **different** replacement pool, and the `ensure` would release the stale
+captured one — leaking the replacement's lease and recreating the incident for that
+pool. The window is narrow and pre-dates this fix, but the eager lease removes it
+entirely and makes "everything `migrate_tenant` leases goes through the captured
+pool" true rather than nearly-true. Surfaced by an adversarial review panel.
+
+**Untouched by design:**
+
+- `migrate_primary` — uses the app's default pool on the main thread; that pool is
+  eviction-protected (`default_tenant_pool?`) and must not be released here.
+- End-of-run `evict_migration_pools` — role-scoped bulk teardown; release does not
+  replace it.
+
+**Why the release is best-effort:** a release failure must never mask a migration
+error or corrupt the returned `Result`. Same rescue+warn posture as
+`Tenant.each(release_connection:)`.
+
+## Decisions
+
+### Targeted `release_connection` over handler-wide `:all`
+
+`clear_active_connections!(:all)` (the `Tenant.each` idiom) is tempting for
+consistency, but the decider is safety: because the release lives in
+`migrate_tenant`, and
+`migrate_one` / the sequential path run on a **caller-owned** execution context,
+handler-wide `clear_active_connections!(:all)` would release the caller's unrelated
+leases (default pool, an outer connection) on those paths.
+`Tenant.each(release_connection:)` gets away with `:all` only because the breadth
+is gated behind an opt-in flag the caller chooses. Here it would be unconditional.
+Targeted per-pool release is safe regardless of caller and makes the
+"don't-affect-others" constraint visible in the code.
+
+### No `:all` fallback when `tenant_pool` is nil
+
+`tenant_pool` is captured as the first line inside the `switch` block, before any
+lease. It is nil only when we bailed *before* leasing anything (a raising
+default-tenant guard or role switch) — so there is nothing of ours to release.
+Everything `migrate_tenant` leases goes through the captured pool, so
+`tenant_pool&.release_connection` is complete. A `:all` fallback would find nothing
+of ours and, on the caller-owned paths, would release the caller's connections —
+reintroducing the exact breadth hazard targeted release avoids. A regression test
+asserting zero busy connections after each tenant guards a future off-pool lease.
+
+### No per-tenant pool removal
+
+Removing the tenant's migration pool mid-run to shrink the *registered*-pool gauge
+would need an identity-checked, admission-coordinated eviction primitive — the
+existing `evict_migration_pools` drops **all** migration-role pools and can
+disconnect a pool another worker is using. Two hazards make direct per-tenant
+removal unsafe: TOCTOU (another context re-acquires the key between release and
+remove) and shared-role teardown (dropping `:writing` when no distinct
+`migration_role` is configured). Release + existing eviction paths already resolve
+the incident.
+
+## Acceptance (corrected)
+
+The card asked for `TenantPoolsLive ~thread-count`. `TenantPoolsLive` is
+`PoolObserver#sample!` emitting `PoolManager#stats[:total_pools]` — a count of
+**registered** pools, not leased ones. Releasing a connection makes a pool
+evictable but does not deregister it, so that gauge stays bounded by the cap
+(`max_tenant_pools`), not thread-count. The count that tracks ~thread-count is the
+*busy/leased* pool count. Corrected, verifiable acceptance:
+
+- `skip_evict` with `reason: :in_use` → ~0 during a parallel migrate.
+- `cap_unmet` → ~0 during the deploy window.
+- Busy/leased migration pools ~thread-count (at most one per worker at a time).
+- `TenantPoolsLive` (registered pools) bounded by the cap.
+- Migration correctness unchanged.
+
+## Testing
+
+`spec/integration/v4/migrator_connection_release_spec.rb`:
+
+- **Success path**: after a run, every tenant pool reports **0 busy connections**
+  and **0 open transactions**.
+- **Failure path**: `Boom` raises **only for tenants** (not the default), so
+  `migrate_primary` succeeds and every tenant genuinely reaches `migrate_tenant`'s
+  rescue — asserting `run.failed` covers all tenants, then each pool is released
+  with **0 open transactions**. (Raising unconditionally makes `migrate_primary`
+  fail first and `run` abort before any tenant migrates, which silently reduces the
+  test to a no-op — caught in review.)
+- **Skip path**: an up-to-date tenant (`needs_migration?` false) releases cleanly.
+- **Caller-connection safety**: leasing pool A then migrating a different tenant B
+  leaves A's lease intact and releases B's — fails if the release were `:all`.
+- **Sequential cap (admission)**: `max_tenant_pools = 2`, 3 tenants, asserts
+  `run.success?` (no vacuous pass), no `cap_unmet`, tenant pools ≤ cap.
+- **Parallel cap (admission)**: the production shape — `threads: 2` under the cap;
+  asserts `run.success?`, no `cap_unmet`, and no finished pool left leased after
+  join. Skipped on SQLite (no concurrent connections); runs on PG/MySQL. This is
+  the example that exercises the capture→lease race.
+
+Acceptance-level signal: during a parallel migrate, `skip_evict(:in_use)` and
+`cap_unmet` stay ~0; busy pools ~thread-count; `TenantPoolsLive` (registered)
+bounded by the cap.
+
+## Scope boundary
+
+- Version bump `4.0.0.alpha9` → `4.0.0.alpha10`, in this PR.
+- Adopting apps pick up the fix by bumping their `ros-apartment` dependency; no
+  adopter code change is required.

--- a/docs/plans/v4-migrator-connection-release/implementation.md
+++ b/docs/plans/v4-migrator-connection-release/implementation.md
@@ -1,0 +1,414 @@
+# Migrator per-tenant connection release — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Release each worker's leased connection after every tenant migration so finished migration pools stop jamming pool admission (`skip_evict` / `cap_unmet`).
+
+**Architecture:** One targeted change in `Apartment::Migrator#migrate_tenant`: capture the tenant's `ConnectionPool` inside the `switch` block and, in the method's existing `ensure`, best-effort `release_connection` on it. Execution-context scoped, so it only releases the calling worker's own lease. Plus a dedicated integration spec and a version bump.
+
+**Tech Stack:** Ruby, ActiveRecord (Rails 7.2–8.1), RSpec, Apartment v4 pool-per-tenant model.
+
+**Design doc:** `docs/designs/v4-migrator-per-tenant-connection-release.md`
+
+## Global Constraints
+
+- **Targeted release only.** Use `pool.release_connection` on the captured tenant pool. Do NOT use `ActiveRecord::Base.connection_handler.clear_active_connections!(:all)` — its breadth would release a caller's other leases on the shared sequential / `migrate_one` paths.
+- **Best-effort.** A release failure must be rescued and `warn`ed, never raised — it must not mask a migration error or corrupt the returned `Result`.
+- **Do not touch `migrate_primary`.** It uses the app's default pool, which is eviction-protected and must not be released here.
+- **No per-tenant pool teardown.** Do not add `remove`/`deregister_shard`/`evict_by_role` per tenant. The end-of-run `evict_migration_pools` stays as-is.
+- **Rails version floor:** `release_connection` is public `ActiveRecord::ConnectionAdapters::ConnectionPool` API across the supported 7.2–8.1 matrix; no version guard needed.
+
+---
+
+### Task 1: Release the tenant connection in `migrate_tenant`
+
+**Files:**
+- Modify: `lib/apartment/migrator.rb` (`Apartment::Migrator#migrate_tenant`, currently lines 145–188)
+- Create: `spec/integration/v4/migrator_connection_release_spec.rb`
+
+**Interfaces:**
+- Consumes: `Apartment::Migrator.new(threads:)#run`; `Apartment.pool_manager.peek(pool_key)` → `ActiveRecord::ConnectionAdapters::ConnectionPool`; pool key format `"#{tenant}:#{ActiveRecord::Base.current_role}"`.
+- Produces: no new public API. `migrate_tenant` behavior: after it returns (success, skip, or failure), the tenant's pool has zero `in_use?` connections and zero open transactions attributable to the migrating worker.
+
+- [ ] **Step 1: Write the failing test (success path)**
+
+Create `spec/integration/v4/migrator_connection_release_spec.rb`. This mirrors the setup in `spec/integration/v4/migrator_integration_spec.rb` (no `migration_role`, no cap — so `evict_migration_pools` no-ops and pools survive for inspection).
+
+```ruby
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+require 'apartment/migrator'
+
+# Regression coverage for docs/designs/v4-migrator-per-tenant-connection-release.md:
+# migrate_tenant must release the worker's leased connection so finished pools
+# are no longer in_use? (and therefore admission-evictable).
+#
+#   bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_connection_release_spec.rb
+RSpec.describe('v4 Migrator connection release', :integration) do
+  before(:all) do
+    skip('requires ActiveRecord + database gem') unless V4_INTEGRATION_AVAILABLE
+  end
+
+  include V4IntegrationHelper
+
+  let(:tmp_dir) { Dir.mktmpdir('apartment_migrator_release') }
+  let(:migrations_dir) { File.join(tmp_dir, 'migrate') }
+  let(:test_tenants) { %w[release_test_a release_test_b release_test_c] }
+  let(:original_migrations_paths) { ActiveRecord::Migrator.migrations_paths.dup }
+
+  def write_test_migration(dir)
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, '20240101000001_create_release_test_widgets.rb'), <<~RUBY)
+      # frozen_string_literal: true
+      class CreateReleaseTestWidgets < ActiveRecord::Migration[7.0]
+        def change
+          create_table(:release_test_widgets, force: true) do |t|
+            t.string :name
+          end
+        end
+      end
+    RUBY
+  end
+
+  # Peek the pool AR created for a tenant under the current role, without
+  # touching its idle timestamp.
+  def tenant_pool(tenant)
+    Apartment.pool_manager.peek("#{tenant}:#{ActiveRecord::Base.current_role}")
+  end
+
+  def busy_connections(pool)
+    pool.connections.count { |c| c.in_use? }
+  end
+
+  def open_transactions(pool)
+    pool.connections.sum { |c| c.respond_to?(:open_transactions) ? c.open_transactions : 0 }
+  end
+
+  before do
+    write_test_migration(migrations_dir)
+    ActiveRecord::Migrator.migrations_paths = [migrations_dir]
+
+    V4IntegrationHelper.ensure_test_database! unless V4IntegrationHelper.sqlite?
+    config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+
+    Apartment.configure do |c|
+      c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+      c.tenants_provider = -> { test_tenants }
+      c.default_tenant = V4IntegrationHelper.default_tenant
+      c.check_pending_migrations = false
+    end
+
+    Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+    Apartment.activate!
+    test_tenants.each { |t| Apartment.adapter.create(t) }
+  end
+
+  after do
+    ActiveRecord::Migrator.migrations_paths = original_migrations_paths
+    Apartment::Tenant.reset
+    V4IntegrationHelper.cleanup_tenants!(test_tenants, Apartment.adapter)
+    Apartment.clear_config
+    Apartment::Current.reset
+    if V4IntegrationHelper.sqlite?
+      ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+      FileUtils.rm_rf(tmp_dir)
+    end
+  end
+
+  it 'leaves no leased connection on any tenant pool after a successful run' do
+    Apartment::Migrator.new(threads: 0).run
+
+    test_tenants.each do |tenant|
+      pool = tenant_pool(tenant)
+      expect(pool).not_to(be_nil), "expected a pool for #{tenant}"
+      expect(busy_connections(pool)).to(
+        eq(0), "expected #{tenant} pool to have no leased connection after migrating"
+      )
+      expect(open_transactions(pool)).to(eq(0))
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_connection_release_spec.rb -e "no leased connection"`
+Expected: FAIL — `busy_connections(pool)` is `1` (the migrating thread's lease is never checked in). If it unexpectedly PASSES, stop: the leak premise is wrong for this Rails version — reassess before implementing.
+
+- [ ] **Step 3: Implement the release in `migrate_tenant`**
+
+Edit `lib/apartment/migrator.rb`. Make exactly three changes to `migrate_tenant`:
+
+(a) Add `tenant_pool = nil` immediately after `Apartment::Current.migrating = true` (method scope, so it is visible in the `ensure`):
+
+```ruby
+    def migrate_tenant(tenant) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      start = monotonic_now
+      Apartment::Current.migrating = true
+      tenant_pool = nil
+```
+
+(b) Capture the pool as the FIRST statement inside the `switch` block, and read `migration_context` off it (so the skip path is covered and we don't call `connection_pool` twice):
+
+```ruby
+      with_migration_role do
+        Apartment::Tenant.switch(tenant) do
+          tenant_pool = ActiveRecord::Base.connection_pool
+          context = tenant_pool.migration_context
+```
+
+(c) Extend the existing `ensure` (currently just resets the `migrating` flag) with the best-effort release:
+
+```ruby
+    ensure
+      Apartment::Current.migrating = false
+      # Release THIS worker's lease on the tenant pool so the finished pool is no
+      # longer in_use? and becomes admission-evictable. Targeted (not handler-wide
+      # clear_active_connections!) so the shared sequential / migrate_one paths,
+      # which run on a caller-owned execution context, do not release a caller's
+      # other leases. Best-effort: a release failure must never mask a migration
+      # error or the returned Result.
+      # See docs/designs/v4-migrator-per-tenant-connection-release.md.
+      begin
+        tenant_pool&.release_connection
+      rescue StandardError => release_error
+        warn "[Apartment::Migrator] connection release failed: " \
+             "#{release_error.class}: #{release_error.message}"
+      end
+    end
+```
+
+Leave `migrate_primary`, `run`, `run_parallel`, `run_sequential`, and `evict_migration_pools` unchanged.
+
+- [ ] **Step 4: Run the success-path test to verify it PASSES**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_connection_release_spec.rb -e "no leased connection"`
+Expected: PASS.
+
+- [ ] **Step 5: Add the failure-path and skip-path tests**
+
+Append two more examples inside the same `describe` block in `spec/integration/v4/migrator_connection_release_spec.rb`.
+
+Failure path — a raising migration must still release (and Rails must have rolled the transaction back, so `open_transactions == 0` too):
+
+```ruby
+  it 'releases the connection even when a tenant migration raises' do
+    # Add a second migration that always raises, so migrate_tenant hits its rescue.
+    File.write(File.join(migrations_dir, '20240101000002_boom.rb'), <<~RUBY)
+      # frozen_string_literal: true
+      class Boom < ActiveRecord::Migration[7.0]
+        def change
+          raise 'boom'
+        end
+      end
+    RUBY
+
+    run = Apartment::Migrator.new(threads: 0).run
+    expect(run.failed).not_to(be_empty)
+
+    test_tenants.each do |tenant|
+      pool = tenant_pool(tenant)
+      next if pool.nil?
+
+      expect(busy_connections(pool)).to(eq(0))
+      expect(open_transactions(pool)).to(eq(0))
+    end
+  end
+
+  it 'releases cleanly on the skip path (already up to date)' do
+    Apartment::Migrator.new(threads: 0).run          # bring all tenants current
+    second = Apartment::Migrator.new(threads: 0).run  # everything :skipped now
+
+    expect(second.results.reject { |r| r.tenant == Apartment.config.default_tenant })
+      .to(all(have_attributes(status: :skipped)))
+
+    test_tenants.each do |tenant|
+      pool = tenant_pool(tenant)
+      expect(busy_connections(pool)).to(eq(0)) if pool
+    end
+  end
+```
+
+- [ ] **Step 6: Run the full new spec file to verify all pass**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_connection_release_spec.rb`
+Expected: 3 examples, 0 failures.
+
+- [ ] **Step 7: Rubocop on both changed files**
+
+Run: `bundle exec rubocop lib/apartment/migrator.rb spec/integration/v4/migrator_connection_release_spec.rb`
+Expected: no offenses. (If `migrate_tenant` trips `Metrics/MethodLength`/`AbcSize`, the existing `rubocop:disable` on its `def` line already covers it — do not add new disables without cause.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/apartment/migrator.rb spec/integration/v4/migrator_connection_release_spec.rb
+git commit -m "Fix(v4): Migrator releases each tenant's connection after migrating
+
+migrate_tenant leased a connection per tenant (switch restores Current.tenant
+but never checks the connection in), leaving finished migration pools in_use?
+and non-evictable — the skip_evict/cap_unmet amplifier. Capture the tenant pool
+inside the switch block and best-effort release_connection it in the ensure.
+Targeted (not handler-wide) so the shared sequential/migrate_one paths don't
+release a caller's other leases.
+
+See docs/designs/v4-migrator-per-tenant-connection-release.md.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_014NsWCDm8xAb6EwHfCaniDp"
+```
+
+---
+
+### Task 2: Guards — caller-connection safety + admission under a cap
+
+**Files:**
+- Modify: `spec/integration/v4/migrator_connection_release_spec.rb` (add the caller-held-connection safety example to the existing `describe`, then a `describe 'under a pool cap'` context)
+
+**Interfaces:**
+- Consumes: `Apartment::Migrator#migrate_tenant` (private — invoked via `.send(:migrate_tenant, name)` for the isolated safety test); `Apartment.configure { |c| c.max_tenant_pools = N }` (wires `PoolReaper` as the admission controller); `Apartment.pool_manager.stats[:tenants]`; `ActiveSupport::Notifications` event `cap_unmet.apartment`; the `tenant_pool` / `busy_connections` helpers from Task 1's spec file.
+- Produces: (a) proof that the targeted release does NOT disturb a connection the caller holds on a *different* pool (the guard that fails if anyone swaps in `clear_active_connections!(:all)`); (b) proof that after release, sequential migration over more tenants than the cap does not emit `:cap_unmet` and keeps registered pools bounded by the cap — the deterministic stand-in for the production `skip_evict`/`cap_unmet` flood.
+
+- [ ] **Step 1: Add the caller-connection safety test**
+
+This is the design doc's fourth Testing scenario ("release does not disturb a caller-held connection"). Add it as an example in the **existing top-level `describe`** in `spec/integration/v4/migrator_connection_release_spec.rb` (it reuses the `tenant_pool` and `busy_connections` helpers already defined there). It leases tenant A's pool on the test thread, migrates a *different* tenant B via `migrate_tenant`, and asserts A's lease survived while B's was released. A handler-wide `clear_active_connections!(:all)` would release A too — so this example is the regression guard for the targeted-vs-`:all` decision.
+
+```ruby
+  it 'targeted release does not disturb a connection the caller holds on another pool' do
+    # Caller leases tenant A's pool on this thread; switch does not check it in,
+    # so the lease persists after the block (that is the bug this fix addresses).
+    Apartment::Tenant.switch(test_tenants[0]) do
+      ActiveRecord::Base.connection.execute('SELECT 1')
+    end
+    pool_a = tenant_pool(test_tenants[0])
+    expect(busy_connections(pool_a)).to(eq(1)) # caller's lease established
+
+    # Migrate a DIFFERENT tenant; its targeted release touches only tenant B's pool.
+    Apartment::Migrator.new(threads: 0).send(:migrate_tenant, test_tenants[1])
+
+    expect(busy_connections(pool_a)).to(eq(1)) # caller's lease on A untouched
+    expect(busy_connections(tenant_pool(test_tenants[1]))).to(eq(0)) # B released
+  end
+```
+
+- [ ] **Step 2: Write the cap test**
+
+Add this context to `spec/integration/v4/migrator_connection_release_spec.rb`. It re-runs `Apartment.configure` with a cap (config is frozen after configure, so a fresh `configure` + `activate!` is required — see CLAUDE.md "Frozen config"). Uses sequential migration to avoid thread-timing flakiness; the background reaper's 300s idle timeout guarantees it does not interfere, so any eviction is admission-driven.
+
+```ruby
+  describe 'under a pool cap (admission)' do
+    # default pool (protected) + cap of 2 tenant pools, migrating 3 tenants,
+    # forces at least one admission eviction. With the connection released after
+    # each tenant, the LRU tenant pool is not in_use? and evicts cleanly, so no
+    # :cap_unmet fires. Without release it would (the production incident).
+    before do
+      Apartment.configure do |c|
+        c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+        c.tenants_provider = -> { test_tenants }
+        c.default_tenant = V4IntegrationHelper.default_tenant
+        c.check_pending_migrations = false
+        c.max_tenant_pools = 2
+      end
+      Apartment.activate!
+    end
+
+    it 'does not emit :cap_unmet and keeps registered pools within the cap' do
+      cap_unmet = []
+      sub = ActiveSupport::Notifications.subscribe('cap_unmet.apartment') do |*args|
+        cap_unmet << args.last
+      end
+
+      Apartment::Migrator.new(threads: 0).run
+
+      # Count only the test-tenant pools (keys "<tenant>:<role>"), excluding the
+      # protected default pool and any reading-role pool, so the bound is robust.
+      tenant_pool_count = Apartment.pool_manager.stats[:tenants].count do |key|
+        test_tenants.any? { |t| key.to_s.start_with?("#{t}:") }
+      end
+      expect(cap_unmet).to(be_empty)
+      expect(tenant_pool_count).to(be <= 2)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub)
+    end
+  end
+```
+
+> Event name confirmed: `Apartment::Instrumentation.instrument(:cap_unmet, ...)` publishes `cap_unmet.apartment` (all Apartment events are `*.apartment`, per `lib/apartment/instrumentation.rb`). The `subscribe('cap_unmet.apartment')` string above is correct.
+
+- [ ] **Step 3: Run both new tests**
+
+Run: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_connection_release_spec.rb -e "caller holds" -e "under a pool cap"`
+Expected: PASS — caller's lease on A survives; no `:cap_unmet`; tenant pools ≤ 2.
+
+Sanity check (proves both tests have teeth): temporarily change `tenant_pool&.release_connection` in `migrate_tenant` to `ActiveRecord::Base.connection_handler.clear_active_connections!(:all)` and re-run — the caller-connection test should FAIL (A's lease dropped to 0). Then comment the release out entirely and re-run — the cap test should FAIL with a non-empty `cap_unmet`. Restore the correct line before committing.
+
+- [ ] **Step 4: Rubocop**
+
+Run: `bundle exec rubocop spec/integration/v4/migrator_connection_release_spec.rb`
+Expected: no offenses.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spec/integration/v4/migrator_connection_release_spec.rb
+git commit -m "Test(v4): guard caller-connection safety and cap admission on release
+
+Two guards for the release fix: (1) targeted release does not disturb a
+connection the caller holds on another pool — the regression guard against
+swapping in clear_active_connections!(:all); (2) deterministic stand-in for the
+production skip_evict/cap_unmet flood — with a 2-pool cap and 3 tenants migrated
+sequentially, admission evicts the released LRU tenant pool cleanly and no
+:cap_unmet fires.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_014NsWCDm8xAb6EwHfCaniDp"
+```
+
+---
+
+### Task 3: Version bump to 4.0.0.alpha10
+
+**Files:**
+- Modify: `lib/apartment/version.rb`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Apartment::VERSION == '4.0.0.alpha10'`.
+
+- [ ] **Step 1: Bump the version**
+
+Edit `lib/apartment/version.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+module Apartment
+  VERSION = '4.0.0.alpha10'
+end
+```
+
+- [ ] **Step 2: Verify the gem builds**
+
+Run: `gem build ros-apartment.gemspec`
+Expected: builds `ros-apartment-4.0.0.alpha10.gem` with no error. Remove the built artifact afterward: `rm -f ros-apartment-4.0.0.alpha10.gem`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/apartment/version.rb
+git commit -m "Bump version to 4.0.0.alpha10
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_014NsWCDm8xAb6EwHfCaniDp"
+```
+
+---
+
+## Verification before PR
+
+- [ ] Full new spec file green on SQLite: `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_connection_release_spec.rb`
+- [ ] Existing migrator specs still green (no regression): `bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_integration_spec.rb spec/unit/migrator_spec.rb`
+- [ ] PostgreSQL pass (the incident engine): `DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/migrator_connection_release_spec.rb`
+- [ ] Rubocop clean on all changed files: `bundle exec rubocop lib/apartment/migrator.rb lib/apartment/version.rb spec/integration/v4/migrator_connection_release_spec.rb`

--- a/lib/apartment/migrator.rb
+++ b/lib/apartment/migrator.rb
@@ -146,10 +146,19 @@ module Apartment
     def migrate_tenant(tenant) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       start = monotonic_now
       Apartment::Current.migrating = true
+      tenant_pool = nil
 
       with_migration_role do
         Apartment::Tenant.switch(tenant) do
-          context = ActiveRecord::Base.connection_pool.migration_context
+          tenant_pool = ActiveRecord::Base.connection_pool
+          # Lease eagerly so the pool stays in_use? for the whole migration. This
+          # closes a capture->lease window: a parallel admission pass could
+          # otherwise evict the not-yet-leased pool, and the later lease_connection
+          # (in with_advisory_locks_disabled) would resolve a DIFFERENT replacement
+          # pool that this method's ensure would not release. It also guarantees the
+          # release below targets the pool that actually holds the lease.
+          tenant_pool.lease_connection
+          context = tenant_pool.migration_context
 
           unless @version || context.needs_migration?
             return Result.new(
@@ -186,6 +195,7 @@ module Apartment
       )
     ensure
       Apartment::Current.migrating = false
+      release_tenant_pool_connection(tenant, tenant_pool)
     end
 
     def run_sequential(tenants)
@@ -276,6 +286,25 @@ module Apartment
     # cannot re-escape the handler. Success-path instrumentation is left
     # un-isolated by design — only the failure path carries the hard no-raise
     # guarantee, and swallowing there would mask real subscriber bugs.
+    # Best-effort release of THIS worker's lease on the tenant pool, so the
+    # finished pool is no longer in_use? and becomes admission-evictable.
+    # Targeted (not handler-wide clear_active_connections!) so the shared
+    # sequential / migrate_one paths, which run on a caller-owned execution
+    # context, do not release a caller's other leases. A release failure must
+    # never mask the migration error or the returned Result, so it is swallowed
+    # and warned; the warn is nested-rescued because a broken $stderr raises
+    # IOError (a StandardError) — the same guard instrument_failure applies to
+    # its own warn. See docs/designs/v4-migrator-per-tenant-connection-release.md.
+    def release_tenant_pool_connection(tenant, pool)
+      pool&.release_connection
+    rescue StandardError => e
+      begin
+        warn "[Apartment::Migrator] connection release failed for #{tenant}: #{e.class}: #{e.message}"
+      rescue StandardError
+        nil
+      end
+    end
+
     def instrument_failure(tenant, error, duration)
       Instrumentation.instrument(:migrate_tenant_failed, tenant: tenant, error: error, duration: duration)
     rescue StandardError => e

--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha9'
+  VERSION = '4.0.0.alpha10'
 end

--- a/spec/integration/v4/migrator_connection_release_spec.rb
+++ b/spec/integration/v4/migrator_connection_release_spec.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+require 'apartment/migrator'
+
+# Regression coverage for docs/designs/v4-migrator-per-tenant-connection-release.md:
+# migrate_tenant must release the worker's leased connection so finished pools
+# are no longer in_use? (and therefore admission-evictable).
+#
+#   bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/migrator_connection_release_spec.rb
+RSpec.describe('v4 Migrator connection release', :integration) do
+  before(:all) do
+    skip('requires ActiveRecord + database gem') unless V4_INTEGRATION_AVAILABLE
+  end
+
+  include V4IntegrationHelper
+
+  let(:tmp_dir) { Dir.mktmpdir('apartment_migrator_release') }
+  let(:migrations_dir) { File.join(tmp_dir, 'migrate') }
+  let(:test_tenants) { %w[release_test_a release_test_b release_test_c] }
+  let(:original_migrations_paths) { ActiveRecord::Migrator.migrations_paths.dup }
+
+  def write_test_migration(dir)
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, '20240101000001_create_release_test_widgets.rb'), <<~RUBY)
+      # frozen_string_literal: true
+      class CreateReleaseTestWidgets < ActiveRecord::Migration[7.0]
+        def change
+          create_table(:release_test_widgets, force: true) do |t|
+            t.string :name
+          end
+        end
+      end
+    RUBY
+  end
+
+  # Peek the pool AR created for a tenant under the current role, without
+  # touching its idle timestamp.
+  def tenant_pool(tenant)
+    Apartment.pool_manager.peek("#{tenant}:#{ActiveRecord::Base.current_role}")
+  end
+
+  def busy_connections(pool)
+    pool.connections.count(&:in_use?)
+  end
+
+  def open_transactions(pool)
+    pool.connections.sum { |c| c.respond_to?(:open_transactions) ? c.open_transactions : 0 }
+  end
+
+  before do
+    write_test_migration(migrations_dir)
+    ActiveRecord::Migrator.migrations_paths = [migrations_dir]
+
+    V4IntegrationHelper.ensure_test_database! unless V4IntegrationHelper.sqlite?
+    @connection_config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+
+    Apartment.configure do |c|
+      c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+      c.tenants_provider = -> { test_tenants }
+      c.default_tenant = V4IntegrationHelper.default_tenant
+      c.check_pending_migrations = false
+    end
+
+    Apartment.adapter = V4IntegrationHelper.build_adapter(@connection_config)
+    Apartment.activate!
+    test_tenants.each { |t| Apartment.adapter.create(t) }
+  end
+
+  after do
+    ActiveRecord::Migrator.migrations_paths = original_migrations_paths
+    Apartment::Tenant.reset
+    V4IntegrationHelper.cleanup_tenants!(test_tenants, Apartment.adapter)
+    Apartment.clear_config
+    Apartment::Current.reset
+    if V4IntegrationHelper.sqlite?
+      ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+      FileUtils.rm_rf(tmp_dir)
+    end
+  end
+
+  it 'leaves no leased connection on any tenant pool after a successful run' do
+    Apartment::Migrator.new(threads: 0).run
+
+    test_tenants.each do |tenant|
+      pool = tenant_pool(tenant)
+      expect(pool).not_to(be_nil, "expected a pool for #{tenant}")
+      expect(busy_connections(pool)).to(
+        eq(0), "expected #{tenant} pool to have no leased connection after migrating"
+      )
+      expect(open_transactions(pool)).to(eq(0))
+    end
+  end
+
+  it 'releases the connection even when a tenant migration raises' do
+    # A second migration that raises ONLY for tenants, not the default (primary)
+    # tenant. If it raised unconditionally, migrate_primary — which runs first —
+    # would fail and Migrator#run would abort before touching any tenant, so the
+    # per-tenant failure path (the thing under test) would never execute. Scoping
+    # the raise lets the primary succeed and every tenant hit migrate_tenant's
+    # rescue for real.
+    File.write(File.join(migrations_dir, '20240101000002_boom.rb'), <<~RUBY)
+      # frozen_string_literal: true
+      class Boom < ActiveRecord::Migration[7.0]
+        def change
+          return if Apartment::Tenant.current.to_s == Apartment.config.default_tenant.to_s
+
+          raise 'boom'
+        end
+      end
+    RUBY
+
+    run = Apartment::Migrator.new(threads: 0).run
+
+    # Every tenant must have failed (proving the rescue path ran); the primary
+    # must not be among the failures.
+    expect(run.failed.map(&:tenant)).to(match_array(test_tenants))
+
+    test_tenants.each do |tenant|
+      pool = tenant_pool(tenant)
+      # The pool exists because migrate_tenant captured it before Boom raised.
+      expect(pool).not_to(be_nil, "expected a pool for #{tenant} after its failed migration")
+      expect(busy_connections(pool)).to(eq(0), "expected #{tenant} pool released after a failed migration")
+      expect(open_transactions(pool)).to(eq(0), "expected #{tenant} migration transaction rolled back")
+    end
+  end
+
+  it 'releases cleanly on the skip path (already up to date)' do
+    Apartment::Migrator.new(threads: 0).run # bring all tenants current
+    second = Apartment::Migrator.new(threads: 0).run # everything :skipped now
+
+    expect(second.results.reject { |r| r.tenant == Apartment.config.default_tenant })
+      .to(all(have_attributes(status: :skipped)))
+
+    test_tenants.each do |tenant|
+      pool = tenant_pool(tenant)
+      expect(busy_connections(pool)).to(eq(0)) if pool
+    end
+  end
+
+  it 'targeted release does not disturb a connection the caller holds on another pool' do
+    # Caller leases tenant A's pool on this thread; switch does not check it in,
+    # so the lease persists after the block (that is the bug this fix addresses).
+    Apartment::Tenant.switch(test_tenants[0]) do
+      ActiveRecord::Base.connection.execute('SELECT 1')
+    end
+    pool_a = tenant_pool(test_tenants[0])
+    expect(busy_connections(pool_a)).to(eq(1)) # caller's lease established
+
+    # Migrate a DIFFERENT tenant; its targeted release touches only tenant B's pool.
+    Apartment::Migrator.new(threads: 0).send(:migrate_tenant, test_tenants[1])
+
+    expect(busy_connections(pool_a)).to(eq(1)) # caller's lease on A untouched
+    expect(busy_connections(tenant_pool(test_tenants[1]))).to(eq(0)) # B released
+  end
+
+  describe 'under a pool cap (admission)' do
+    # default pool (protected) + cap of 2 tenant pools, migrating 3 tenants,
+    # forces at least one admission eviction. With the connection released after
+    # each tenant, the LRU tenant pool is not in_use? and evicts cleanly, so no
+    # :cap_unmet fires. Without release it would (the production incident).
+    before do
+      Apartment.configure do |c|
+        c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+        c.tenants_provider = -> { test_tenants }
+        c.default_tenant = V4IntegrationHelper.default_tenant
+        c.check_pending_migrations = false
+        c.max_tenant_pools = 2
+      end
+      # configure tears down @adapter (see lib/apartment.rb#teardown_old_state);
+      # re-set it before activate!, same as the outer before, so the lazy
+      # Apartment.adapter accessor doesn't recurse through
+      # ConnectionHandling#connection_pool -> build_adapter -> Apartment.adapter.
+      Apartment.adapter = V4IntegrationHelper.build_adapter(@connection_config)
+      Apartment.activate!
+    end
+
+    it 'does not emit :cap_unmet and keeps registered pools within the cap' do
+      cap_unmet = []
+      sub = ActiveSupport::Notifications.subscribe('cap_unmet.apartment') do |*args|
+        cap_unmet << args.last
+      end
+
+      run = Apartment::Migrator.new(threads: 0).run
+      # Guard against a vacuous pass: if the run failed before creating pools,
+      # cap_unmet and the pool count would both be empty for the wrong reason.
+      expect(run).to(be_success)
+
+      # Count only the test-tenant pools (keys "<tenant>:<role>"), excluding the
+      # protected default pool and any reading-role pool, so the bound is robust.
+      tenant_pool_count = Apartment.pool_manager.stats[:tenants].count do |key|
+        test_tenants.any? { |t| key.to_s.start_with?("#{t}:") }
+      end
+      expect(cap_unmet).to(be_empty)
+      expect(tenant_pool_count).to(be <= 2)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub)
+    end
+
+    # The production incident was a PARALLEL migrate under a cap. This is that
+    # shape: concurrent workers each releasing their own tenant's lease, so
+    # admission can evict released pools instead of hitting the skip_evict/
+    # cap_unmet wall. It also exercises the capture->lease eviction window — if a
+    # worker's captured pool could be evicted before its sticky lease, a leased
+    # replacement pool would survive and cap_unmet would fire.
+    it 'stays within the cap under parallel workers without a cap_unmet storm',
+       skip: (V4IntegrationHelper.sqlite? ? 'SQLite does not support concurrent connections' : false) do
+      cap_unmet = []
+      sub = ActiveSupport::Notifications.subscribe('cap_unmet.apartment') do |*args|
+        cap_unmet << args.last
+      end
+
+      run = Apartment::Migrator.new(threads: 2).run
+      expect(run).to(be_success)
+      expect(cap_unmet).to(be_empty)
+
+      # No finished tenant pool still holds a lease after all workers joined.
+      Apartment.pool_manager.stats[:tenants].each do |key|
+        next unless test_tenants.any? { |t| key.to_s.start_with?("#{t}:") }
+
+        pool = Apartment.pool_manager.peek(key)
+        expect(busy_connections(pool)).to(eq(0), "expected #{key} released after parallel migrate") if pool
+      end
+    ensure
+      ActiveSupport::Notifications.unsubscribe(sub)
+    end
+  end
+end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -152,6 +152,8 @@ RSpec.describe(Apartment::Migrator) do
       allow(mock_connection).to(receive(:instance_variable_defined?)
         .with(:@advisory_locks_enabled).and_return(true))
       allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
+      allow(mock_pool).to(receive(:release_connection))
+      allow(mock_pool).to(receive(:lease_connection))
       allow(mock_migration_context).to(receive_messages(needs_migration?: true, migrate: []))
       allow(Apartment::Instrumentation).to(receive(:instrument))
       allow(Apartment::Tenant).to(receive(:switch)) { |_tenant, &block| block.call }
@@ -275,6 +277,8 @@ RSpec.describe(Apartment::Migrator) do
       allow(mock_connection).to(receive(:instance_variable_defined?)
         .with(:@advisory_locks_enabled).and_return(true))
       allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
+      allow(mock_pool).to(receive(:release_connection))
+      allow(mock_pool).to(receive(:lease_connection))
       allow(mock_migration_context).to(receive(:needs_migration?).and_return(true))
       allow(Apartment::Tenant).to(receive(:switch)) { |_tenant, &block| block.call }
     end
@@ -382,7 +386,9 @@ RSpec.describe(Apartment::Migrator) do
   end
 
   describe '#migrate_tenant Current.migrating lifecycle' do
-    let(:mock_pool) { double('pool', migration_context: double(needs_migration?: false)) }
+    let(:mock_pool) do
+      double('pool', migration_context: double(needs_migration?: false), release_connection: nil, lease_connection: nil)
+    end
 
     it 'sets Current.migrating = true before Tenant.switch' do
       migrating_value_during_switch = nil
@@ -488,6 +494,8 @@ RSpec.describe(Apartment::Migrator) do
       allow(mock_connection).to(receive(:instance_variable_defined?)
         .with(:@advisory_locks_enabled).and_return(true))
       allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
+      allow(mock_pool).to(receive(:release_connection))
+      allow(mock_pool).to(receive(:lease_connection))
       allow(mock_migration_context).to(receive_messages(needs_migration?: true, migrate: []))
       allow(Apartment::Instrumentation).to(receive(:instrument))
       allow(Apartment::Tenant).to(receive(:switch)) { |_tenant, &block| block.call }
@@ -588,6 +596,8 @@ RSpec.describe(Apartment::Migrator) do
       allow(mock_connection).to(receive(:instance_variable_defined?)
         .with(:@advisory_locks_enabled).and_return(true))
       allow(mock_pool).to(receive(:migration_context).and_return(mock_migration_context))
+      allow(mock_pool).to(receive(:release_connection))
+      allow(mock_pool).to(receive(:lease_connection))
       allow(mock_migration_context).to(receive_messages(needs_migration?: true, migrate: []))
       allow(Apartment::Instrumentation).to(receive(:instrument))
       allow(Apartment::Tenant).to(receive(:switch)) { |_tenant, &block| block.call }


### PR DESCRIPTION
Publishes **v4.0.0.alpha10**. Tracks `main` per the Model A release flow in `RELEASING.md` — merging this PR triggers `gem-publish.yml` (`rake release` tags `v4.0.0.alpha10` and pushes to RubyGems).

**Delta over alpha9:** the Migrator per-tenant connection-release fix (#476) — `migrate_tenant` now releases each worker's leased connection after migrating, so finished migration pools stop jamming pool admission (`skip_evict`/`cap_unmet`) during parallel `apartment:migrate`.

⚠️ **Merge with a merge commit — do not squash or rebase** (`RELEASING.md` step 2): `4-0-alpha` tracks `main`'s history; squashing diverges the branches and breaks release-note generation.