### PR TITLE
Fix(v4): refuse default credentials for ddl_role, and stop the lazy adapter build recursing

### DIFF
--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -56,10 +56,38 @@ module Apartment # rubocop:disable Metrics/ModuleLength
     attr_reader :config, :pool_manager, :pool_reaper
     attr_writer :adapter
 
+    # Fiber-local latch guarding the lazy build below. Thread#[] is fiber-local, so a
+    # fiber-based server gets its own, and a nested build cannot see a sibling's.
+    BUILDING_ADAPTER = :apartment_building_adapter
+
     # Lazy-loading adapter. Built on first access via build_adapter.
     # Can be set manually (e.g., in tests) via Apartment.adapter=.
+    #
+    # The latch is a backstop, not the fix. @adapter is not assigned until the build
+    # returns, so anything inside the build that resolves a connection through the
+    # tenant-aware pool lookup asks for the adapter again and recurses to
+    # SystemStackError — a stack dump naming no cause a reader can act on.
+    # default_connection_db_config closes the one such circle the gem had; this turns
+    # any future one into a sentence.
     def adapter
-      @adapter ||= build_adapter
+      return @adapter if @adapter
+
+      if Thread.current[BUILDING_ADAPTER]
+        raise(ConfigurationError,
+              'Apartment.adapter was re-entered while the adapter was still being ' \
+              'built, which means something in the build resolved a connection ' \
+              'through the tenant-aware pool lookup. Build the adapter before ' \
+              'switching tenants — Apartment.adapter with no tenant current, or an ' \
+              'explicit Apartment.adapter= — and report this, because the gem should ' \
+              'not need you to.')
+      end
+
+      Thread.current[BUILDING_ADAPTER] = true
+      begin
+        @adapter ||= build_adapter
+      ensure
+        Thread.current[BUILDING_ADAPTER] = nil
+      end
     end
 
     # An always-valid validator, used when config.tenant_validator is false.
@@ -484,11 +512,35 @@ module Apartment # rubocop:disable Metrics/ModuleLength
                 raise(AdapterNotFound, "Strategy #{strategy} not yet implemented")
               end
 
-      klass.new(ActiveRecord::Base.connection_db_config.configuration_hash)
+      klass.new(default_connection_db_config.configuration_hash)
     end
 
     def detect_database_adapter
-      ActiveRecord::Base.connection_db_config.adapter
+      default_connection_db_config.adapter
+    end
+
+    # The DEFAULT connection's db_config, resolved with the tenant unset.
+    #
+    # Unsetting it is what breaks a circle, not a precaution: connection_db_config is
+    # connection_pool.db_config, connection_pool goes through
+    # Patches::ConnectionHandling, and that patch asks Apartment.adapter for
+    # shared_pinned_connection?. Reading this under a live tenant therefore re-enters
+    # the very build it is part of, and @adapter is not assigned until the build
+    # returns, so it recursed until SystemStackError.
+    #
+    # The circle was reachable, not theoretical. configure clears @adapter and
+    # activate! does not rebuild it, so any process whose FIRST Apartment operation is
+    # a tenant switch — a job worker, a rake task, rails runner — took it. The request
+    # path escaped by accident: Elevators::Generic resolves the adapter per request
+    # before it switches, filling the memo while no tenant is current.
+    #
+    # The default connection is also the right answer. Which engine the app runs on is
+    # a property of the app rather than of whichever tenant happens to be current, and
+    # a tenant's config is derived from the default one anyway.
+    def default_connection_db_config
+      Apartment::Current.set(tenant: nil) do
+        ActiveRecord::Base.connection_db_config
+      end
     end
   end
 end

--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -648,6 +648,11 @@ module Apartment
       #
       # The release comes first because our own import_schema lease is on this pool;
       # without it the in-use check would see this thread and skip every discard.
+      #
+      # The in-use check is a narrowing, not a lock: another thread can lease between
+      # pool_in_use? and deregister_shard. Accepted, and documented with the reasoning
+      # at PoolManager#remove — leasing bypasses the manager's map entirely, so the race
+      # cannot be closed there.
       def discard_ddl_role_pool(tenant)
         role = Apartment.config.ddl_role
         return unless role

--- a/lib/apartment/patches/connection_handling.rb
+++ b/lib/apartment/patches/connection_handling.rb
@@ -68,10 +68,17 @@ module Apartment
             # default pool (bypasses the patch), and check_pending_migrations? /
             # schema-cache load operate on the explicit `pool`, so all are safe.
             # Keep it that way if you add work to this block.
-            # Resolve base config from the current role's default pool when available.
-            # Falls back to nil (adapter uses its own base_config) when the default pool
-            # is not accessible — e.g., in worker threads during parallel migration where
-            # the ConnectionHandler may not have the pool registered for this context.
+            # Resolve base config from the current role's default pool when available,
+            # falling back to nil so the adapter uses its own base_config.
+            #
+            # The fallback is for a handler that has no pool for this role at all — in
+            # practice a CUSTOM ConnectionHandler installed on one thread only, which is
+            # this repo's own integration harness. It is NOT for parallel-migration
+            # worker threads, as this comment used to claim: workers see the same
+            # process-default handler and the same registrations, verified on 7.2.3.1,
+            # 8.0.5 and 8.1.3.1. ddl_role is excluded from it — see
+            # #guard_ddl_role_registered!.
+            #
             # NOTE: `super` must be called here (not in a helper) because it refers to
             # the original connection_pool method on AR::Base, which only resolves from
             # the prepended method scope.
@@ -79,6 +86,7 @@ module Apartment
               default_pool = super
               default_pool.db_config.configuration_hash.stringify_keys
             rescue ActiveRecord::ConnectionNotEstablished
+              guard_ddl_role_registered!(role, tenant)
               nil
             end
 
@@ -144,6 +152,35 @@ module Apartment
       end
 
       private
+
+      # Substituting the default connection's config is never a valid answer for
+      # ddl_role. Doing it silently gave every per-tenant migration ordinary application
+      # privileges under a pool key that claimed the elevated role — the failure that
+      # putting create and migrate on one role exists to prevent, arriving by typo, and
+      # invisible precisely because the label lies.
+      #
+      # Called from inside the base-config rescue, which is what makes it sound: it can
+      # only fire when the lookup actually failed, ActiveRecord's error stays as the Ruby
+      # #cause, and some future unrelated source of a nil base cannot be misread as an
+      # unregistered role.
+      #
+      # Gated on the role BEING ddl_role. An unregistered :reading role fabricates
+      # identically, and that is a separate contract with its own specs; this must not
+      # change it by accident.
+      #
+      # role_pool_registered? is deliberately conservative — it answers "registered" when
+      # it cannot answer at all — so a probe failure can never become a spurious raise.
+      def guard_ddl_role_registered!(role, tenant)
+        return unless role == Apartment.config&.ddl_role
+        return if Apartment::MigrationRole.role_pool_registered?(role)
+
+        raise(Apartment::ConfigurationError,
+              "ddl_role is set to #{role.inspect} but ActiveRecord has no connection " \
+              "registered for that role, so the pool for tenant '#{tenant}' would be built " \
+              'from the default connection — running tenant DDL on ordinary application ' \
+              'credentials under a pool key that claims the elevated role. Declare the role ' \
+              'with connects_to on your application record, or unset ddl_role.')
+      end
 
       def check_pending_migrations?(pool)
         return false unless Apartment.config.check_pending_migrations

--- a/lib/apartment/pool_manager.rb
+++ b/lib/apartment/pool_manager.rb
@@ -49,6 +49,24 @@ module Apartment
     # These mutators also bypass PoolReaper's in-use guard: they will drop a pool
     # with a checked-out connection or an open transaction.
     # See docs/designs/out-of-band-tenant-ddl.md.
+    #
+    # ACCEPTED LIMITATION, the check-then-act race. A caller that guards a discard with
+    # Apartment.pool_in_use? — AbstractAdapter#discard_ddl_role_pool is the one in the
+    # gem — reads "not in use" and then calls Apartment.deregister_shard, and another
+    # thread can lease a connection from that pool in between. The guard narrows the
+    # window; it does not close it.
+    #
+    # It cannot be closed here. Leasing does not go through this map: a thread that
+    # already holds the pool object leases from the object directly, so no lock this
+    # class could take would serialize the two. Closing it would need a lock inside
+    # ActiveRecord's pool, which is not ours to add.
+    #
+    # Two things bound the exposure. Migrator leases eagerly rather than lazily, which
+    # its own comment explains as closing a capture->lease window — so the pool a
+    # migration will use is already in use by the time a concurrent discard could look
+    # at it. And #evict_by_role, which Migrator calls at the end of a run, has no in-use
+    # check at all: the race class is pre-existing and strictly wider there, so a guarded
+    # discard is an improvement on the surrounding code rather than a new hazard.
     def remove(tenant_key)
       pool = @pools.delete(tenant_key)
       @timestamps.delete(tenant_key)

--- a/spec/integration/v4/ddl_role_resolution_spec.rb
+++ b/spec/integration/v4/ddl_role_resolution_spec.rb
@@ -83,4 +83,79 @@ RSpec.describe('An unresolvable ddl_role', :integration, :postgresql_only, :rbac
     conn = ActiveRecord::Base.connection
     expect(conn.select_value("SELECT to_regnamespace(#{conn.quote(tenant)}) IS NOT NULL")).to(be(false))
   end
+
+  # The tenant path, which the create above never reaches: resolving a pool for an
+  # EXISTING tenant under the bogus role. This is where the defect hid, because nothing
+  # raised — the base-config lookup failed, the fallback substituted the adapter's own
+  # config, and the pool came up on the DEFAULT connection's credentials while its key
+  # said ":nope". Probed against live PostgreSQL before the fix:
+  #
+  #   POOL db_config name: apartment_probe_tenant:totally_unregistered
+  #   POOL username:       the default connection's user
+  #   => RAISED NOTHING
+  #
+  # Every per-tenant migration would then run with application privileges under a label
+  # claiming the elevated role, which is exactly what running create and migrate on one
+  # role exists to prevent.
+  context 'resolving a pool for an existing tenant' do
+    before do
+      # Build the tenant with a working configuration, then re-point ddl_role at the
+      # unregistered one, so the switch below is the first thing to need that role.
+      Apartment.clear_config
+      config = V4IntegrationHelper.establish_default_connection!
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [tenant] }
+        c.default_tenant = 'public'
+        c.check_pending_migrations = false
+      end
+      Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+      Apartment.adapter.create(tenant)
+
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [tenant] }
+        c.default_tenant = 'public'
+        c.ddl_role = :nope
+        c.check_pending_migrations = false
+      end
+      Apartment.adapter = V4IntegrationHelper.build_adapter(config)
+    end
+
+    it 'refuses to build the pool on default credentials', :aggregate_failures do
+      raised = nil
+      begin
+        ActiveRecord::Base.connected_to(role: :nope) do
+          Apartment::Tenant.switch(tenant) { ActiveRecord::Base.connection_pool }
+        end
+      rescue StandardError => e
+        raised = e
+      end
+
+      expect(raised).to(be_a(Apartment::ConfigurationError))
+      expect(raised.message).to(match(/ddl_role.*:nope/))
+      expect(raised.cause).to(be_a(ActiveRecord::ConnectionNotEstablished))
+    end
+
+    # The gate. A registered role resolves normally through the same code path, so the
+    # raise cannot be firing on the mere presence of a ddl_role.
+    it 'still resolves a pool when ddl_role is registered' do
+      Apartment.configure do |c|
+        c.tenant_strategy = :schema
+        c.tenants_provider = -> { [tenant] }
+        c.default_tenant = 'public'
+        c.ddl_role = :db_manager
+        c.check_pending_migrations = false
+      end
+      Apartment.adapter = V4IntegrationHelper.build_adapter(
+        V4IntegrationHelper.default_connection_config
+      )
+
+      pool = ActiveRecord::Base.connected_to(role: :db_manager) do
+        Apartment::Tenant.switch(tenant) { ActiveRecord::Base.connection_pool }
+      end
+
+      expect(pool).not_to(be_nil)
+    end
+  end
 end

--- a/spec/integration/v4/lazy_adapter_build_spec.rb
+++ b/spec/integration/v4/lazy_adapter_build_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative 'support'
+
+# The lazy adapter build under a live tenant, with a real connection and NO
+# pre-assigned adapter — deliberately unlike every other integration spec here, all of
+# which assign Apartment.adapter in their setup and so never exercise the build.
+#
+# configure clears @adapter and activate! does not rebuild it, so the first Apartment
+# operation of a process is what triggers the build. When that operation is a tenant
+# switch, the build reads the default connection's config through the tenant-aware pool
+# lookup, which asks for the adapter it is still building: SystemStackError, on a path
+# a job worker, a rake task or rails runner takes routinely. The request path escaped
+# only because Elevators::Generic resolves the adapter before it switches.
+RSpec.describe('Lazy adapter build under a tenant', :integration,
+               skip: (V4_INTEGRATION_AVAILABLE ? false : 'requires ActiveRecord + database gem')) do
+  include V4IntegrationHelper
+
+  let(:tmp_dir) { Dir.mktmpdir('apartment_lazy_adapter') }
+  let(:tenant) { 'lazy_adapter_tenant' }
+
+  before do
+    V4IntegrationHelper.ensure_test_database! unless V4IntegrationHelper.sqlite?
+    @config = V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+
+    Apartment.configure do |c|
+      c.tenant_strategy = V4IntegrationHelper.tenant_strategy
+      c.tenants_provider = -> { [tenant] }
+      c.default_tenant = V4IntegrationHelper.default_tenant
+      c.check_pending_migrations = false
+    end
+
+    # No Apartment.adapter assignment. That is the point of this spec.
+    Apartment.activate!
+  end
+
+  after do
+    V4IntegrationHelper.establish_default_connection!(tmp_dir: tmp_dir)
+    Apartment.adapter = V4IntegrationHelper.build_adapter(
+      V4IntegrationHelper.default_connection_config(tmp_dir: tmp_dir)
+    )
+    V4IntegrationHelper.cleanup_tenants!([tenant], Apartment.adapter)
+    Apartment.clear_config
+    Apartment::Current.reset
+    FileUtils.remove_entry(tmp_dir) if File.directory?(tmp_dir)
+  end
+
+  it 'builds the adapter rather than recursing to SystemStackError', :aggregate_failures do
+    resolved = nil
+
+    expect do
+      Apartment::Tenant.switch(tenant) { resolved = ActiveRecord::Base.connection_pool }
+    end.not_to(raise_error)
+
+    expect(resolved).not_to(be_nil)
+    expect(Apartment.adapter).not_to(be_nil)
+  end
+end

--- a/spec/unit/apartment_spec.rb
+++ b/spec/unit/apartment_spec.rb
@@ -667,6 +667,73 @@ RSpec.describe(Apartment) do
     end
   end
 
+  # The build reads the DEFAULT connection's config. Reading it under a live tenant
+  # goes through the tenant-aware pool lookup, which asks Apartment.adapter for
+  # shared_pinned_connection? — the adapter this build has not finished producing. That
+  # recursed to SystemStackError on the first tenant switch of any process that had not
+  # already built the adapter.
+  describe '.default_connection_db_config (private)' do
+    let(:db_config) { double('db_config', adapter: 'postgresql', configuration_hash: { adapter: 'postgresql' }) }
+
+    before do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+      end
+    end
+
+    it 'resolves with the tenant unset, and restores it', :aggregate_failures do
+      observed = :never_called
+      allow(ActiveRecord::Base).to(receive(:connection_db_config)) do
+        observed = Apartment::Current.tenant
+        db_config
+      end
+      Apartment::Current.tenant = 'acme'
+
+      described_class.send(:default_connection_db_config)
+
+      expect(observed).to(be_nil)
+      expect(Apartment::Current.tenant).to(eq('acme'))
+    end
+
+    it 'lets a build complete with a tenant current' do
+      allow(ActiveRecord::Base).to(receive(:connection_db_config).and_return(db_config))
+      Apartment::Current.tenant = 'acme'
+
+      expect(described_class.send(:build_adapter)).to(be_a(Apartment::Adapters::PostgresqlSchemaAdapter))
+    end
+  end
+
+  # The backstop for any future circle of the same shape: a sentence rather than a
+  # stack dump. Simulated by having the config read ask for the adapter again, which
+  # is exactly what the tenant-aware pool lookup used to do.
+  describe '.adapter re-entrancy' do
+    it 'raises a ConfigurationError instead of recursing' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+      end
+      allow(ActiveRecord::Base).to(receive(:connection_db_config)) { described_class.adapter }
+
+      expect { described_class.adapter }.to(
+        raise_error(Apartment::ConfigurationError, /re-entered while the adapter was still being built/)
+      )
+    end
+
+    it 'clears the latch, so a later build still works' do
+      described_class.configure do |config|
+        config.tenant_strategy = :schema
+        config.tenants_provider = -> { [] }
+      end
+      db_config = double('db_config', adapter: 'postgresql', configuration_hash: { adapter: 'postgresql' })
+      allow(ActiveRecord::Base).to(receive(:connection_db_config)) { described_class.adapter }
+      expect { described_class.adapter }.to(raise_error(Apartment::ConfigurationError))
+
+      allow(ActiveRecord::Base).to(receive(:connection_db_config).and_return(db_config))
+      expect(described_class.adapter).to(be_a(Apartment::Adapters::PostgresqlSchemaAdapter))
+    end
+  end
+
   describe '.tenant_validator' do
     it 'returns an always-true callable when config.tenant_validator is false' do
       described_class.configure do |c|

--- a/spec/unit/patches/connection_handling_spec.rb
+++ b/spec/unit/patches/connection_handling_spec.rb
@@ -236,6 +236,71 @@ RSpec.describe(Apartment::Patches::ConnectionHandling) do
       end
     end
 
+    # The defect the base-config fallback hid. On the TENANT path an unregistered
+    # ddl_role does not raise: `super` fails, `base` becomes nil, and the adapter
+    # supplies its own config — so the pool is established with the DEFAULT
+    # connection's credentials while its key still claims the elevated role. Every
+    # per-tenant migration then runs as the application user under a label that lies,
+    # which is the failure the create-under-ddl_role fix exists to prevent, arriving
+    # by typo instead.
+    context 'when ddl_role names an unregistered role' do
+      def configure_ddl_role(role)
+        Apartment.configure do |config|
+          config.tenant_strategy = :schema
+          config.tenants_provider = -> { %w[acme widgets] }
+          config.default_tenant = 'public'
+          config.check_pending_migrations = false
+          config.ddl_role = role
+        end
+        # Reassigned because configure clears @adapter, and a rebuild would resolve the
+        # default config through the guard-1 `super` — surfacing the unregistered role
+        # from the BUILD rather than from the tenant-path fallback under test.
+        Apartment.adapter = mock_adapter
+      end
+
+      it 'raises a ConfigurationError naming the key instead of fabricating a pool', :aggregate_failures do
+        configure_ddl_role(:nope)
+        Apartment::Current.tenant = 'acme'
+
+        raised = nil
+        begin
+          ActiveRecord::Base.connected_to(role: :nope) { ActiveRecord::Base.connection_pool }
+        rescue StandardError => e
+          raised = e
+        end
+
+        expect(raised).to(be_a(Apartment::ConfigurationError))
+        expect(raised.message).to(match(/ddl_role.*:nope/))
+        # Raised inside the rescue, so ActiveRecord's own error stays as the cause.
+        expect(raised.cause).to(be_a(ActiveRecord::ConnectionNotEstablished))
+      end
+
+      # Gated on the role being ddl_role. An unregistered :reading role fabricates the
+      # same way, and that is a separate contract with its own specs — this fix must
+      # not change it by accident.
+      it 'leaves a non-ddl_role role to the existing fallback' do
+        configure_ddl_role(:db_manager)
+        Apartment::Current.tenant = 'acme'
+
+        pool = ActiveRecord::Base.connected_to(role: :reading) { ActiveRecord::Base.connection_pool }
+
+        expect(pool).not_to(be_nil)
+      end
+
+      # The probe is conservative by construction: it reports "registered" when it
+      # cannot answer, so a probe failure can never turn into a spurious raise.
+      it 'falls back rather than raising when the probe cannot answer' do
+        configure_ddl_role(:nope)
+        allow(ActiveRecord::Base).to(receive(:connection_handler).and_call_original)
+        allow(Apartment::MigrationRole).to(receive(:role_pool_registered?).and_return(true))
+        Apartment::Current.tenant = 'acme'
+
+        pool = ActiveRecord::Base.connected_to(role: :nope) { ActiveRecord::Base.connection_pool }
+
+        expect(pool).not_to(be_nil)
+      end
+    end
+
     context 'when tenant equals the default tenant' do
       it 'returns the default pool' do
         Apartment::Current.tenant = 'public'


### PR DESCRIPTION
Three commits. The first is a crash in released code that I had mis-scoped as unreachable; the second is the defect this branch was opened for; the third is documentation.

## 1. The lazy adapter build recursed under a live tenant (`dca60b90`)

Reproduced on `main` with a bare script — real sqlite3, no custom handler, nothing forced:

```ruby
Apartment.configure { ... }
Apartment.activate!
Apartment::Tenant.switch('acme') { ActiveRecord::Base.connection_pool }
# => RECURSED: SystemStackError
```

`Apartment.configure` clears `@adapter` via `teardown_old_state` and `activate!` does not rebuild it, so the first Apartment operation of a process triggers the build. When that operation is a tenant switch, `build_adapter` reads the default config through the tenant-aware lookup and asks for the adapter it has not finished building.

Any process whose first Apartment operation is a tenant switch takes it: a job worker, a rake task, `rails runner`. The request path escapes only because `Elevators::Generic#resolve_adapter` reads the adapter before switching, filling the memo while no tenant is current. This repo's own harness had already worked around it by hand — `migrator_connection_release_spec.rb:174` names the exact chain in a comment.

Fixed by breaking the circle rather than labelling it: both reads of the default config now resolve under `Current.set(tenant: nil)`. That is also the more correct answer, since which engine the app runs on is a property of the app, not of whichever tenant happens to be current. A re-entrancy latch remains as a backstop, and the two compose — with the circularity restored, the integration example reports the latch's `ConfigurationError` rather than `SystemStackError`.

The circularity had **two** links, not one: `detect_database_adapter` and `build_adapter`'s own `klass.new(connection_db_config.configuration_hash)`. Fixing only the first moves the recursion instead of removing it.

`spec/integration/v4/lazy_adapter_build_spec.rb` deliberately assigns no adapter — unlike every other spec in that directory, which is why none of them caught this.

## 2. An unregistered `ddl_role` fabricated a pool on default credentials (`50eae23e`)

Measured before the fix:

```
ddl_role = :totally_unregistered
POOL KEY ROLE:       :totally_unregistered
POOL db_config name: apartment_probe_tenant:totally_unregistered
POOL username:       "<the default connection's user>"
=> RAISED NOTHING
```

A typo in `ddl_role` therefore ran every per-tenant migration on ordinary application credentials while the pool key claimed the elevated role — the failure #490 fixed, reintroduced by misconfiguration and harder to see because the label lies. `MigrationRole`'s classifier cannot reach it, because nothing raises on the tenant path.

The check sits inside `connection_pool`'s `rescue ActiveRecord::ConnectionNotEstablished`, so it fires only when the default-role lookup actually failed, ActiveRecord's error stays as the Ruby `cause`, and a future unrelated source of a nil base config is not misread as an unregistered role. It is gated on `role == cfg.ddl_role`: an unregistered `:reading` role fabricates identically, but that is a separate feature with its own specs. It reuses `MigrationRole.role_pool_registered?` unchanged, including its conservative "assume registered if the probe itself fails", so a probe error cannot cause a spurious raise.

The discriminator is sound across threads, which is what makes this safe for parallel migration:

```
MAIN   :db_manager -> found     MAIN   :nope -> NIL
THREAD :db_manager -> found     THREAD :nope -> NIL     (same handler object)
```

**A comment corrected in passing, and it matters more than the raise.** The nil fallback claimed to exist for "worker threads during parallel migration where the ConnectionHandler may not have the pool registered for this context." That is not true — workers share the process-default handler, as above. The case where both `super` and the probe return nil is a custom handler installed only on the main thread, i.e. this repo's integration harness. A comment was justifying production credential substitution by citing a scenario that does not occur.

## 3. The pool-discard race, documented (`b8e78b2a`)

Raised in review on #497. Recorded as an accepted limitation beside `PoolManager#remove`'s existing note: the window is between `pool_in_use?` and `deregister_shard`; `Migrator` narrows it by leasing eagerly, which its own comment already explains as closing a capture-to-lease window; `evict_by_role` has no in-use check at all, so the class is pre-existing and wider there; and it cannot be closed in `PoolManager`, because leasing does not go through the map, so a thread already holding the pool object can lease regardless.

## Testing

Every guard probed by neutering it: disabling the raise fails one unit and one integration example; removing the role gate fails both the `:reading` example and the pre-existing absorb example; restoring the circularity fails the lazy-build example.

1191 unit examples on Rails 7.2 and the default bundle, and 1191 with `CONNECTION_HANDLING_REQUIRED=1` under the sqlite3 appraisal where the connection-handling examples actually execute. 231 PostgreSQL integration, 30 in the `:rbac` lane, 14 in `:stress` run explicitly because threaded specs are where a spurious raise would surface, 229 SQLite. 185 files rubocop-clean.

## A third case that turned out to need nothing

An earlier draft of this description claimed a gap here: that an unregistered `ddl_role` in a process which has not yet built its adapter would surface as a bare `ActiveRecord::ConnectionNotDefined`, without naming the key. Probed, and it does not:

```
adapter built yet? false
RAISED: Apartment::ConfigurationError
names ddl_role? true
```

The raise does originate in the build's `super` rather than the tenant path, but it propagates through `MigrationRole.wrap`, and `ConnectionNotDefined` is a subclass of the `ConnectionNotEstablished` that clause names — so the probe runs, finds the role unregistered, and translates. All three paths name the key.

No change made, and deliberately none proposed: teaching `build_adapter` about `ddl_role` would put an RBAC concern inside an adapter factory whose only job is choosing an engine class, and would duplicate a classifier that already covers this, giving two places that can disagree.
