### PR TITLE
Chore: add the MIT LICENSE file the gemspec has always claimed

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2010-2026 Ryan Brunner, Brad Robertson, Rui Baltazar, Mauricio Novelo,
+and the ros-apartment contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2010-2026 Ryan Brunner, Brad Robertson, Rui Baltazar, Mauricio Novelo,
-and the ros-apartment contributors
+Copyright (c) 2010-2026 Ryan Brunner, Brad Robertson, Rui Baltazar, Mauricio Novelo, and the ros-apartment contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -487,4 +487,4 @@ application code with the standard `Exclude:` keys if needed. See
 
 ## License
 
-[MIT License](http://www.opensource.org/licenses/MIT)
+MIT — see [LICENSE](LICENSE). SPDX identifier: `MIT`.

--- a/ros-apartment.gemspec
+++ b/ros-apartment.gemspec
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# SPDX-License-Identifier: MIT
+
 $LOAD_PATH << File.expand_path('lib', __dir__)
 require 'apartment/version'
 
@@ -13,7 +15,9 @@ Gem::Specification.new do |s|
                     'through schema-based or database-based isolation strategies.'
   s.email         = ['ryan@influitive.com', 'brad@influitive.com', 'rui.p.baltazar@gmail.com', 'mauricio@campusesp.com']
 
-  s.files = %w[ros-apartment.gemspec README.md] + `git ls-files -- lib config`.split("\n")
+  # LICENSE ships in the gem deliberately: MIT requires the notice to travel with
+  # every distribution, and RubyGems has no other copy of it.
+  s.files = %w[ros-apartment.gemspec README.md LICENSE] + `git ls-files -- lib config`.split("\n")
   s.require_paths = ['lib']
 
   s.homepage = 'https://github.com/rails-on-services/apartment'


### PR DESCRIPTION
## Summary

The gemspec has declared `s.licenses = ['MIT']` and the README has linked the MIT text for the life of this project, but **no LICENSE file has ever existed in the repository** — not in this fork, and not in the upstream it came from (`git log --all` finds none here; `influitive/apartment` returns 404 from GitHub's license endpoint too).

Consequences:

- `GET /repos/rails-on-services/apartment` reports `license: null`, `spdx_id: null`.
- Tooling that gates on a detected open-source license treats the project as unlicensed.
- The packaged gem shipped **no copy of the notice at all** — `s.files` listed only the gemspec, README, `lib`, and `config`.

This documents the license that was already declared. It does not choose one.

## Changes

- **`LICENSE`** — verbatim MIT text, so the code host's classifier can match it.
- **Copyright line** mirrors the gemspec's `authors` and the repository's own commit history (first commit 2010), rather than naming a legal entity the project has never named for itself. Easy to change if you want different attribution — that is the one judgment call here.
- **`s.files` includes LICENSE.** MIT requires the notice to travel with every distribution, and RubyGems had no other copy of it.
- **`SPDX-License-Identifier: MIT`** comment in the gemspec, for scanners that read manifests instead of classifying license bodies.
- **README** License section points at the file in-tree instead of opensource.org.

## The part worth knowing

The first version wrapped the copyright onto two lines. That silently *degraded* detection: licensee strips a **single-line** copyright notice as attribution, so the overflow line was scored as license body instead.

| Copyright layout | Matcher | Confidence |
|---|---|---|
| Two lines | `Dice` | 98.94% (threshold is 98%) |
| One line | `Exact` | **100.00%** |

98.94% passed locally with zero margin for a different licensee version on the code host — and GitHub's API did in fact decline to classify it. Now an exact match.

Also worth recording: **GitHub's license endpoint cannot verify this before merge.** It returns an identical generic 404 for an unclassified ref and for a ref that does not exist, so it cannot distinguish "classified nothing" from "never resolved the ref". Verification here is `licensee detect .` — licensee 10.0.0, the same tool GitHub runs.

## Verification

```
$ licensee detect .
License:        MIT
Matched files:  LICENSE, README.md, ros-apartment.gemspec
LICENSE:
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
```

- `rubocop`: clean (169 files)
- Unit suite: 1036 examples, 0 failures
- `gem build` output contains `LICENSE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
