### PR TITLE
Chore: add the Greptile OSS badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/ros-apartment.svg)](https://badge.fury.io/rb/ros-apartment)
 [![CI](https://github.com/rails-on-services/apartment/actions/workflows/ci.yml/badge.svg)](https://github.com/rails-on-services/apartment/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/rails-on-services/apartment/graph/badge.svg?token=Q4I5QL78SA)](https://codecov.io/gh/rails-on-services/apartment)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
 *Database-level multitenancy for Rails and ActiveRecord*
 


### PR DESCRIPTION
## Summary

Adds the Greptile open-source badge as a fourth badge in the existing row, after codecov.

```markdown
[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
```

Unblocked by #479. Greptile's open-source check requires a license the code host can classify, and this repository had never carried a `LICENSE` file despite the gemspec declaring MIT since forever. `GET /repos/rails-on-services/apartment` now reports:

```json
{"name": "MIT License", "path": "LICENSE", "spdx": "MIT"}
```

## Verification

- `https://www.greptile.com/badge.svg` returns `200 image/svg+xml`
- README-only change; no code, no specs affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QnbNp6puqXk2zfkyvU1Ti