### PR TITLE
CI: cap every job, and stop an apt stall hanging for 18 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
   unit:
     name: Unit · Ruby ${{ matrix.ruby }} · Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # observed ~30s
     # Rails main is a canary: it tracks an unreleased edge and is allowed to
     # fail. continue-on-error keeps a red main cell from failing the `unit` job,
     # so it neither blocks the workflow nor flips needs.unit.result for ci-gate.
@@ -66,6 +67,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.engine == 'all' || inputs.engine == 'postgresql' }}
     name: PG ${{ matrix.pg }} · Ruby ${{ matrix.ruby }} · Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # observed ~2m
     needs: unit
     strategy:
       fail-fast: false
@@ -162,6 +164,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.engine == 'all' || inputs.engine == 'mysql' }}
     name: MySQL 8.4 · Ruby ${{ matrix.ruby }} · Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # observed ~3.5m
     needs: unit
     strategy:
       fail-fast: false
@@ -228,6 +231,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.engine == 'all' || inputs.engine == 'sqlite' }}
     name: SQLite · Ruby ${{ matrix.ruby }} · Rails ${{ matrix.rails }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # observed ~70s
     needs: unit
     strategy:
       fail-fast: false
@@ -264,6 +268,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.engine == 'all' || inputs.engine == 'postgresql' }}
     name: PgBouncer tx-mode · PG ${{ matrix.pg }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # observed ~50s
     needs: unit
     strategy:
       fail-fast: false
@@ -295,10 +300,20 @@ jobs:
           ruby-version: '3.4'
           bundler-cache: true
 
+      # A mirror stall here once hung for 18 minutes and produced an empty log, because
+      # -qq suppresses everything and the job inherited the 360-minute default. Three
+      # changes, addressing cause then symptom: apt gets its own connect timeout and
+      # retries so a bad mirror fails instead of blocking; update keeps its output so
+      # there is something to read; and the step is capped well above the ~15s the
+      # install actually takes.
       - name: Install PgBouncer
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq pgbouncer
+          sudo apt-get update $APT_OPTS
+          sudo apt-get install -y -qq $APT_OPTS pgbouncer
           pgbouncer --version
           # track_extra_parameters arrived in PgBouncer 1.20. Below that the safe
           # configuration cannot even be expressed, so fail loudly rather than
@@ -395,6 +410,7 @@ jobs:
     if: always()
     needs: [unit, postgresql, mysql, sqlite, pgbouncer]
     runs-on: ubuntu-latest
+    timeout-minutes: 5 # observed ~3s
     env:
       UNIT: ${{ needs.unit.result }}
       POSTGRESQL: ${{ needs.postgresql.result }}


### PR DESCRIPTION
## What happened

`PgBouncer tx-mode · PG 18` in run 32185297198 sat in `Install PgBouncer` for 18 minutes and had to be cancelled by hand. The identical step on `PG 16` finished the whole job in 45 seconds. On re-run, PG 18 passed in 49 seconds — so this was an apt mirror stall on the runner, not anything in the code under test.

Two things turned a transient stall into an 18-minute hang with nothing to look at:

No workflow in this repo sets `timeout-minutes`, so every job inherits GitHub's 360-minute default. And both apt calls used `-qq`, so after 18 minutes the log was empty.

It also blocks merges rather than merely wasting minutes: `ci-gate` declares `needs: [unit, postgresql, mysql, sqlite, pgbouncer]` and aggregates all five results, and the `main` ruleset requires `ci-gate`. A hung job leaves that check pending forever.

## What this changes

**Every job gets `timeout-minutes`**, sized well above its observed p100 from that run so a slow runner cannot flake it:

| Job | Observed | Cap |
|---|---|---|
| unit | ~30s | 10m |
| postgresql | ~2m | 15m |
| mysql | ~3.5m | 15m |
| sqlite | ~70s | 10m |
| pgbouncer | ~50s | 10m |
| ci-gate | ~3s | 5m |

**The install step is fixed at the cause, not just capped.** apt gets `Acquire::Retries=3` and a 15-second connect timeout, so an unreachable mirror fails and retries instead of blocking — a job cap alone would only have shortened the hang, not avoided it. `apt-get update` keeps its output so a future stall leaves something readable. `DEBIAN_FRONTEND=noninteractive` removes the other classic hang. And the step carries its own 5-minute cap, roughly twenty times what the install actually takes, so the ceiling is a last resort rather than the mechanism.

## Not included

`rubocop.yml`, `security-scan.yml` and `gem-publish.yml` also lack timeouts. They are short and have not misbehaved, and adding them would mean reasoning about three more workflows to fix one observed failure. Easy follow-up if you want the whole set covered.

## Verification

The YAML parses and both changes are where they should be — six jobs carrying `timeout-minutes`, the install step carrying its own plus the apt options. The real proof is the next PgBouncer run on this branch, since that is the job the change is aimed at.
