### PR TITLE
Release: 4.0.0.alpha13

### DIFF
--- a/lib/apartment/version.rb
+++ b/lib/apartment/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Apartment
-  VERSION = '4.0.0.alpha12'
+  VERSION = '4.0.0.alpha13'
 end


### PR DESCRIPTION
Bumps `4.0.0.alpha12` → `4.0.0.alpha13`. Version-only; no other file changes.

Six changes have merged since the `v4.0.0.alpha12` tag and none carried a bump, because this repo's convention has been for bumps to ride along inside feature PRs (#483 carried alpha12).

## Breaking, and it should lead the release notes

**#492 renames `migration_role` to `ddl_role` and removes `app_role`.** Every RBAC adopter has to edit their initializer:

```ruby
# before
c.migration_role = :db_manager
c.app_role       = 'app_user'

# after
c.ddl_role = :db_manager
c.tenant_privilege_policy = Apartment::Privileges.standard(grant_to: 'app_user')
```

`ddl_role`'s contract is also wider than the old name implied: every statement the gem issues against a tenant runs on it — container creation, schema import, migration, rollback and now drop — with seeding deliberately outside. `app_role`'s String form is gone with no shim; it issued six statements on PostgreSQL schemas, one with different semantics on MySQL, and nothing at all on the other two adapters, so one key had four behaviours.

Migration guidance is in `docs/upgrading-to-v4.md`, and the full contract with per-engine recipes is in the new `docs/rbac.md`.

## Also in this release

- **#490** — tenant-create DDL now runs on the migration role. PostgreSQL scopes `ALTER DEFAULT PRIVILEGES` to the role that executed it, so creating a tenant under one role while migrating under another left every migration-created table outside the grant rule, silently. This is the bug that motivated #492.
- **#491** — creating a tenant no longer trips the pending-migration check against the container it just built.
- **#488, #489** — pinned table qualification now proves it took effect rather than assuming, with the reasoning recorded in the root `CLAUDE.md`.
- **#493** — every CI job carries a timeout, and the PgBouncer install is hardened after an apt mirror stall hung a job for 18 minutes against the same step passing in 45 seconds elsewhere.

## Releasing

Merging this only changes the number. Publishing is a push to `4-0-alpha`, which triggers `gem-publish.yml` and `rake release`.

Verified locally: 1174 unit examples pass, and `gem build ros-apartment.gemspec` produces `ros-apartment-4.0.0.alpha13.gem`.
