### PR TITLE
Docs: a green local rubocop means nothing until the plugins are updated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,13 @@ bundle exec appraisal rails-8.1-sqlite3 rspec spec/integration/v4/              
 DATABASE_ENGINE=postgresql bundle exec appraisal rails-8.1-postgresql rspec spec/integration/v4/  # PostgreSQL
 DATABASE_ENGINE=mysql bundle exec appraisal rails-8.1-mysql2 rspec spec/integration/v4/          # MySQL
 
-# Lint
+# Lint. Update the plugins first, or a green local run tells you nothing about CI:
+# no Gemfile.lock is committed, so CI resolves rubocop's plugins fresh while a local
+# checkout keeps whatever it last resolved. AllCops.NewCops is `enable`, so a cop
+# added in a plugin minor is enforced the moment it ships — CI fails on a commit that
+# linted clean locally. Deliberate: 247 cops are pending across the loaded plugins and
+# the alternative drops all of them.
+bundle update rubocop rubocop-rspec rubocop-rails rubocop-performance rubocop-rake rubocop-thread_safety
 bundle exec rubocop
 
 # Build gem


### PR DESCRIPTION
Documents an update step in the lint command. No configuration change — I went looking for one, measured it, and it was the wrong fix.

## The failure

CI failed nine `RSpec/MatchWithSimpleRegex` offences on a branch where `bundle exec rubocop` had reported 184 files clean locally.

The cop ships in **rubocop-rspec 3.10**; the local bundle held **3.9.0**, where it does not exist — 113 RSpec cops loaded and this was not among them. No `Gemfile.lock` is committed, which is correct for a gem and what the current RubyGems guidance recommends, so CI resolves plugins fresh while a local checkout keeps whatever it last resolved. A green local rubocop therefore says nothing about CI whenever a plugin has shipped a new cop.

## Why not fix it in configuration

`AllCops.NewCops: enable` is what promotes a newly released *pending* cop to an immediate hard failure. Setting it to `pending` would stop that, and it was my first instinct.

Measured instead of assumed: with `NewCops: pending`, this repo gains **three** new offences — `Lint/RedundantCopDisableDirective` on existing `rubocop:disable` comments for `Style/MapIntoArray` and `Style/NilLambda`. Both of those are themselves pending cops, which means this codebase is already enforcing cops it only receives because `NewCops` is `enable`, and has deliberately disabled them in two spots.

So the setting is load-bearing. **247 cops are pending** across the loaded plugins; turning them off to avoid occasional lint churn trades broad coverage for a scheduling annoyance. Pinning the plugins instead buys determinism at the price of weekly Dependabot bumps — for a failure whose actual cost was one autocorrect commit.

The genuine defect was that the local gate silently disagreed with CI, so that is what this documents.

## What changes

The `# Lint` block in `CLAUDE.md` now updates the plugins before running, and states why: no committed lockfile, `NewCops: enable`, and the consequence for a local run. It also records that the setting is deliberate, so the next person who hits a surprise cop does not reach for the switch I nearly flipped.
